### PR TITLE
TabIconViewのアイコンとカスタム絵文字の大きさを揃える

### DIFF
--- a/lib/view/common/misskey_notes/custom_emoji.dart
+++ b/lib/view/common/misskey_notes/custom_emoji.dart
@@ -8,12 +8,14 @@ class CustomEmoji extends ConsumerStatefulWidget {
   final MisskeyEmojiData emojiData;
   final double fontSizeRatio;
   final bool isAttachTooltip;
+  final double? size;
 
   const CustomEmoji({
     super.key,
     required this.emojiData,
     this.fontSizeRatio = 1,
     this.isAttachTooltip = true,
+    this.size,
   });
 
   @override
@@ -35,8 +37,9 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
   @override
   Widget build(BuildContext context) {
     if (cachedImage != null) return cachedImage!;
-    final scopedFontSize = (DefaultTextStyle.of(context).style.fontSize ?? 22) *
-        widget.fontSizeRatio;
+    final scopedFontSize = widget.size ??
+        (DefaultTextStyle.of(context).style.fontSize ?? 22) *
+            widget.fontSizeRatio;
 
     final emojiData = widget.emojiData;
     switch (emojiData) {

--- a/lib/view/common/tab_icon_view.dart
+++ b/lib/view/common/tab_icon_view.dart
@@ -10,29 +10,42 @@ import 'package:miria/view/common/misskey_notes/custom_emoji.dart';
 class TabIconView extends ConsumerWidget {
   final TabIcon? icon;
   final Color? color;
+  final double? size;
 
   const TabIconView({
     super.key,
     required this.icon,
     this.color,
+    this.size,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final codePoint = icon?.codePoint;
+    final iconSize = size ?? IconTheme.of(context).size;
     if (codePoint != null) {
       return Icon(
         IconData(codePoint, fontFamily: "MaterialIcons"),
         color: color,
+        size: iconSize,
       );
     }
     final customEmoji = icon?.customEmojiName;
     if (customEmoji != null) {
-      return CustomEmoji(
-          emojiData: MisskeyEmojiData.fromEmojiName(
+      return SizedBox(
+        width: iconSize,
+        height: iconSize,
+        child: Center(
+          child: CustomEmoji(
+            emojiData: MisskeyEmojiData.fromEmojiName(
               emojiName: ":$customEmoji:",
               repository:
-                  ref.read(emojiRepositoryProvider(AccountScope.of(context)))));
+                  ref.read(emojiRepositoryProvider(AccountScope.of(context))),
+            ),
+            size: iconSize,
+          ),
+        ),
+      );
     }
     return const SizedBox.shrink();
   }


### PR DESCRIPTION
Fix #90 

| カスタム絵文字 | Unicode絵文字 | 一覧 |
| ---- | ---- | ---- |
| ![](https://user-images.githubusercontent.com/63451158/242651710-9396974c-b92e-457f-82df-07d7bfd49d24.png) | ![](https://user-images.githubusercontent.com/63451158/242651775-9c6c6bb0-975e-476c-9335-f88fd888d829.png) | ![](https://user-images.githubusercontent.com/63451158/242651875-e23b9a7f-1071-4981-8082-fec69e0908e3.png) |