### PR TITLE
リノートの直後のノートを表示する

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -16,6 +16,7 @@ import 'package:miria/view/federation_page/federation_page.dart';
 import 'package:miria/view/hashtag_page/hashtag_page.dart';
 import 'package:miria/view/note_create_page/note_create_page.dart';
 import 'package:miria/view/note_detail_page/note_detail_page.dart';
+import 'package:miria/view/notes_after_renote_page/notes_after_renote_page.dart';
 import 'package:miria/view/notification_page/notification_page.dart';
 import 'package:miria/view/search_page/search_page.dart';
 import 'package:miria/view/photo_edit_page/photo_edit_page.dart';
@@ -55,6 +56,7 @@ class AppRouter extends _$AppRouter {
     AutoRoute(page: AntennaNotesRoute.page),
     AutoRoute(page: TimeLineRoute.page),
     AutoRoute(page: NoteDetailRoute.page),
+    AutoRoute(page: NotesAfterRenoteRoute.page),
     AutoRoute(page: UserRoute.page),
     AutoRoute(page: NotificationRoute.page),
     AutoRoute(page: FavoritedNoteRoute.page),

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -15,16 +15,6 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
-    AntennaRoute.name: (routeData) {
-      final args = routeData.argsAs<AntennaRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: AntennaPage(
-          account: args.account,
-          key: args.key,
-        ),
-      );
-    },
     AntennaNotesRoute.name: (routeData) {
       final args = routeData.argsAs<AntennaNotesRouteArgs>();
       return AutoRoutePage<dynamic>(
@@ -36,20 +26,35 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    NotificationRoute.name: (routeData) {
-      final args = routeData.argsAs<NotificationRouteArgs>();
+    AntennaRoute.name: (routeData) {
+      final args = routeData.argsAs<AntennaRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotificationPage(
+        child: AntennaPage(
+          account: args.account,
+          key: args.key,
+        ),
+      );
+    },
+    ChannelsRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelsRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ChannelsPage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    LoginRoute.name: (routeData) {
+    ChannelDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const LoginPage(),
+        child: ChannelDetailPage(
+          key: args.key,
+          account: args.account,
+          channelId: args.channelId,
+        ),
       );
     },
     ClipDetailRoute.name: (routeData) {
@@ -73,6 +78,76 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    ExploreRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExplorePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ExploreRoleUsersRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExploreRoleUsersPage(
+          key: args.key,
+          item: args.item,
+          account: args.account,
+        ),
+      );
+    },
+    FavoritedNoteRoute.name: (routeData) {
+      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FavoritedNotePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    FederationRoute.name: (routeData) {
+      final args = routeData.argsAs<FederationRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FederationPage(
+          key: args.key,
+          account: args.account,
+          host: args.host,
+        ),
+      );
+    },
+    HashtagRoute.name: (routeData) {
+      final args = routeData.argsAs<HashtagRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: HashtagPage(
+          key: args.key,
+          hashtag: args.hashtag,
+          account: args.account,
+        ),
+      );
+    },
+    LoginRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const LoginPage(),
+      );
+    },
+    NotesAfterRenoteRoute.name: (routeData) {
+      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: NotesAfterRenotePage(
+          key: args.key,
+          note: args.note,
+          account: args.account,
+        ),
+      );
+    },
     NoteCreateRoute.name: (routeData) {
       final args = routeData.argsAs<NoteCreateRouteArgs>();
       return AutoRoutePage<dynamic>(
@@ -89,46 +164,23 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    HashtagRoute.name: (routeData) {
-      final args = routeData.argsAs<HashtagRouteArgs>();
+    NoteDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<NoteDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: HashtagPage(
+        child: NoteDetailPage(
           key: args.key,
-          hashtag: args.hashtag,
+          note: args.note,
           account: args.account,
         ),
       );
     },
-    UserFolloweeRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFolloweeRouteArgs>();
+    NotificationRoute.name: (routeData) {
+      final args = routeData.argsAs<NotificationRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserFolloweePage(
+        child: NotificationPage(
           key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserRoute.name: (routeData) {
-      final args = routeData.argsAs<UserRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserPage(
-          key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserFollowerRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFollowerRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserFollowerPage(
-          key: args.key,
-          userId: args.userId,
           account: args.account,
         ),
       );
@@ -145,10 +197,86 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    SplashRoute.name: (routeData) {
+    SearchRoute.name: (routeData) {
+      final args = routeData.argsAs<SearchRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const SplashPage(),
+        child: SearchPage(
+          key: args.key,
+          initialSearchText: args.initialSearchText,
+          account: args.account,
+        ),
+      );
+    },
+    AccountListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AccountListPage(),
+      );
+    },
+    AppInfoRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AppInfoPage(),
+      );
+    },
+    GeneralSettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const GeneralSettingsPage(),
+      );
+    },
+    SettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SettingsPage(),
+      );
+    },
+    TabSettingsListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const TabSettingsListPage(),
+      );
+    },
+    TabSettingsRoute.name: (routeData) {
+      final args = routeData.argsAs<TabSettingsRouteArgs>(
+          orElse: () => const TabSettingsRouteArgs());
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: TabSettingsPage(
+          key: args.key,
+          tabIndex: args.tabIndex,
+        ),
+      );
+    },
+    HardMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<HardMuteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: HardMutePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    InstanceMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<InstanceMuteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: InstanceMutePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ReactionDeckRoute.name: (routeData) {
+      final args = routeData.argsAs<ReactionDeckRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ReactionDeckPage(
+          key: args.key,
+          account: args.account,
+        ),
       );
     },
     SeveralAccountGeneralSettingsRoute.name: (routeData) {
@@ -171,33 +299,41 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    InstanceMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<InstanceMuteRouteArgs>();
+    SharingAccountSelectRoute.name: (routeData) {
+      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
+          orElse: () => const SharingAccountSelectRouteArgs());
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: InstanceMutePage(
+        child: SharingAccountSelectPage(
           key: args.key,
-          account: args.account,
+          sharingText: args.sharingText,
+          filePath: args.filePath,
         ),
       );
     },
-    HardMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<HardMuteRouteArgs>();
+    SplashRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: HardMutePage(
+        child: const SplashPage(),
+      );
+    },
+    TimeLineRoute.name: (routeData) {
+      final args = routeData.argsAs<TimeLineRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: TimeLinePage(
           key: args.key,
-          account: args.account,
+          currentTabSetting: args.currentTabSetting,
         ),
       );
     },
-    ReactionDeckRoute.name: (routeData) {
-      final args = routeData.argsAs<ReactionDeckRouteArgs>();
+    UsersListRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ReactionDeckPage(
+        child: UsersListPage(
+          args.account,
           key: args.key,
-          account: args.account,
         ),
       );
     },
@@ -212,203 +348,40 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    UsersListRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListRouteArgs>();
+    UserFolloweeRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFolloweeRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UsersListPage(
-          args.account,
+        child: UserFolloweePage(
           key: args.key,
-        ),
-      );
-    },
-    ChannelDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelDetailRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ChannelDetailPage(
-          key: args.key,
-          account: args.account,
-          channelId: args.channelId,
-        ),
-      );
-    },
-    ChannelsRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelsRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ChannelsPage(
-          key: args.key,
+          userId: args.userId,
           account: args.account,
         ),
       );
     },
-    FederationRoute.name: (routeData) {
-      final args = routeData.argsAs<FederationRouteArgs>();
+    UserFollowerRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFollowerRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: FederationPage(
+        child: UserFollowerPage(
           key: args.key,
-          account: args.account,
-          host: args.host,
-        ),
-      );
-    },
-    NoteDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<NoteDetailRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: NoteDetailPage(
-          key: args.key,
-          note: args.note,
+          userId: args.userId,
           account: args.account,
         ),
       );
     },
-    SearchRoute.name: (routeData) {
-      final args = routeData.argsAs<SearchRouteArgs>();
+    UserRoute.name: (routeData) {
+      final args = routeData.argsAs<UserRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: SearchPage(
+        child: UserPage(
           key: args.key,
-          initialSearchText: args.initialSearchText,
-          account: args.account,
-        ),
-      );
-    },
-    SharingAccountSelectRoute.name: (routeData) {
-      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
-          orElse: () => const SharingAccountSelectRouteArgs());
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: SharingAccountSelectPage(
-          key: args.key,
-          sharingText: args.sharingText,
-          filePath: args.filePath,
-        ),
-      );
-    },
-    GeneralSettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const GeneralSettingsPage(),
-      );
-    },
-    TabSettingsRoute.name: (routeData) {
-      final args = routeData.argsAs<TabSettingsRouteArgs>(
-          orElse: () => const TabSettingsRouteArgs());
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TabSettingsPage(
-          key: args.key,
-          tabIndex: args.tabIndex,
-        ),
-      );
-    },
-    TabSettingsListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const TabSettingsListPage(),
-      );
-    },
-    AppInfoRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AppInfoPage(),
-      );
-    },
-    SettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const SettingsPage(),
-      );
-    },
-    AccountListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AccountListPage(),
-      );
-    },
-    ExploreRoleUsersRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExploreRoleUsersPage(
-          key: args.key,
-          item: args.item,
-          account: args.account,
-        ),
-      );
-    },
-    ExploreRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExplorePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    TimeLineRoute.name: (routeData) {
-      final args = routeData.argsAs<TimeLineRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TimeLinePage(
-          key: args.key,
-          currentTabSetting: args.currentTabSetting,
-        ),
-      );
-    },
-    FavoritedNoteRoute.name: (routeData) {
-      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: FavoritedNotePage(
-          key: args.key,
+          userId: args.userId,
           account: args.account,
         ),
       );
     },
   };
-}
-
-/// generated route for
-/// [AntennaPage]
-class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
-  AntennaRoute({
-    required Account account,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          AntennaRoute.name,
-          args: AntennaRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'AntennaRoute';
-
-  static const PageInfo<AntennaRouteArgs> page =
-      PageInfo<AntennaRouteArgs>(name);
-}
-
-class AntennaRouteArgs {
-  const AntennaRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'AntennaRouteArgs{account: $account, key: $key}';
-  }
 }
 
 /// generated route for
@@ -455,29 +428,67 @@ class AntennaNotesRouteArgs {
 }
 
 /// generated route for
-/// [NotificationPage]
-class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
-  NotificationRoute({
+/// [AntennaPage]
+class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
+  AntennaRoute({
+    required Account account,
+    Key? key,
+    List<PageRouteInfo>? children,
+  }) : super(
+          AntennaRoute.name,
+          args: AntennaRouteArgs(
+            account: account,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'AntennaRoute';
+
+  static const PageInfo<AntennaRouteArgs> page =
+      PageInfo<AntennaRouteArgs>(name);
+}
+
+class AntennaRouteArgs {
+  const AntennaRouteArgs({
+    required this.account,
+    this.key,
+  });
+
+  final Account account;
+
+  final Key? key;
+
+  @override
+  String toString() {
+    return 'AntennaRouteArgs{account: $account, key: $key}';
+  }
+}
+
+/// generated route for
+/// [ChannelsPage]
+class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
+  ChannelsRoute({
     Key? key,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotificationRoute.name,
-          args: NotificationRouteArgs(
+          ChannelsRoute.name,
+          args: ChannelsRouteArgs(
             key: key,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotificationRoute';
+  static const String name = 'ChannelsRoute';
 
-  static const PageInfo<NotificationRouteArgs> page =
-      PageInfo<NotificationRouteArgs>(name);
+  static const PageInfo<ChannelsRouteArgs> page =
+      PageInfo<ChannelsRouteArgs>(name);
 }
 
-class NotificationRouteArgs {
-  const NotificationRouteArgs({
+class ChannelsRouteArgs {
+  const ChannelsRouteArgs({
     this.key,
     required this.account,
   });
@@ -488,22 +499,51 @@ class NotificationRouteArgs {
 
   @override
   String toString() {
-    return 'NotificationRouteArgs{key: $key, account: $account}';
+    return 'ChannelsRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [LoginPage]
-class LoginRoute extends PageRouteInfo<void> {
-  const LoginRoute({List<PageRouteInfo>? children})
-      : super(
-          LoginRoute.name,
+/// [ChannelDetailPage]
+class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
+  ChannelDetailRoute({
+    Key? key,
+    required Account account,
+    required String channelId,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ChannelDetailRoute.name,
+          args: ChannelDetailRouteArgs(
+            key: key,
+            account: account,
+            channelId: channelId,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'LoginRoute';
+  static const String name = 'ChannelDetailRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static const PageInfo<ChannelDetailRouteArgs> page =
+      PageInfo<ChannelDetailRouteArgs>(name);
+}
+
+class ChannelDetailRouteArgs {
+  const ChannelDetailRouteArgs({
+    this.key,
+    required this.account,
+    required this.channelId,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String channelId;
+
+  @override
+  String toString() {
+    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
+  }
 }
 
 /// generated route for
@@ -588,6 +628,268 @@ class ClipListRouteArgs {
 }
 
 /// generated route for
+/// [ExplorePage]
+class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
+  ExploreRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoute.name,
+          args: ExploreRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoute';
+
+  static const PageInfo<ExploreRouteArgs> page =
+      PageInfo<ExploreRouteArgs>(name);
+}
+
+class ExploreRouteArgs {
+  const ExploreRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ExploreRoleUsersPage]
+class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
+  ExploreRoleUsersRoute({
+    Key? key,
+    required RolesListResponse item,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoleUsersRoute.name,
+          args: ExploreRoleUsersRouteArgs(
+            key: key,
+            item: item,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoleUsersRoute';
+
+  static const PageInfo<ExploreRoleUsersRouteArgs> page =
+      PageInfo<ExploreRoleUsersRouteArgs>(name);
+}
+
+class ExploreRoleUsersRouteArgs {
+  const ExploreRoleUsersRouteArgs({
+    this.key,
+    required this.item,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final RolesListResponse item;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FavoritedNotePage]
+class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
+  FavoritedNoteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FavoritedNoteRoute.name,
+          args: FavoritedNoteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FavoritedNoteRoute';
+
+  static const PageInfo<FavoritedNoteRouteArgs> page =
+      PageInfo<FavoritedNoteRouteArgs>(name);
+}
+
+class FavoritedNoteRouteArgs {
+  const FavoritedNoteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FederationPage]
+class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
+  FederationRoute({
+    Key? key,
+    required Account account,
+    required String host,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FederationRoute.name,
+          args: FederationRouteArgs(
+            key: key,
+            account: account,
+            host: host,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FederationRoute';
+
+  static const PageInfo<FederationRouteArgs> page =
+      PageInfo<FederationRouteArgs>(name);
+}
+
+class FederationRouteArgs {
+  const FederationRouteArgs({
+    this.key,
+    required this.account,
+    required this.host,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String host;
+
+  @override
+  String toString() {
+    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
+  }
+}
+
+/// generated route for
+/// [HashtagPage]
+class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
+  HashtagRoute({
+    Key? key,
+    required String hashtag,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          HashtagRoute.name,
+          args: HashtagRouteArgs(
+            key: key,
+            hashtag: hashtag,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'HashtagRoute';
+
+  static const PageInfo<HashtagRouteArgs> page =
+      PageInfo<HashtagRouteArgs>(name);
+}
+
+class HashtagRouteArgs {
+  const HashtagRouteArgs({
+    this.key,
+    required this.hashtag,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String hashtag;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+  }
+}
+
+/// generated route for
+/// [LoginPage]
+class LoginRoute extends PageRouteInfo<void> {
+  const LoginRoute({List<PageRouteInfo>? children})
+      : super(
+          LoginRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'LoginRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [NotesAfterRenotePage]
+class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
+  NotesAfterRenoteRoute({
+    Key? key,
+    required Note note,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          NotesAfterRenoteRoute.name,
+          args: NotesAfterRenoteRouteArgs(
+            key: key,
+            note: note,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'NotesAfterRenoteRoute';
+
+  static const PageInfo<NotesAfterRenoteRouteArgs> page =
+      PageInfo<NotesAfterRenoteRouteArgs>(name);
+}
+
+class NotesAfterRenoteRouteArgs {
+  const NotesAfterRenoteRouteArgs({
+    this.key,
+    required this.note,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Note note;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
+  }
+}
+
+/// generated route for
 /// [NoteCreatePage]
 class NoteCreateRoute extends PageRouteInfo<NoteCreateRouteArgs> {
   NoteCreateRoute({
@@ -656,173 +958,83 @@ class NoteCreateRouteArgs {
 }
 
 /// generated route for
-/// [HashtagPage]
-class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
-  HashtagRoute({
+/// [NoteDetailPage]
+class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
+  NoteDetailRoute({
     Key? key,
-    required String hashtag,
+    required Note note,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          HashtagRoute.name,
-          args: HashtagRouteArgs(
+          NoteDetailRoute.name,
+          args: NoteDetailRouteArgs(
             key: key,
-            hashtag: hashtag,
+            note: note,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'HashtagRoute';
+  static const String name = 'NoteDetailRoute';
 
-  static const PageInfo<HashtagRouteArgs> page =
-      PageInfo<HashtagRouteArgs>(name);
+  static const PageInfo<NoteDetailRouteArgs> page =
+      PageInfo<NoteDetailRouteArgs>(name);
 }
 
-class HashtagRouteArgs {
-  const HashtagRouteArgs({
+class NoteDetailRouteArgs {
+  const NoteDetailRouteArgs({
     this.key,
-    required this.hashtag,
+    required this.note,
     required this.account,
   });
 
   final Key? key;
 
-  final String hashtag;
+  final Note note;
 
   final Account account;
 
   @override
   String toString() {
-    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
   }
 }
 
 /// generated route for
-/// [UserFolloweePage]
-class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
-  UserFolloweeRoute({
+/// [NotificationPage]
+class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
+  NotificationRoute({
     Key? key,
-    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          UserFolloweeRoute.name,
-          args: UserFolloweeRouteArgs(
+          NotificationRoute.name,
+          args: NotificationRouteArgs(
             key: key,
-            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UserFolloweeRoute';
+  static const String name = 'NotificationRoute';
 
-  static const PageInfo<UserFolloweeRouteArgs> page =
-      PageInfo<UserFolloweeRouteArgs>(name);
+  static const PageInfo<NotificationRouteArgs> page =
+      PageInfo<NotificationRouteArgs>(name);
 }
 
-class UserFolloweeRouteArgs {
-  const UserFolloweeRouteArgs({
+class NotificationRouteArgs {
+  const NotificationRouteArgs({
     this.key,
-    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String userId;
-
   final Account account;
 
   @override
   String toString() {
-    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserPage]
-class UserRoute extends PageRouteInfo<UserRouteArgs> {
-  UserRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserRoute.name,
-          args: UserRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserRoute';
-
-  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
-}
-
-class UserRouteArgs {
-  const UserRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserFollowerPage]
-class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
-  UserFollowerRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserFollowerRoute.name,
-          args: UserFollowerRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserFollowerRoute';
-
-  static const PageInfo<UserFollowerRouteArgs> page =
-      PageInfo<UserFollowerRouteArgs>(name);
-}
-
-class UserFollowerRouteArgs {
-  const UserFollowerRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
+    return 'NotificationRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -875,17 +1087,267 @@ class PhotoEditRouteArgs {
 }
 
 /// generated route for
-/// [SplashPage]
-class SplashRoute extends PageRouteInfo<void> {
-  const SplashRoute({List<PageRouteInfo>? children})
-      : super(
-          SplashRoute.name,
+/// [SearchPage]
+class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
+  SearchRoute({
+    Key? key,
+    String? initialSearchText,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          SearchRoute.name,
+          args: SearchRouteArgs(
+            key: key,
+            initialSearchText: initialSearchText,
+            account: account,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'SplashRoute';
+  static const String name = 'SearchRoute';
+
+  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+}
+
+class SearchRouteArgs {
+  const SearchRouteArgs({
+    this.key,
+    this.initialSearchText,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String? initialSearchText;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
+  }
+}
+
+/// generated route for
+/// [AccountListPage]
+class AccountListRoute extends PageRouteInfo<void> {
+  const AccountListRoute({List<PageRouteInfo>? children})
+      : super(
+          AccountListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AccountListRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [AppInfoPage]
+class AppInfoRoute extends PageRouteInfo<void> {
+  const AppInfoRoute({List<PageRouteInfo>? children})
+      : super(
+          AppInfoRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AppInfoRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [GeneralSettingsPage]
+class GeneralSettingsRoute extends PageRouteInfo<void> {
+  const GeneralSettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          GeneralSettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'GeneralSettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [SettingsPage]
+class SettingsRoute extends PageRouteInfo<void> {
+  const SettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          SettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsListPage]
+class TabSettingsListRoute extends PageRouteInfo<void> {
+  const TabSettingsListRoute({List<PageRouteInfo>? children})
+      : super(
+          TabSettingsListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsPage]
+class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
+  TabSettingsRoute({
+    Key? key,
+    int? tabIndex,
+    List<PageRouteInfo>? children,
+  }) : super(
+          TabSettingsRoute.name,
+          args: TabSettingsRouteArgs(
+            key: key,
+            tabIndex: tabIndex,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsRoute';
+
+  static const PageInfo<TabSettingsRouteArgs> page =
+      PageInfo<TabSettingsRouteArgs>(name);
+}
+
+class TabSettingsRouteArgs {
+  const TabSettingsRouteArgs({
+    this.key,
+    this.tabIndex,
+  });
+
+  final Key? key;
+
+  final int? tabIndex;
+
+  @override
+  String toString() {
+    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
+  }
+}
+
+/// generated route for
+/// [HardMutePage]
+class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
+  HardMuteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          HardMuteRoute.name,
+          args: HardMuteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'HardMuteRoute';
+
+  static const PageInfo<HardMuteRouteArgs> page =
+      PageInfo<HardMuteRouteArgs>(name);
+}
+
+class HardMuteRouteArgs {
+  const HardMuteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'HardMuteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [InstanceMutePage]
+class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
+  InstanceMuteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          InstanceMuteRoute.name,
+          args: InstanceMuteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'InstanceMuteRoute';
+
+  static const PageInfo<InstanceMuteRouteArgs> page =
+      PageInfo<InstanceMuteRouteArgs>(name);
+}
+
+class InstanceMuteRouteArgs {
+  const InstanceMuteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ReactionDeckPage]
+class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
+  ReactionDeckRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ReactionDeckRoute.name,
+          args: ReactionDeckRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ReactionDeckRoute';
+
+  static const PageInfo<ReactionDeckRouteArgs> page =
+      PageInfo<ReactionDeckRouteArgs>(name);
+}
+
+class ReactionDeckRouteArgs {
+  const ReactionDeckRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
+  }
 }
 
 /// generated route for
@@ -967,116 +1429,136 @@ class SeveralAccountSettingsRouteArgs {
 }
 
 /// generated route for
-/// [InstanceMutePage]
-class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
-  InstanceMuteRoute({
+/// [SharingAccountSelectPage]
+class SharingAccountSelectRoute
+    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
+  SharingAccountSelectRoute({
     Key? key,
-    required Account account,
+    String? sharingText,
+    List<String>? filePath,
     List<PageRouteInfo>? children,
   }) : super(
-          InstanceMuteRoute.name,
-          args: InstanceMuteRouteArgs(
+          SharingAccountSelectRoute.name,
+          args: SharingAccountSelectRouteArgs(
             key: key,
-            account: account,
+            sharingText: sharingText,
+            filePath: filePath,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'InstanceMuteRoute';
+  static const String name = 'SharingAccountSelectRoute';
 
-  static const PageInfo<InstanceMuteRouteArgs> page =
-      PageInfo<InstanceMuteRouteArgs>(name);
+  static const PageInfo<SharingAccountSelectRouteArgs> page =
+      PageInfo<SharingAccountSelectRouteArgs>(name);
 }
 
-class InstanceMuteRouteArgs {
-  const InstanceMuteRouteArgs({
+class SharingAccountSelectRouteArgs {
+  const SharingAccountSelectRouteArgs({
     this.key,
-    required this.account,
+    this.sharingText,
+    this.filePath,
   });
 
   final Key? key;
 
-  final Account account;
+  final String? sharingText;
+
+  final List<String>? filePath;
 
   @override
   String toString() {
-    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
   }
 }
 
 /// generated route for
-/// [HardMutePage]
-class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
-  HardMuteRoute({
+/// [SplashPage]
+class SplashRoute extends PageRouteInfo<void> {
+  const SplashRoute({List<PageRouteInfo>? children})
+      : super(
+          SplashRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SplashRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TimeLinePage]
+class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
+  TimeLineRoute({
     Key? key,
-    required Account account,
+    required TabSetting currentTabSetting,
     List<PageRouteInfo>? children,
   }) : super(
-          HardMuteRoute.name,
-          args: HardMuteRouteArgs(
+          TimeLineRoute.name,
+          args: TimeLineRouteArgs(
             key: key,
-            account: account,
+            currentTabSetting: currentTabSetting,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'HardMuteRoute';
+  static const String name = 'TimeLineRoute';
 
-  static const PageInfo<HardMuteRouteArgs> page =
-      PageInfo<HardMuteRouteArgs>(name);
+  static const PageInfo<TimeLineRouteArgs> page =
+      PageInfo<TimeLineRouteArgs>(name);
 }
 
-class HardMuteRouteArgs {
-  const HardMuteRouteArgs({
+class TimeLineRouteArgs {
+  const TimeLineRouteArgs({
     this.key,
-    required this.account,
+    required this.currentTabSetting,
   });
 
   final Key? key;
 
-  final Account account;
+  final TabSetting currentTabSetting;
 
   @override
   String toString() {
-    return 'HardMuteRouteArgs{key: $key, account: $account}';
+    return 'TimeLineRouteArgs{key: $key, currentTabSetting: $currentTabSetting}';
   }
 }
 
 /// generated route for
-/// [ReactionDeckPage]
-class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
-  ReactionDeckRoute({
-    Key? key,
+/// [UsersListPage]
+class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
+  UsersListRoute({
     required Account account,
+    Key? key,
     List<PageRouteInfo>? children,
   }) : super(
-          ReactionDeckRoute.name,
-          args: ReactionDeckRouteArgs(
-            key: key,
+          UsersListRoute.name,
+          args: UsersListRouteArgs(
             account: account,
+            key: key,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ReactionDeckRoute';
+  static const String name = 'UsersListRoute';
 
-  static const PageInfo<ReactionDeckRouteArgs> page =
-      PageInfo<ReactionDeckRouteArgs>(name);
+  static const PageInfo<UsersListRouteArgs> page =
+      PageInfo<UsersListRouteArgs>(name);
 }
 
-class ReactionDeckRouteArgs {
-  const ReactionDeckRouteArgs({
-    this.key,
+class UsersListRouteArgs {
+  const UsersListRouteArgs({
     required this.account,
+    this.key,
   });
-
-  final Key? key;
 
   final Account account;
 
+  final Key? key;
+
   @override
   String toString() {
-    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
+    return 'UsersListRouteArgs{account: $account, key: $key}';
   }
 }
 
@@ -1124,557 +1606,129 @@ class UsersListTimelineRouteArgs {
 }
 
 /// generated route for
-/// [UsersListPage]
-class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
-  UsersListRoute({
-    required Account account,
+/// [UserFolloweePage]
+class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
+  UserFolloweeRoute({
     Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListRoute.name,
-          args: UsersListRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListRoute';
-
-  static const PageInfo<UsersListRouteArgs> page =
-      PageInfo<UsersListRouteArgs>(name);
-}
-
-class UsersListRouteArgs {
-  const UsersListRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'UsersListRouteArgs{account: $account, key: $key}';
-  }
-}
-
-/// generated route for
-/// [ChannelDetailPage]
-class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
-  ChannelDetailRoute({
-    Key? key,
-    required Account account,
-    required String channelId,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ChannelDetailRoute.name,
-          args: ChannelDetailRouteArgs(
-            key: key,
-            account: account,
-            channelId: channelId,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ChannelDetailRoute';
-
-  static const PageInfo<ChannelDetailRouteArgs> page =
-      PageInfo<ChannelDetailRouteArgs>(name);
-}
-
-class ChannelDetailRouteArgs {
-  const ChannelDetailRouteArgs({
-    this.key,
-    required this.account,
-    required this.channelId,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String channelId;
-
-  @override
-  String toString() {
-    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
-  }
-}
-
-/// generated route for
-/// [ChannelsPage]
-class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
-  ChannelsRoute({
-    Key? key,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          ChannelsRoute.name,
-          args: ChannelsRouteArgs(
+          UserFolloweeRoute.name,
+          args: UserFolloweeRouteArgs(
             key: key,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ChannelsRoute';
+  static const String name = 'UserFolloweeRoute';
 
-  static const PageInfo<ChannelsRouteArgs> page =
-      PageInfo<ChannelsRouteArgs>(name);
+  static const PageInfo<UserFolloweeRouteArgs> page =
+      PageInfo<UserFolloweeRouteArgs>(name);
 }
 
-class ChannelsRouteArgs {
-  const ChannelsRouteArgs({
+class UserFolloweeRouteArgs {
+  const UserFolloweeRouteArgs({
     this.key,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
+  final String userId;
+
   final Account account;
 
   @override
   String toString() {
-    return 'ChannelsRouteArgs{key: $key, account: $account}';
+    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }
 
 /// generated route for
-/// [FederationPage]
-class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
-  FederationRoute({
+/// [UserFollowerPage]
+class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
+  UserFollowerRoute({
     Key? key,
-    required Account account,
-    required String host,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FederationRoute.name,
-          args: FederationRouteArgs(
-            key: key,
-            account: account,
-            host: host,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FederationRoute';
-
-  static const PageInfo<FederationRouteArgs> page =
-      PageInfo<FederationRouteArgs>(name);
-}
-
-class FederationRouteArgs {
-  const FederationRouteArgs({
-    this.key,
-    required this.account,
-    required this.host,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String host;
-
-  @override
-  String toString() {
-    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
-  }
-}
-
-/// generated route for
-/// [NoteDetailPage]
-class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
-  NoteDetailRoute({
-    Key? key,
-    required Note note,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NoteDetailRoute.name,
-          args: NoteDetailRouteArgs(
+          UserFollowerRoute.name,
+          args: UserFollowerRouteArgs(
             key: key,
-            note: note,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NoteDetailRoute';
+  static const String name = 'UserFollowerRoute';
 
-  static const PageInfo<NoteDetailRouteArgs> page =
-      PageInfo<NoteDetailRouteArgs>(name);
+  static const PageInfo<UserFollowerRouteArgs> page =
+      PageInfo<UserFollowerRouteArgs>(name);
 }
 
-class NoteDetailRouteArgs {
-  const NoteDetailRouteArgs({
+class UserFollowerRouteArgs {
+  const UserFollowerRouteArgs({
     this.key,
-    required this.note,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final Note note;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
+    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }
 
 /// generated route for
-/// [SearchPage]
-class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
-  SearchRoute({
+/// [UserPage]
+class UserRoute extends PageRouteInfo<UserRouteArgs> {
+  UserRoute({
     Key? key,
-    String? initialSearchText,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          SearchRoute.name,
-          args: SearchRouteArgs(
+          UserRoute.name,
+          args: UserRouteArgs(
             key: key,
-            initialSearchText: initialSearchText,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'SearchRoute';
+  static const String name = 'UserRoute';
 
-  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
 }
 
-class SearchRouteArgs {
-  const SearchRouteArgs({
+class UserRouteArgs {
+  const UserRouteArgs({
     this.key,
-    this.initialSearchText,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String? initialSearchText;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
-  }
-}
-
-/// generated route for
-/// [SharingAccountSelectPage]
-class SharingAccountSelectRoute
-    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
-  SharingAccountSelectRoute({
-    Key? key,
-    String? sharingText,
-    List<String>? filePath,
-    List<PageRouteInfo>? children,
-  }) : super(
-          SharingAccountSelectRoute.name,
-          args: SharingAccountSelectRouteArgs(
-            key: key,
-            sharingText: sharingText,
-            filePath: filePath,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'SharingAccountSelectRoute';
-
-  static const PageInfo<SharingAccountSelectRouteArgs> page =
-      PageInfo<SharingAccountSelectRouteArgs>(name);
-}
-
-class SharingAccountSelectRouteArgs {
-  const SharingAccountSelectRouteArgs({
-    this.key,
-    this.sharingText,
-    this.filePath,
-  });
-
-  final Key? key;
-
-  final String? sharingText;
-
-  final List<String>? filePath;
-
-  @override
-  String toString() {
-    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
-  }
-}
-
-/// generated route for
-/// [GeneralSettingsPage]
-class GeneralSettingsRoute extends PageRouteInfo<void> {
-  const GeneralSettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          GeneralSettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'GeneralSettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [TabSettingsPage]
-class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
-  TabSettingsRoute({
-    Key? key,
-    int? tabIndex,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TabSettingsRoute.name,
-          args: TabSettingsRouteArgs(
-            key: key,
-            tabIndex: tabIndex,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsRoute';
-
-  static const PageInfo<TabSettingsRouteArgs> page =
-      PageInfo<TabSettingsRouteArgs>(name);
-}
-
-class TabSettingsRouteArgs {
-  const TabSettingsRouteArgs({
-    this.key,
-    this.tabIndex,
-  });
-
-  final Key? key;
-
-  final int? tabIndex;
-
-  @override
-  String toString() {
-    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
-  }
-}
-
-/// generated route for
-/// [TabSettingsListPage]
-class TabSettingsListRoute extends PageRouteInfo<void> {
-  const TabSettingsListRoute({List<PageRouteInfo>? children})
-      : super(
-          TabSettingsListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AppInfoPage]
-class AppInfoRoute extends PageRouteInfo<void> {
-  const AppInfoRoute({List<PageRouteInfo>? children})
-      : super(
-          AppInfoRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AppInfoRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [SettingsPage]
-class SettingsRoute extends PageRouteInfo<void> {
-  const SettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          SettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'SettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AccountListPage]
-class AccountListRoute extends PageRouteInfo<void> {
-  const AccountListRoute({List<PageRouteInfo>? children})
-      : super(
-          AccountListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AccountListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [ExploreRoleUsersPage]
-class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
-  ExploreRoleUsersRoute({
-    Key? key,
-    required RolesListResponse item,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoleUsersRoute.name,
-          args: ExploreRoleUsersRouteArgs(
-            key: key,
-            item: item,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoleUsersRoute';
-
-  static const PageInfo<ExploreRoleUsersRouteArgs> page =
-      PageInfo<ExploreRoleUsersRouteArgs>(name);
-}
-
-class ExploreRoleUsersRouteArgs {
-  const ExploreRoleUsersRouteArgs({
-    this.key,
-    required this.item,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final RolesListResponse item;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ExplorePage]
-class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
-  ExploreRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoute.name,
-          args: ExploreRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoute';
-
-  static const PageInfo<ExploreRouteArgs> page =
-      PageInfo<ExploreRouteArgs>(name);
-}
-
-class ExploreRouteArgs {
-  const ExploreRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [TimeLinePage]
-class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
-  TimeLineRoute({
-    Key? key,
-    required TabSetting currentTabSetting,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TimeLineRoute.name,
-          args: TimeLineRouteArgs(
-            key: key,
-            currentTabSetting: currentTabSetting,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TimeLineRoute';
-
-  static const PageInfo<TimeLineRouteArgs> page =
-      PageInfo<TimeLineRouteArgs>(name);
-}
-
-class TimeLineRouteArgs {
-  const TimeLineRouteArgs({
-    this.key,
-    required this.currentTabSetting,
-  });
-
-  final Key? key;
-
-  final TabSetting currentTabSetting;
-
-  @override
-  String toString() {
-    return 'TimeLineRouteArgs{key: $key, currentTabSetting: $currentTabSetting}';
-  }
-}
-
-/// generated route for
-/// [FavoritedNotePage]
-class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
-  FavoritedNoteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FavoritedNoteRoute.name,
-          args: FavoritedNoteRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FavoritedNoteRoute';
-
-  static const PageInfo<FavoritedNoteRouteArgs> page =
-      PageInfo<FavoritedNoteRouteArgs>(name);
-}
-
-class FavoritedNoteRouteArgs {
-  const FavoritedNoteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
+    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }

--- a/lib/view/common/misskey_notes/note_modal_sheet.dart
+++ b/lib/view/common/misskey_notes/note_modal_sheet.dart
@@ -157,6 +157,17 @@ class NoteModalSheet extends ConsumerWidget {
                 );
               },
             ),
+            ListTile(
+              title: const Text("リノートの直後のノート"),
+              onTap: () {
+                context.pushRoute(
+                  NotesAfterRenoteRoute(
+                    note: targetNote,
+                    account: account,
+                  ),
+                );
+              },
+            ),
             if (baseNote.user.host == null &&
                 baseNote.user.username == account.userId &&
                 baseNote.text?.isNotEmpty == true) ...[

--- a/lib/view/notes_after_renote_page/notes_after_renote_page.dart
+++ b/lib/view/notes_after_renote_page/notes_after_renote_page.dart
@@ -1,0 +1,130 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/model/account.dart';
+import 'package:miria/providers.dart';
+import 'package:miria/view/common/account_scope.dart';
+import 'package:miria/view/common/misskey_notes/misskey_note.dart';
+import 'package:miria/view/common/pushable_listview.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+@RoutePage()
+class NotesAfterRenotePage extends ConsumerStatefulWidget {
+  final Note note;
+  final Account account;
+
+  const NotesAfterRenotePage({
+    super.key,
+    required this.note,
+    required this.account,
+  });
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _NotesAfterRenotePageState();
+}
+
+class _NotesAfterRenotePageState extends ConsumerState<NotesAfterRenotePage> {
+  String? untilId;
+
+  @override
+  Widget build(BuildContext context) {
+    final misskey = ref.watch(misskeyProvider(widget.account));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("リノートの直後のノート")),
+      body: Padding(
+        padding: const EdgeInsets.only(left: 10, right: 10),
+        child: PushableListView<Note>(
+          initializeFuture: () async {
+            final (
+              notesAfterRenote,
+              lastRenoteId,
+            ) = await getNotesAfterRenote(misskey);
+            ref
+                .read(notesProvider(widget.account))
+                .registerAll(notesAfterRenote);
+            setState(() {
+              untilId = lastRenoteId;
+            });
+            return notesAfterRenote;
+          },
+          nextFuture: (_, __) async {
+            final (
+              notesAfterRenote,
+              lastRenoteId,
+            ) = await getNotesAfterRenote(
+              misskey,
+              untilId: untilId,
+            );
+            ref
+                .read(notesProvider(widget.account))
+                .registerAll(notesAfterRenote);
+            setState(() {
+              untilId = lastRenoteId;
+            });
+            return notesAfterRenote;
+          },
+          itemBuilder: (context, item) {
+            return AccountScope(
+              account: widget.account,
+              child: MisskeyNote(note: item),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  /// 指定されたノートに対するリノートの次に投稿されたノートのリストと
+  /// 取得した最後のリノートのIDを返す
+  Future<(List<Note>, String?)> getNotesAfterRenote(
+    Misskey misskey, {
+    String? untilId,
+  }) async {
+    final renotesAndQuotes = await misskey.notes.renotes(
+      NotesRenoteRequest(
+        noteId: widget.note.id,
+        untilId: untilId,
+      ),
+    );
+    if (renotesAndQuotes.isEmpty) {
+      return (List<Note>.empty(), untilId);
+    }
+    final lastRenoteId = renotesAndQuotes.last.id;
+    final renotes = renotesAndQuotes.where((note) => isRenote(note));
+    final notesAfterRenote = await Future.wait(
+      renotes.map((renote) => getNoteAfterNote(misskey, renote)),
+    );
+    final notes = notesAfterRenote.nonNulls
+        .where(
+          (note) => note.renoteId == null && note.replyId == null,
+        )
+        .toList();
+    if (notes.isEmpty) {
+      // リノートがまだあるときに空のリストを返すと次が呼ばれなくなるため
+      return getNotesAfterRenote(misskey, untilId: lastRenoteId);
+    }
+    return (notes, lastRenoteId);
+  }
+
+  /// 指定されたノートを投稿したユーザーがその次に投稿したノートを (あれば) 返す
+  Future<Note?> getNoteAfterNote(Misskey misskey, Note note) async {
+    final notes = await misskey.users.notes(
+      UsersNotesRequest(
+        userId: note.userId,
+        sinceId: note.id,
+        limit: 1,
+      ),
+    );
+    return notes.singleOrNull;
+  }
+
+  /// 指定されたノートが引用ではないリノートかどうか
+  bool isRenote(Note note) {
+    return note.renoteId != null &&
+        note.text == null &&
+        note.fileIds.isEmpty &&
+        note.poll == null;
+  }
+}


### PR DESCRIPTION
リノートの直後のノートを表示するやつを追加しました
ノートのモーダルから画面遷移します

- InheritedWidget がよくわかっていなくて Account の受け渡しとかが間違っているかもしれないので修正していただけるとありがたいです
- 単純にリノートの次のノートを表示していて時間差は考慮していません