### PR TITLE
ノート投稿時に本文がないときにnullを指定する

### DIFF
--- a/lib/state_notifier/note_create_page/note_create_state_notifier.dart
+++ b/lib/state_notifier/note_create_page/note_create_state_notifier.dart
@@ -237,8 +237,9 @@ class NoteCreateNotifier extends StateNotifier<NoteCreate> {
 
       await misskey.notes.create(NotesCreateRequest(
         visibility: state.noteVisibility,
-        text:
-            "${state.replyTo.map((e) => "@${e.username}${e.host == null ? " " : "@${e.host} "}").join("")}${state.text}",
+        text: state.text.isEmpty
+            ? null
+            : "${state.replyTo.map((e) => "@${e.username}${e.host == null ? " " : "@${e.host} "}").join("")}${state.text}",
         cw: state.isCw ? state.cwText : null,
         localOnly: state.localOnly,
         replyId: state.reply?.id,


### PR DESCRIPTION
Fix #140 