### PR TITLE
Android: MiAuthのリダイレクトを追加

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,6 +51,15 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="miria"
+                    android:host="miria"
+                    android:pathPrefix="/miauth"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -299,3 +299,5 @@ final antennasNotifierProvider = AsyncNotifierProvider.autoDispose
 
 final clipsNotifierProvider = AsyncNotifierProvider.autoDispose
     .family<ClipsNotifier, List<Clip>, Misskey>(ClipsNotifier.new);
+
+final miAuthCallbackProvider = StateProvider.autoDispose<Uri?>((ref) => null);

--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
@@ -293,10 +294,15 @@ class AccountRepository extends Notifier<List<Account>> {
         server,
         _sessionId,
         name: "Miria",
+        callback: Platform.isAndroid ? "miria://miria/miauth" : null,
         permission: Permission.values,
       ),
       mode: LaunchMode.externalApplication,
     );
+  }
+
+  bool verifySessionId(String id) {
+    return id == _sessionId;
   }
 
   Future<void> validateMiAuth(String server) async {

--- a/lib/view/login_page/mi_auth_login.dart
+++ b/lib/view/login_page/mi_auth_login.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/providers.dart';
@@ -48,6 +50,22 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
 
   @override
   Widget build(BuildContext context) {
+    if (isAuthed) {
+      if (Platform.isAndroid) {
+        ref.listen(miAuthCallbackProvider, (_, uri) async {
+          final sessionId = uri?.queryParameters["session"];
+          if (sessionId != null) {
+            final isSameId = ref
+                .read(accountRepositoryProvider.notifier)
+                .verifySessionId(sessionId);
+            if (isSameId) {
+              await login().expectFailure(context);
+            }
+          }
+        });
+      }
+    }
+
     return CenteringWidget(
         child: Column(
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
MiAuthの認証後に自動でアプリに戻ってログインするようにしました

- Androidでしか試していません
  - iOSで動かすには多分カスタムURLスキーマの設定をする必要があると思います
- MiAuthのコールバックに `miria://miria/miauth` を指定しています
  - これは適当に決めたので気に入らなければ変更してください
- ブラウザでMiAuthが承認されると `miria://miria/miauth&sessionId=abc123` のようなURLがMiriaで開かれます
  - クエリパラメータのsessionIdが認証作成時に生成したIDと同じであれば「認証してきた」を押したときと同じ処理を行います

Related to https://github.com/shiosyakeyakini-info/miria/issues/23