### PR TITLE
ノートのRenote表示を詳細に

### DIFF
--- a/lib/extensions/note_visibility_extension.dart
+++ b/lib/extensions/note_visibility_extension.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+extension NoteVisibilityExtension on NoteVisibility {
+  IconData get icon {
+    return switch (this) {
+      NoteVisibility.public => Icons.public,
+      NoteVisibility.home => Icons.home,
+      NoteVisibility.followers => Icons.lock_outline,
+      NoteVisibility.specified => Icons.mail,
+    };
+  }
+}

--- a/lib/extensions/note_visibility_extension.dart
+++ b/lib/extensions/note_visibility_extension.dart
@@ -6,7 +6,7 @@ extension NoteVisibilityExtension on NoteVisibility {
     return switch (this) {
       NoteVisibility.public => Icons.public,
       NoteVisibility.home => Icons.home,
-      NoteVisibility.followers => Icons.lock_outline,
+      NoteVisibility.followers => Icons.lock,
       NoteVisibility.specified => Icons.mail,
     };
   }

--- a/lib/extensions/user_extension.dart
+++ b/lib/extensions/user_extension.dart
@@ -1,0 +1,7 @@
+import 'package:misskey_dart/misskey_dart.dart';
+
+extension UserExtension on User {
+  String get acct {
+    return "@$username${host != null ? "@$host" : ""}";
+  }
+}

--- a/lib/view/common/misskey_notes/custom_emoji.dart
+++ b/lib/view/common/misskey_notes/custom_emoji.dart
@@ -9,6 +9,7 @@ class CustomEmoji extends ConsumerStatefulWidget {
   final double fontSizeRatio;
   final bool isAttachTooltip;
   final double? size;
+  final TextStyle? style;
 
   const CustomEmoji({
     super.key,
@@ -16,6 +17,7 @@ class CustomEmoji extends ConsumerStatefulWidget {
     this.fontSizeRatio = 1,
     this.isAttachTooltip = true,
     this.size,
+    this.style,
   });
 
   @override
@@ -56,42 +58,50 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
     final scopedFontSize = widget.size ??
         (DefaultTextStyle.of(context).style.fontSize ?? 22) *
             widget.fontSizeRatio;
+    final style = widget.style ??
+        TextStyle(
+          color: Theme.of(context).textTheme.bodyMedium?.color,
+        );
 
     final emojiData = widget.emojiData;
     switch (emojiData) {
       case CustomEmojiData():
         cachedImage = ConditionalTooltip(
-            isAttachTooltip: widget.isAttachTooltip,
-            message: emojiData.hostedName,
-            child: NetworkImageView(
-                url: resolveCustomEmojiUrl(emojiData.url).toString(),
-                type: ImageType.customEmoji,
-                errorBuilder: (context, e, s) => Text(emojiData.hostedName,
-                    style: TextStyle(
-                        color: Theme.of(context).textTheme.bodyMedium?.color)),
-                loadingBuilder: (context, widget, chunk) => SizedBox(
-                      height: scopedFontSize,
-                      width: scopedFontSize,
-                    ),
-                height: scopedFontSize));
+          isAttachTooltip: widget.isAttachTooltip,
+          message: emojiData.hostedName,
+          child: NetworkImageView(
+            url: resolveCustomEmojiUrl(emojiData.url).toString(),
+            type: ImageType.customEmoji,
+            errorBuilder: (context, e, s) => Text(
+              emojiData.hostedName,
+              style: style,
+            ),
+            loadingBuilder: (context, widget, chunk) => SizedBox(
+              height: scopedFontSize,
+              width: scopedFontSize,
+            ),
+            height: scopedFontSize,
+          ),
+        );
         break;
       case UnicodeEmojiData():
         cachedImage = SizedBox(
-            width: scopedFontSize,
-            height: scopedFontSize,
-            child: FittedBox(
-                fit: BoxFit.cover,
-                child: Text(
-                  emojiData.char,
-                  style: TextStyle(
-                          color: Theme.of(context).textTheme.bodyMedium?.color)
-                      .merge(AppTheme.of(context).unicodeEmojiStyle),
-                )));
+          width: scopedFontSize,
+          height: scopedFontSize,
+          child: FittedBox(
+            fit: BoxFit.cover,
+            child: Text(
+              emojiData.char,
+              style: style.merge(AppTheme.of(context).unicodeEmojiStyle),
+            ),
+          ),
+        );
         break;
       case NotEmojiData():
-        cachedImage = Text(emojiData.name,
-            style: TextStyle(
-                color: Theme.of(context).textTheme.bodyMedium?.color));
+        cachedImage = Text(
+          emojiData.name,
+          style: style,
+        );
         break;
     }
     return cachedImage!;
@@ -103,11 +113,12 @@ class ConditionalTooltip extends StatelessWidget {
   final String message;
   final Widget child;
 
-  const ConditionalTooltip(
-      {super.key,
-      required this.isAttachTooltip,
-      required this.message,
-      required this.child});
+  const ConditionalTooltip({
+    super.key,
+    required this.isAttachTooltip,
+    required this.message,
+    required this.child,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/common/misskey_notes/mfm_text.dart
+++ b/lib/view/common/misskey_notes/mfm_text.dart
@@ -154,6 +154,7 @@ class MfmTextState extends ConsumerState<MfmText> {
               child: CustomEmoji(
                 emojiData: emojiData,
                 fontSizeRatio: 2,
+                style: style,
               ),
             ),
           ),
@@ -277,6 +278,7 @@ class SimpleMfmText extends ConsumerWidget {
             emojiInfo: emojis,
           ),
           fontSizeRatio: 1,
+          style: style,
         ),
       ),
       style: style,

--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -5,6 +5,8 @@ import 'package:collection/collection.dart';
 import 'package:dotted_border/dotted_border.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/extensions/date_time_extension.dart';
+import 'package:miria/extensions/note_visibility_extension.dart';
+import 'package:miria/extensions/user_extension.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/model/misskey_emoji_data.dart';
 import 'package:miria/providers.dart';
@@ -212,10 +214,9 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                 if (isEmptyRenote)
                   Padding(
                     padding: const EdgeInsets.only(bottom: 2),
-                    child: SimpleMfmText(
-                      "${widget.note.user.name ?? widget.note.user.username} が ${widget.note.user.acct == widget.note.renote?.user.acct ? "セルフRenote" : "Renote"}",
-                      style: Theme.of(context).textTheme.bodySmall,
-                      emojis: widget.note.user.emojis,
+                    child: RenoteHeader(
+                      note: widget.note,
+                      loginAs: widget.loginAs,
                     ),
                   ),
                 if (displayNote.reply != null && !widget.isForceUnvisibleReply)
@@ -645,6 +646,74 @@ class NoteHeader1 extends StatelessWidget {
             child: LocalOnlyIcon(
               size: Theme.of(context).textTheme.bodySmall?.fontSize,
               color: Theme.of(context).textTheme.bodySmall?.color,
+            ),
+          )
+      ],
+    );
+  }
+}
+
+class RenoteHeader extends StatelessWidget {
+  final Note note;
+  final Account? loginAs;
+
+  const RenoteHeader({
+    super.key,
+    required this.note,
+    this.loginAs,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final renoteTextStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: AppTheme.of(context).renoteBorderColor,
+        );
+
+    return Row(
+      children: [
+        Expanded(
+          child: GestureDetector(
+            onTap: () async => await _navigateUserDetailPage(
+              context,
+              note,
+              loginAs,
+            ).expectFailure(context),
+            child: SimpleMfmText(
+              note.user.name ?? note.user.username,
+              style: renoteTextStyle?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              emojis: note.user.emojis,
+              suffixSpan: [
+                TextSpan(
+                  text:
+                      " が ${note.user.acct == note.renote?.user.acct ? "セルフRenote" : "Renote"}",
+                  style: renoteTextStyle,
+                )
+              ],
+            ),
+          ),
+        ),
+        Text(
+          note.createdAt.differenceNow,
+          textAlign: TextAlign.right,
+          style: renoteTextStyle,
+        ),
+        if (note.visibility != NoteVisibility.public)
+          Padding(
+            padding: const EdgeInsets.only(left: 5),
+            child: Icon(
+              note.visibility.icon,
+              size: renoteTextStyle?.fontSize,
+              color: renoteTextStyle?.color,
+            ),
+          ),
+        if (note.localOnly)
+          Padding(
+            padding: const EdgeInsets.only(left: 5),
+            child: LocalOnlyIcon(
+              size: renoteTextStyle?.fontSize,
+              color: renoteTextStyle?.color,
             ),
           )
       ],

--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -630,29 +630,11 @@ class NoteHeader1 extends StatelessWidget {
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ),
-        if (displayNote.visibility == NoteVisibility.followers)
+        if (displayNote.visibility != NoteVisibility.public)
           Padding(
             padding: const EdgeInsets.only(left: 5),
             child: Icon(
-              Icons.lock,
-              size: Theme.of(context).textTheme.bodySmall?.fontSize,
-              color: Theme.of(context).textTheme.bodySmall?.color,
-            ),
-          ),
-        if (displayNote.visibility == NoteVisibility.home)
-          Padding(
-            padding: const EdgeInsets.only(left: 5),
-            child: Icon(
-              Icons.home,
-              size: Theme.of(context).textTheme.bodySmall?.fontSize,
-              color: Theme.of(context).textTheme.bodySmall?.color,
-            ),
-          ),
-        if (displayNote.visibility == NoteVisibility.specified)
-          Padding(
-            padding: const EdgeInsets.only(left: 5),
-            child: Icon(
-              Icons.mail,
+              displayNote.visibility.icon,
               size: Theme.of(context).textTheme.bodySmall?.fontSize,
               color: Theme.of(context).textTheme.bodySmall?.color,
             ),

--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -116,6 +116,7 @@ class MisskeyNote extends ConsumerStatefulWidget {
   final Account? loginAs;
   final bool isForceUnvisibleReply;
   final bool isForceUnvisibleRenote;
+  final bool isVisibleAllReactions;
 
   const MisskeyNote({
     super.key,
@@ -125,6 +126,7 @@ class MisskeyNote extends ConsumerStatefulWidget {
     this.loginAs,
     this.isForceUnvisibleReply = false,
     this.isForceUnvisibleRenote = false,
+    this.isVisibleAllReactions = false,
   });
 
   @override
@@ -134,6 +136,7 @@ class MisskeyNote extends ConsumerStatefulWidget {
 class MisskeyNoteState extends ConsumerState<MisskeyNote> {
   var isCwOpened = false;
   final globalKey = GlobalKey();
+  late var isAllReactionVisible = widget.isVisibleAllReactions;
 
   @override
   Widget build(BuildContext context) {
@@ -378,6 +381,9 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                             children: [
                               for (final reaction in displayNote
                                   .reactions.entries
+                                  .take(isAllReactionVisible
+                                      ? displayNote.reactions.length
+                                      : 16)
                                   .mapIndexed((index, element) =>
                                       (index: index, element: element))
                                   .sorted((a, b) {
@@ -397,7 +403,17 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                                   myReaction: displayNote.myReaction,
                                   noteId: displayNote.id,
                                   loginAs: widget.loginAs,
-                                )
+                                ),
+                              if (!isAllReactionVisible &&
+                                  displayNote.reactions.length > 16)
+                                OutlinedButton(
+                                    style: AppTheme.of(context)
+                                        .reactionButtonStyle,
+                                    onPressed: () => setState(() {
+                                          isAllReactionVisible = true;
+                                        }),
+                                    child: Text(
+                                        "ほか${displayNote.reactions.length - 16}個")),
                             ],
                           ),
                           if (displayNote.channel != null)

--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -213,7 +213,7 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                   Padding(
                     padding: const EdgeInsets.only(bottom: 2),
                     child: SimpleMfmText(
-                      "${widget.note.user.name ?? widget.note.user.username} が ${widget.note.user.username == widget.note.renote?.user.username ? "セルフRenote" : "Renote"}",
+                      "${widget.note.user.name ?? widget.note.user.username} が ${widget.note.user.acct == widget.note.renote?.user.acct ? "セルフRenote" : "Renote"}",
                       style: Theme.of(context).textTheme.bodySmall,
                       emojis: widget.note.user.emojis,
                     ),

--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -382,9 +382,6 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                             children: [
                               for (final reaction in displayNote
                                   .reactions.entries
-                                  .take(isAllReactionVisible
-                                      ? displayNote.reactions.length
-                                      : 16)
                                   .mapIndexed((index, element) =>
                                       (index: index, element: element))
                                   .sorted((a, b) {
@@ -392,7 +389,9 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                                     b.element.value.compareTo(a.element.value);
                                 if (primary != 0) return primary;
                                 return a.index.compareTo(b.index);
-                              }))
+                              }).take(isAllReactionVisible
+                                      ? displayNote.reactions.length
+                                      : 16))
                                 ReactionButton(
                                   emojiData: MisskeyEmojiData.fromEmojiName(
                                       emojiName: reaction.element.key,

--- a/lib/view/common/timeline_listview.dart
+++ b/lib/view/common/timeline_listview.dart
@@ -125,12 +125,22 @@ class _TimelineListViewState extends State<TimelineListView> {
   //FIXME static
   static double minMaxExtent = 0.0;
 
+  void timingCallback(_) {
+    final extent = _negativeOffset?.maxScrollExtent;
+    if (extent != null) {
+      minMaxExtent = -extent;
+    } else {
+      minMaxExtent = 0;
+    }
+  }
+
   @override
   void initState() {
     super.initState();
     if (widget.controller == null) {
       _controller = TimelineScrollController();
     }
+    WidgetsBinding.instance.addTimingsCallback(timingCallback);
   }
 
   @override
@@ -148,6 +158,7 @@ class _TimelineListViewState extends State<TimelineListView> {
   void dispose() {
     _controller?.dispose();
     super.dispose();
+    WidgetsBinding.instance.removeTimingsCallback(timingCallback);
   }
 
   @override
@@ -232,14 +243,6 @@ class _TimelineListViewState extends State<TimelineListView> {
   SliverChildDelegate get negativeChildrenDelegate {
     return SliverChildBuilderDelegate(
       (BuildContext context, int index) {
-        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-          final extent = _negativeOffset?.maxScrollExtent;
-          if (extent != null) {
-            minMaxExtent = -extent;
-          } else {
-            minMaxExtent = 0;
-          }
-        });
         final separatorBuilder = widget.separatorBuilder;
         if (separatorBuilder != null) {
           final itemIndex = (-1 - index) ~/ 2;


### PR DESCRIPTION
Renoteされたノートの上に表示されるヘッダーを変更しました

- 表示される情報を増やしました
  - 時間差
  - 公開範囲
  - 連合なし
- 色を `AppTheme.renoteBorderColor` に変更しました
  - borderには使われていないのでこの名前は適切ではないと思いますが修正していません
  - Misskey Web では `--renote` が適用されているようなので、Misskey Web のテーマの `renote` から来ている `renoteBorderColor` を使いました
- 名前をタップしたときにそのユーザーのユーザー詳細画面に遷移するようにしました
- セルフRenoteの判定にacctを使うようにしました

Fix #195
Fix #237