### PR TITLE
絵文字が見つからないときのTextのstyleを修正

### DIFF
--- a/lib/view/common/misskey_notes/custom_emoji.dart
+++ b/lib/view/common/misskey_notes/custom_emoji.dart
@@ -61,37 +61,47 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
     switch (emojiData) {
       case CustomEmojiData():
         cachedImage = ConditionalTooltip(
-            isAttachTooltip: widget.isAttachTooltip,
-            message: emojiData.hostedName,
-            child: NetworkImageView(
-                url: resolveCustomEmojiUrl(emojiData.url).toString(),
-                type: ImageType.customEmoji,
-                errorBuilder: (context, e, s) => Text(emojiData.hostedName,
-                    style: TextStyle(
-                        color: Theme.of(context).textTheme.bodyMedium?.color)),
-                loadingBuilder: (context, widget, chunk) => SizedBox(
-                      height: scopedFontSize,
-                      width: scopedFontSize,
-                    ),
-                height: scopedFontSize));
+          isAttachTooltip: widget.isAttachTooltip,
+          message: emojiData.hostedName,
+          child: NetworkImageView(
+            url: resolveCustomEmojiUrl(emojiData.url).toString(),
+            type: ImageType.customEmoji,
+            errorBuilder: (context, e, s) => Text(
+              emojiData.hostedName,
+              style: TextStyle(
+                color: Theme.of(context).textTheme.bodyMedium?.color,
+              ),
+            ),
+            loadingBuilder: (context, widget, chunk) => SizedBox(
+              height: scopedFontSize,
+              width: scopedFontSize,
+            ),
+            height: scopedFontSize,
+          ),
+        );
         break;
       case UnicodeEmojiData():
         cachedImage = SizedBox(
-            width: scopedFontSize,
-            height: scopedFontSize,
-            child: FittedBox(
-                fit: BoxFit.cover,
-                child: Text(
-                  emojiData.char,
-                  style: TextStyle(
-                          color: Theme.of(context).textTheme.bodyMedium?.color)
-                      .merge(AppTheme.of(context).unicodeEmojiStyle),
-                )));
+          width: scopedFontSize,
+          height: scopedFontSize,
+          child: FittedBox(
+            fit: BoxFit.cover,
+            child: Text(
+              emojiData.char,
+              style: TextStyle(
+                color: Theme.of(context).textTheme.bodyMedium?.color,
+              ).merge(AppTheme.of(context).unicodeEmojiStyle),
+            ),
+          ),
+        );
         break;
       case NotEmojiData():
-        cachedImage = Text(emojiData.name,
-            style: TextStyle(
-                color: Theme.of(context).textTheme.bodyMedium?.color));
+        cachedImage = Text(
+          emojiData.name,
+          style: TextStyle(
+            color: Theme.of(context).textTheme.bodyMedium?.color,
+          ),
+        );
         break;
     }
     return cachedImage!;
@@ -103,11 +113,12 @@ class ConditionalTooltip extends StatelessWidget {
   final String message;
   final Widget child;
 
-  const ConditionalTooltip(
-      {super.key,
-      required this.isAttachTooltip,
-      required this.message,
-      required this.child});
+  const ConditionalTooltip({
+    super.key,
+    required this.isAttachTooltip,
+    required this.message,
+    required this.child,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/common/misskey_notes/custom_emoji.dart
+++ b/lib/view/common/misskey_notes/custom_emoji.dart
@@ -9,6 +9,7 @@ class CustomEmoji extends ConsumerStatefulWidget {
   final double fontSizeRatio;
   final bool isAttachTooltip;
   final double? size;
+  final TextStyle? style;
 
   const CustomEmoji({
     super.key,
@@ -16,6 +17,7 @@ class CustomEmoji extends ConsumerStatefulWidget {
     this.fontSizeRatio = 1,
     this.isAttachTooltip = true,
     this.size,
+    this.style,
   });
 
   @override
@@ -56,6 +58,10 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
     final scopedFontSize = widget.size ??
         (DefaultTextStyle.of(context).style.fontSize ?? 22) *
             widget.fontSizeRatio;
+    final style = widget.style ??
+        TextStyle(
+          color: Theme.of(context).textTheme.bodyMedium?.color,
+        );
 
     final emojiData = widget.emojiData;
     switch (emojiData) {
@@ -68,9 +74,7 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
             type: ImageType.customEmoji,
             errorBuilder: (context, e, s) => Text(
               emojiData.hostedName,
-              style: TextStyle(
-                color: Theme.of(context).textTheme.bodyMedium?.color,
-              ),
+              style: style,
             ),
             loadingBuilder: (context, widget, chunk) => SizedBox(
               height: scopedFontSize,
@@ -88,9 +92,7 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
             fit: BoxFit.cover,
             child: Text(
               emojiData.char,
-              style: TextStyle(
-                color: Theme.of(context).textTheme.bodyMedium?.color,
-              ).merge(AppTheme.of(context).unicodeEmojiStyle),
+              style: style.merge(AppTheme.of(context).unicodeEmojiStyle),
             ),
           ),
         );
@@ -98,9 +100,7 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
       case NotEmojiData():
         cachedImage = Text(
           emojiData.name,
-          style: TextStyle(
-            color: Theme.of(context).textTheme.bodyMedium?.color,
-          ),
+          style: style,
         );
         break;
     }

--- a/lib/view/common/misskey_notes/mfm_text.dart
+++ b/lib/view/common/misskey_notes/mfm_text.dart
@@ -154,6 +154,7 @@ class MfmTextState extends ConsumerState<MfmText> {
               child: CustomEmoji(
                 emojiData: emojiData,
                 fontSizeRatio: 2,
+                style: style,
               ),
             ),
           ),
@@ -277,6 +278,7 @@ class SimpleMfmText extends ConsumerWidget {
             emojiInfo: emojis,
           ),
           fontSizeRatio: 1,
+          style: style,
         ),
       ),
       style: style,


### PR DESCRIPTION
カスタム絵文字の読み込み時にエラーが起きたときや、存在しないカスタム絵文字が参照されたときに表示される `:name:` のような文字がMfmTextに与えられたTextStyleに従っていなかったのを修正しました