### PR TITLE
firefishからのログインをはじく、パスワード認証画面を削除

### DIFF
--- a/lib/view/login_page/api_key_login.dart
+++ b/lib/view/login_page/api_key_login.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
+import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:miria/view/common/modal_indicator.dart';
 import 'package:miria/view/login_page/centraing_widget.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -79,7 +80,8 @@ class APiKeyLoginState extends ConsumerState<ApiKeyLogin> {
                 ),
                 TextField(
                   controller: apiKeyController,
-                  decoration: const InputDecoration(prefixIcon: Icon(Icons.key)),
+                  decoration:
+                      const InputDecoration(prefixIcon: Icon(Icons.key)),
                 )
               ]),
               // ],
@@ -89,7 +91,7 @@ class APiKeyLoginState extends ConsumerState<ApiKeyLogin> {
                   padding: const EdgeInsets.only(top: 10),
                   child: ElevatedButton(
                       onPressed: () {
-                        login();
+                        login().expectFailure(context);
                       },
                       child: const Text("ログイン")),
                 )

--- a/lib/view/login_page/login_page.dart
+++ b/lib/view/login_page/login_page.dart
@@ -1,4 +1,3 @@
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/view/login_page/api_key_login.dart';
@@ -25,11 +24,10 @@ class LoginPageState extends ConsumerState<LoginPage> {
             bottom: const TabBar(isScrollable: true, tabs: [
               Tab(text: "MiAuthでログイン"),
               Tab(text: "APIキーでログイン"),
-              Tab(text: "パスワードでログイン")
             ]),
           ),
           body: const TabBarView(
-            children: [MiAuthLogin(), ApiKeyLogin(), PasswordLogin()],
+            children: [MiAuthLogin(), ApiKeyLogin()],
           )),
     );
   }


### PR DESCRIPTION
- firefishからのログインを、ソフトウェア名で判断して弾く
- これまでAPIキーでバリデーションを行っていなかったのを、APIキーでもnodeinfoとかから見てバリデーションするようにする
- パスワードによるログイン画面は出さないようにした