### PR TITLE
#202 MagicMouseでスクロールできるように

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,5 +63,6 @@ class AppScrollBehavior extends MaterialScrollBehavior {
   Set<PointerDeviceKind> get dragDevices => {
         PointerDeviceKind.touch,
         PointerDeviceKind.mouse,
+        PointerDeviceKind.trackpad,
       };
 }


### PR DESCRIPTION
MagicMouseのスクロールホイールで画面をスクロールできるように、dragDevicesにtrackpadを追加しました。
Fix #202 