### PR TITLE
Future() の中の setState の前に mounted を確認する

### DIFF
--- a/lib/view/channels_page/channel_detail_info.dart
+++ b/lib/view/channels_page/channel_detail_info.dart
@@ -76,10 +76,12 @@ class ChannelDetailInfoState extends ConsumerState<ChannelDetailInfo> {
             .show(ChannelsShowRequest(channelId: widget.channelId));
 
         ref.read(notesProvider(account)).registerAll(result.pinnedNotes ?? []);
+        if (!mounted) return;
         setState(() {
           data = result;
         });
       } catch (e, s) {
+        if (!mounted) return;
         setState(() {
           error = (e, s);
         });

--- a/lib/view/common/misskey_notes/clip_modal_sheet.dart
+++ b/lib/view/common/misskey_notes/clip_modal_sheet.dart
@@ -1,4 +1,3 @@
-
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -33,6 +32,7 @@ class ClipModalSheetState extends ConsumerState<ClipModalSheet> {
     super.didChangeDependencies();
 
     Future(() async {
+      if (!mounted) return;
       setState(() {
         isLoading = true;
       });
@@ -45,6 +45,7 @@ class ClipModalSheetState extends ConsumerState<ClipModalSheet> {
               .clips(NotesClipsRequest(noteId: widget.noteId)))
           .toList();
 
+      if (!mounted) return;
       setState(() {
         isLoading = false;
       });

--- a/lib/view/common/pushable_listview.dart
+++ b/lib/view/common/pushable_listview.dart
@@ -45,6 +45,7 @@ class PushableListViewState<T> extends ConsumerState<PushableListView<T>> {
         items
           ..clear()
           ..addAll(await widget.initializeFuture());
+        if (!mounted) return;
         setState(() {
           isLoading = false;
         });
@@ -52,10 +53,12 @@ class PushableListViewState<T> extends ConsumerState<PushableListView<T>> {
             duration: const Duration(milliseconds: 100), curve: Curves.easeIn);
       } catch (e, s) {
         if (kDebugMode) print(e);
-        setState(() {
-          error = (e, s);
-          isLoading = false;
-        });
+        if (mounted) {
+          setState(() {
+            error = (e, s);
+            isLoading = false;
+          });
+        }
         rethrow;
       }
     });
@@ -85,19 +88,23 @@ class PushableListViewState<T> extends ConsumerState<PushableListView<T>> {
     if (isLoading || items.isEmpty) return;
     Future(() async {
       try {
+        if (!mounted) return;
         setState(() {
           isLoading = true;
         });
         final result = await widget.nextFuture(items.last, items.length);
         if (result.isEmpty) isFinalPage = true;
         items.addAll(result);
+        if (!mounted) return;
         setState(() {
           isLoading = false;
         });
       } catch (e) {
-        setState(() {
-          isLoading = false;
-        });
+        if (mounted) {
+          setState(() {
+            isLoading = false;
+          });
+        }
         rethrow;
       }
     });

--- a/lib/view/explore_page/explore_users.dart
+++ b/lib/view/explore_page/explore_users.dart
@@ -32,6 +32,7 @@ class ExploreUsersState extends ConsumerState<ExploreUsers> {
       final response = await ref
           .read(misskeyProvider(AccountScope.of(context)))
           .pinnedUsers();
+      if (!mounted) return;
       setState(() {
         pinnedUser
           ..clear()
@@ -96,7 +97,8 @@ class ExploreUsersState extends ConsumerState<ExploreUsers> {
               if (isDetailOpen) ...[
                 Row(
                   children: [
-                    const Expanded(child: Text("並び順", textAlign: TextAlign.center)),
+                    const Expanded(
+                        child: Text("並び順", textAlign: TextAlign.center)),
                     Expanded(
                       child: DropdownButton<UsersSortType>(
                           items: [

--- a/lib/view/federation_page/federation_custom_emojis.dart
+++ b/lib/view/federation_page/federation_custom_emojis.dart
@@ -36,6 +36,7 @@ class FederationCustomEmojisState
       emojis
         ..clear()
         ..addAll(result.emojis.groupListsBy((e) => e.category ?? ""));
+      if (!mounted) return;
       setState(() {});
     });
   }

--- a/lib/view/federation_page/federation_info.dart
+++ b/lib/view/federation_page/federation_info.dart
@@ -116,10 +116,12 @@ class FederationInfoState extends ConsumerState<FederationInfo> {
           );
         }
 
+        if (!mounted) return;
         setState(() {});
       } catch (e, s) {
         print(e);
         print(s);
+        if (!mounted) return;
         setState(() {
           error = (e, s);
         });

--- a/lib/view/note_detail_page/note_detail_page.dart
+++ b/lib/view/note_detail_page/note_detail_page.dart
@@ -52,6 +52,7 @@ class NoteDetailPageState extends ConsumerState<NoteDetailPage> {
       conversations
         ..clear()
         ..addAll(conversationResult.toList().reversed);
+      if (!mounted) return;
       setState(() {
         isLoading = false;
       });

--- a/lib/view/photo_edit_page/license_confirm_dialog.dart
+++ b/lib/view/photo_edit_page/license_confirm_dialog.dart
@@ -36,11 +36,13 @@ class LicenseConfirmDialogState extends ConsumerState<LicenseConfirmDialog> {
         final response = await ref
             .read(misskeyProvider(widget.account))
             .emoji(EmojiRequest(name: widget.emoji));
+        if (!mounted) return;
         setState(() {
           isLoading = false;
           data = response;
         });
       } catch (e) {
+        if (!mounted) return;
         setState(() {
           error = e;
         });

--- a/lib/view/reaction_picker_dialog/reaction_picker_content.dart
+++ b/lib/view/reaction_picker_dialog/reaction_picker_content.dart
@@ -60,6 +60,7 @@ class ReactionPickerContentState extends ConsumerState<ReactionPickerContent> {
             onChanged: (value) {
               Future(() async {
                 final result = await emojiRepository.searchEmojis(value);
+                if (!mounted) return;
                 setState(() {
                   emojis.clear();
                   emojis.addAll(result);

--- a/lib/view/server_detail_dialog.dart
+++ b/lib/view/server_detail_dialog.dart
@@ -76,6 +76,7 @@ class ServerDetailDialogState extends ConsumerState<ServerDetailDialog> {
             .read(misskeyProvider(widget.account))
             .getOnlineUsersCount();
 
+        if (!mounted) return;
         setState(() {
           onlineUsers = onlineUserCountsResponse.count;
         });
@@ -85,7 +86,10 @@ class ServerDetailDialogState extends ConsumerState<ServerDetailDialog> {
       try {
         final serverInfoResponse =
             await ref.read(misskeyProvider(widget.account)).serverInfo();
-        totalMemories = serverInfoResponse.mem.total;
+        if (!mounted) return;
+        setState(() {
+          totalMemories = serverInfoResponse.mem.total;
+        });
       } catch (e) {
         //TODO
       }
@@ -100,6 +104,7 @@ class ServerDetailDialogState extends ConsumerState<ServerDetailDialog> {
       final pingResponse =
           await ref.read(misskeyProvider(widget.account)).ping();
 
+      if (!mounted) return;
       setState(() {
         ping = pingResponse.pong - sendDate.millisecondsSinceEpoch;
       });

--- a/lib/view/settings_page/app_info_page/app_info_page.dart
+++ b/lib/view/settings_page/app_info_page/app_info_page.dart
@@ -22,6 +22,7 @@ class AppInfoPageState extends ConsumerState<AppInfoPage> {
     super.didChangeDependencies();
     Future(() async {
       packageInfo = await PackageInfo.fromPlatform();
+      if (!mounted) return;
       setState(() {});
     });
   }

--- a/lib/view/settings_page/tab_settings_page/antenna_select_dialog.dart
+++ b/lib/view/settings_page/tab_settings_page/antenna_select_dialog.dart
@@ -27,6 +27,7 @@ class AntennaSelectDialogState extends ConsumerState<AntennaSelectDialog> {
       antennas
         ..clear()
         ..addAll(myAntennas);
+      if (!mounted) return;
       setState(() {});
     });
   }

--- a/lib/view/settings_page/tab_settings_page/channel_select_dialog.dart
+++ b/lib/view/settings_page/tab_settings_page/channel_select_dialog.dart
@@ -38,6 +38,7 @@ class ChannelSelectDialogState extends ConsumerState<ChannelSelectDialog> {
       followedChannels
         ..clear()
         ..addAll(followed);
+      if (!mounted) return;
       setState(() {});
     });
   }

--- a/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
@@ -73,6 +73,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
               .read(misskeyProvider(tabSetting.account))
               .channels
               .show(ChannelsShowRequest(channelId: channelId));
+          if (!mounted) return;
           setState(() {});
         });
       }
@@ -84,6 +85,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
               .list
               .show(UsersListsShowRequest(listId: listId));
           selectedUserList = response.toUsersList();
+          if (!mounted) return;
           setState(() {});
         });
       }
@@ -93,6 +95,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
               .read(misskeyProvider(tabSetting.account))
               .antennas
               .show(AntennasShowRequest(antennaId: antennaId));
+          if (!mounted) return;
           setState(() {});
         });
       }

--- a/lib/view/settings_page/tab_settings_page/user_list_select_dialog.dart
+++ b/lib/view/settings_page/tab_settings_page/user_list_select_dialog.dart
@@ -27,6 +27,7 @@ class UserListSelectDialogState extends ConsumerState<UserListSelectDialog> {
       userLists
         ..clear()
         ..addAll(myLists);
+      if (!mounted) return;
       setState(() {});
     });
   }

--- a/lib/view/several_account_settings_page/several_account_general_settings_page/several_account_general_settings_page.dart
+++ b/lib/view/several_account_settings_page/several_account_general_settings_page/several_account_general_settings_page.dart
@@ -42,6 +42,7 @@ class SeveralAccountGeneralSettingsPageState
               element.host == widget.account.host);
       if (loadedSettings != null) {
         accountSettings = loadedSettings;
+        if (!mounted) return;
         setState(() {
           defaultIsLocalOnly = loadedSettings.defaultIsLocalOnly;
           defaultNoteVisibility = loadedSettings.defaultNoteVisibility;

--- a/lib/view/time_line_page/misskey_time_line.dart
+++ b/lib/view/time_line_page/misskey_time_line.dart
@@ -42,18 +42,22 @@ class MisskeyTimelineState extends ConsumerState<MisskeyTimeline> {
     if (isDownDirectionLoading) return;
     Future(() async {
       try {
+        if (!mounted) return;
         setState(() {
           isDownDirectionLoading = true;
         });
         final result = await timelineRepository.previousLoad();
+        if (!mounted) return;
         setState(() {
           isDownDirectionLoading = false;
           isLastLoaded = result == 0;
         });
       } catch (e) {
-        setState(() {
-          isDownDirectionLoading = false;
-        });
+        if (mounted) {
+          setState(() {
+            isDownDirectionLoading = false;
+          });
+        }
         rethrow;
       }
     });

--- a/lib/view/user_page/user_page.dart
+++ b/lib/view/user_page/user_page.dart
@@ -213,6 +213,7 @@ class UserDetailTabState extends ConsumerState<UserDetailTab> {
           );
         }
       } catch (e, s) {
+        if (!mounted) return;
         setState(() {
           error = (e, s);
         });


### PR DESCRIPTION
たまに `setState() called after dispose()` が発生していたので、`Future(() async {})` の中で `setState()` が呼ばれているところの前に `if (!mounted) break;` を追加しました