### PR TITLE
#199 下線ボタンを斜体ボタンに置き換える

### DIFF
--- a/lib/view/common/note_create/custom_keyboard_list.dart
+++ b/lib/view/common/note_create/custom_keyboard_list.dart
@@ -36,9 +36,8 @@ class CustomKeyboardList extends StatelessWidget {
           controller: controller,
           focusNode: focusNode),
       CustomKeyboard(
-          keyboard: "_",
-          afterInsert: "_",
-          displayText: "＿",
+          keyboard: "<i>",
+          afterInsert: "</i>",
           controller: controller,
           focusNode: focusNode),
       CustomKeyboard(


### PR DESCRIPTION
斜体`<i>`の入力補完を追加しました。
既に存在していた`_`に対するMFMの動作が確認できなかったため、`_`と置き換えています。