### PR TITLE
AndroidでURLを開けない問題を修正

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.miria">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
    <application
         android:label="miria"
         android:name="${applicationName}"


### PR DESCRIPTION
Fix #49 

url_launcherのexampleを参考にしてAndroidManifest.xmlを変更しました。

https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher#android

https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/example/android/app/src/main/AndroidManifest.xml