### PR TITLE
設定のインポート・エクスポートのダイアログ修正

### DIFF
--- a/lib/repository/import_export_repository.dart
+++ b/lib/repository/import_export_repository.dart
@@ -24,17 +24,16 @@ class ImportExportRepository extends ChangeNotifier {
   ImportExportRepository(this.reader);
 
   Future<void> import(BuildContext context, Account account) async {
-    final folder = await showDialog<DriveFolder>(
-      barrierDismissible: false,
+    final result = await showDialog<FolderResult>(
       context: context,
-      builder: (context2) => WillPopScope(
-        onWillPop: () async => false,
-        child: FolderSelectDialog(
-          account: account,
-          fileShowTarget: const ["miria.json", "miria.json.unknown"],
-        ),
+      builder: (context2) => FolderSelectDialog(
+        account: account,
+        fileShowTarget: const ["miria.json", "miria.json.unknown"],
       ),
     );
+    if (result == null) return;
+
+    final folder = result.folder;
 
     Iterable<DriveFile> alreadyExists =
         await reader(misskeyProvider(account)).drive.files.find(
@@ -53,6 +52,7 @@ class ImportExportRepository extends ChangeNotifier {
             ),
           );
 
+      if (!context.mounted) return;
       if (alreadyExists.isEmpty) {
         await SimpleMessageDialog.show(context, "ここにMiriaの設定ファイルあれへんかったわ");
         return;
@@ -121,17 +121,16 @@ class ImportExportRepository extends ChangeNotifier {
   }
 
   Future<void> export(BuildContext context, Account account) async {
-    final folder = await showDialog<DriveFolder>(
-      barrierDismissible: false,
+    final result = await showDialog<FolderResult>(
       context: context,
-      builder: (context2) => WillPopScope(
-        onWillPop: () async => false,
-        child: FolderSelectDialog(
-          account: account,
-          fileShowTarget: const ["miria.json", "miria.json.unknown"],
-        ),
+      builder: (context2) => FolderSelectDialog(
+        account: account,
+        fileShowTarget: const ["miria.json", "miria.json.unknown"],
       ),
     );
+    if (result == null) return;
+
+    final folder = result.folder;
 
     final alreadyExists =
         await reader(misskeyProvider(account)).drive.files.find(

--- a/lib/repository/import_export_repository.dart
+++ b/lib/repository/import_export_repository.dart
@@ -29,6 +29,7 @@ class ImportExportRepository extends ChangeNotifier {
       builder: (context2) => FolderSelectDialog(
         account: account,
         fileShowTarget: const ["miria.json", "miria.json.unknown"],
+        confirmationText: "このフォルダーからインポートする",
       ),
     );
     if (result == null) return;
@@ -126,6 +127,7 @@ class ImportExportRepository extends ChangeNotifier {
       builder: (context2) => FolderSelectDialog(
         account: account,
         fileShowTarget: const ["miria.json", "miria.json.unknown"],
+        confirmationText: "このフォルダーに保存する",
       ),
     );
     if (result == null) return;

--- a/lib/view/settings_page/import_export_page/folder_select_dialog.dart
+++ b/lib/view/settings_page/import_export_page/folder_select_dialog.dart
@@ -15,11 +15,13 @@ class FolderResult {
 class FolderSelectDialog extends ConsumerStatefulWidget {
   final Account account;
   final List<String>? fileShowTarget;
+  final String confirmationText;
 
   const FolderSelectDialog({
     super.key,
     required this.account,
     required this.fileShowTarget,
+    required this.confirmationText,
   });
 
   @override
@@ -35,7 +37,7 @@ class FolderSelectDialogState extends ConsumerState<FolderSelectDialog> {
     return AlertDialog(
       title: Column(
         children: [
-          const Text("フォルダ選択"),
+          const Text("フォルダー選択"),
           Row(
             children: [
               if (path.isNotEmpty)
@@ -131,7 +133,7 @@ class FolderSelectDialogState extends ConsumerState<FolderSelectDialog> {
           onPressed: () {
             Navigator.of(context).pop(FolderResult(path.lastOrNull));
           },
-          child: const Text("このフォルダーに保存する"),
+          child: Text(widget.confirmationText),
         )
       ],
     );

--- a/lib/view/settings_page/import_export_page/folder_select_dialog.dart
+++ b/lib/view/settings_page/import_export_page/folder_select_dialog.dart
@@ -6,6 +6,12 @@ import 'package:miria/view/common/futable_list_builder.dart';
 import 'package:miria/view/common/pushable_listview.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
+class FolderResult {
+  const FolderResult(this.folder);
+
+  final DriveFolder? folder;
+}
+
 class FolderSelectDialog extends ConsumerStatefulWidget {
   final Account account;
   final List<String>? fileShowTarget;
@@ -123,7 +129,7 @@ class FolderSelectDialogState extends ConsumerState<FolderSelectDialog> {
       actions: [
         ElevatedButton(
           onPressed: () {
-            Navigator.of(context).pop(path.lastOrNull);
+            Navigator.of(context).pop(FolderResult(path.lastOrNull));
           },
           child: const Text("このフォルダーに保存する"),
         )

--- a/lib/view/settings_page/import_export_page/folder_select_dialog.dart
+++ b/lib/view/settings_page/import_export_page/folder_select_dialog.dart
@@ -34,12 +34,13 @@ class FolderSelectDialogState extends ConsumerState<FolderSelectDialog> {
             children: [
               if (path.isNotEmpty)
                 IconButton(
-                    onPressed: () {
-                      setState(() {
-                        path.removeLast();
-                      });
-                    },
-                    icon: const Icon(Icons.arrow_back)),
+                  onPressed: () {
+                    setState(() {
+                      path.removeLast();
+                    });
+                  },
+                  icon: const Icon(Icons.arrow_back),
+                ),
               Expanded(child: Text(path.map((e) => e.name).join("/"))),
             ],
           )
@@ -52,35 +53,40 @@ class FolderSelectDialogState extends ConsumerState<FolderSelectDialog> {
           child: Column(
             children: [
               PushableListView(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  initializeFuture: () async {
-                    final misskey = ref.read(misskeyProvider(widget.account));
-                    final response = await misskey.drive.folders.folders(
-                        DriveFoldersRequest(
-                            folderId: path.isEmpty ? null : path.last.id));
-                    return response.toList();
-                  },
-                  nextFuture: (lastItem, _) async {
-                    final misskey = ref.read(misskeyProvider(widget.account));
-                    final response = await misskey.drive.folders.folders(
-                        DriveFoldersRequest(
-                            untilId: lastItem.id,
-                            folderId: path.isEmpty ? null : path.last.id));
-                    return response.toList();
-                  },
-                  listKey: path.map((e) => e.id).join("/"),
-                  itemBuilder: (context, item) {
-                    return ListTile(
-                      leading: const Icon(Icons.folder),
-                      title: Text(item.name ?? ""),
-                      onTap: () {
-                        setState(() {
-                          path.add(item);
-                        });
-                      },
-                    );
-                  }),
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                initializeFuture: () async {
+                  final misskey = ref.read(misskeyProvider(widget.account));
+                  final response = await misskey.drive.folders.folders(
+                    DriveFoldersRequest(
+                      folderId: path.isEmpty ? null : path.last.id,
+                    ),
+                  );
+                  return response.toList();
+                },
+                nextFuture: (lastItem, _) async {
+                  final misskey = ref.read(misskeyProvider(widget.account));
+                  final response = await misskey.drive.folders.folders(
+                    DriveFoldersRequest(
+                      untilId: lastItem.id,
+                      folderId: path.isEmpty ? null : path.last.id,
+                    ),
+                  );
+                  return response.toList();
+                },
+                listKey: path.map((e) => e.id).join("/"),
+                itemBuilder: (context, item) {
+                  return ListTile(
+                    leading: const Icon(Icons.folder),
+                    title: Text(item.name ?? ""),
+                    onTap: () {
+                      setState(() {
+                        path.add(item);
+                      });
+                    },
+                  );
+                },
+              ),
               if (widget.fileShowTarget != null)
                 FutureListView(
                   shrinkWrap: true,
@@ -88,18 +94,24 @@ class FolderSelectDialogState extends ConsumerState<FolderSelectDialog> {
                   future: () async {
                     final list = [];
                     for (final element in widget.fileShowTarget!) {
-                      list.addAll(await ref
-                          .read(misskeyProvider(widget.account))
-                          .drive
-                          .files
-                          .find(DriveFilesFindRequest(
-                              folderId: path.lastOrNull?.id, name: element)));
+                      list.addAll(
+                        await ref
+                            .read(misskeyProvider(widget.account))
+                            .drive
+                            .files
+                            .find(
+                              DriveFilesFindRequest(
+                                folderId: path.lastOrNull?.id,
+                                name: element,
+                              ),
+                            ),
+                      );
                     }
                     return list.toList();
                   }(),
                   builder: (context, item) => Row(
                     children: [
-                      Icon(Icons.description),
+                      const Icon(Icons.description),
                       Expanded(child: Text(item.name)),
                     ],
                   ),
@@ -110,10 +122,11 @@ class FolderSelectDialogState extends ConsumerState<FolderSelectDialog> {
       ),
       actions: [
         ElevatedButton(
-            onPressed: () {
-              Navigator.of(context).pop(path.lastOrNull);
-            },
-            child: const Text("このフォルダーに保存する"))
+          onPressed: () {
+            Navigator.of(context).pop(path.lastOrNull);
+          },
+          child: const Text("このフォルダーに保存する"),
+        )
       ],
     );
   }

--- a/lib/view/settings_page/import_export_page/import_export_page.dart
+++ b/lib/view/settings_page/import_export_page/import_export_page.dart
@@ -25,95 +25,98 @@ class ImportExportPageState extends ConsumerState<ImportExportPage> {
       body: Padding(
         padding: const EdgeInsets.only(left: 10, right: 10),
         child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                "設定のインポート",
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
-              const Text(
-                  "設定ファイルをドライブから読み込みます。設定ファイルには保存されたときのすべてのアカウントの設定情報が記録されていますが、そのうちこの端末でログインしているアカウントの情報のみを読み込みます。"),
-              Row(
-                children: [
-                  Expanded(
-                    child: DropdownButton(
-                      isExpanded: true,
-                      items: [
-                        for (final account
-                            in ref.read(accountRepository).account)
-                          DropdownMenuItem(
-                            value: account,
-                            child: Text("@${account.userId}@${account.host}"),
-                          ),
-                      ],
-                      value: selectedImportAccount,
-                      onChanged: (Account? value) {
-                        setState(() {
-                          selectedImportAccount = value;
-                        });
-                      },
-                    ),
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              "設定のインポート",
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const Text(
+              "設定ファイルをドライブから読み込みます。設定ファイルには保存されたときのすべてのアカウントの設定情報が記録されていますが、そのうちこの端末でログインしているアカウントの情報のみを読み込みます。",
+            ),
+            Row(
+              children: [
+                Expanded(
+                  child: DropdownButton(
+                    isExpanded: true,
+                    items: [
+                      for (final account in ref.read(accountRepository).account)
+                        DropdownMenuItem(
+                          value: account,
+                          child: Text("@${account.userId}@${account.host}"),
+                        ),
+                    ],
+                    value: selectedImportAccount,
+                    onChanged: (Account? value) {
+                      setState(() {
+                        selectedImportAccount = value;
+                      });
+                    },
                   ),
-                  ElevatedButton(
-                      onPressed: () async {
-                        final account = selectedImportAccount;
-                        if (account == null) {
-                          await SimpleMessageDialog.show(context, "アカウントを選んでや");
-                          return;
-                        }
-                        await ref
-                            .read(importExportRepository)
-                            .import(context, account);
-                      },
-                      child: const Text("設定ファイル選択")),
-                ],
-              ),
-              const Padding(padding: EdgeInsets.only(top: 30)),
-              Text(
-                "設定のエクスポート",
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
-              const Text(
-                  "設定ファイルをドライブに保存します。設定ファイルにはこの端末でログインしているすべてのアカウントの、ログイン情報以外の情報が記録されます。"),
-              const Text("設定ファイルは1回のエクスポートにつき1つのアカウントに対して保存します。"),
-              Row(
-                children: [
-                  Expanded(
-                    child: DropdownButton(
-                      isExpanded: true,
-                      items: [
-                        for (final account
-                            in ref.read(accountRepository).account)
-                          DropdownMenuItem(
-                            value: account,
-                            child: Text("@${account.userId}@${account.host}"),
-                          ),
-                      ],
-                      value: selectedExportAccount,
-                      onChanged: (Account? value) {
-                        setState(() {
-                          selectedExportAccount = value;
-                        });
-                      },
-                    ),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    final account = selectedImportAccount;
+                    if (account == null) {
+                      await SimpleMessageDialog.show(context, "アカウントを選んでや");
+                      return;
+                    }
+                    await ref
+                        .read(importExportRepository)
+                        .import(context, account);
+                  },
+                  child: const Text("選択"),
+                ),
+              ],
+            ),
+            const Padding(padding: EdgeInsets.only(top: 30)),
+            Text(
+              "設定のエクスポート",
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const Text(
+              "設定ファイルをドライブに保存します。設定ファイルにはこの端末でログインしているすべてのアカウントの、ログイン情報以外の情報が記録されます。",
+            ),
+            const Text("設定ファイルは1回のエクスポートにつき1つのアカウントに対して保存します。"),
+            Row(
+              children: [
+                Expanded(
+                  child: DropdownButton(
+                    isExpanded: true,
+                    items: [
+                      for (final account in ref.read(accountRepository).account)
+                        DropdownMenuItem(
+                          value: account,
+                          child: Text("@${account.userId}@${account.host}"),
+                        ),
+                    ],
+                    value: selectedExportAccount,
+                    onChanged: (Account? value) {
+                      setState(() {
+                        selectedExportAccount = value;
+                      });
+                    },
                   ),
-                  ElevatedButton(
-                      onPressed: () {
-                        final account = selectedExportAccount;
-                        if (account == null) {
-                          SimpleMessageDialog.show(
-                              context, "設定ファイルを保存するアカウントを選んでや");
-                          return;
-                        }
-                        ref
-                            .read(importExportRepository)
-                            .export(context, account);
-                      },
-                      child: const Text("保存")),
-                ],
-              ),
-            ]),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    final account = selectedExportAccount;
+                    if (account == null) {
+                      SimpleMessageDialog.show(
+                        context,
+                        "設定ファイルを保存するアカウントを選んでや",
+                      );
+                      return;
+                    }
+                    ref.read(importExportRepository).export(context, account);
+                  },
+                  child: const Text("保存"),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
- ダイアログが閉じられないのを修正しました
  - popのときに `FolderResult` を返すようにして、それ自体がnullのときと中身がnullのときで処理を変えるようにしました
- インポートのダイアログの文言が間違っているのを修正しました
- フォルダとフォルダーはMisskey本体でも表記ゆれしていたのですが、比較的多く使われていたフォルダーの方に統一しました

Fix #178 
Fix #179 