### PR TITLE
MiAuthログイン時のエラーハンドリングを修正

### DIFF
--- a/lib/view/login_page/mi_auth_login.dart
+++ b/lib/view/login_page/mi_auth_login.dart
@@ -19,6 +19,24 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
   final serverController = TextEditingController();
   bool isAuthed = false;
 
+  Future<void> login() async {
+    try {
+      IndicatorView.showIndicator(context);
+      await ref.read(accountRepository).validateMiAuth(serverController.text);
+      if (!mounted) return;
+      context.pushRoute(
+        TimeLineRoute(
+          currentTabSetting:
+              ref.read(tabSettingsRepositoryProvider).tabSettings.first,
+        ),
+      );
+    } catch (e) {
+      rethrow;
+    } finally {
+      IndicatorView.hideIndicator(context);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return CenteringWidget(
@@ -78,25 +96,7 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
               TableRow(children: [
                 Container(),
                 ElevatedButton(
-                  onPressed: () async {
-                    try {
-                      IndicatorView.showIndicator(context);
-                      await ref
-                          .read(accountRepository)
-                          .validateMiAuth(serverController.text)
-                          .expectFailure(context);
-                      if (!mounted) return;
-                      context.pushRoute(TimeLineRoute(
-                          currentTabSetting: ref
-                              .read(tabSettingsRepositoryProvider)
-                              .tabSettings
-                              .first));
-                    } catch (e) {
-                      rethrow;
-                    } finally {
-                      IndicatorView.hideIndicator(context);
-                    }
-                  },
+                  onPressed: () => login().expectFailure(context),
                   child: const Text("認証してきた"),
                 ),
               ]),


### PR DESCRIPTION
Fix #197 

![image](https://github.com/shiosyakeyakini-info/miria/assets/63451158/822a7c40-4998-4195-8421-44e99dad8075)

メッセージを親切にするべきだとは思いますがそこまではやっていません