### PR TITLE
Feature/fix 180

### DIFF
--- a/lib/model/general_settings.dart
+++ b/lib/model/general_settings.dart
@@ -39,10 +39,24 @@ class GeneralSettings with _$GeneralSettings {
     @Default("") String lightColorThemeId,
     @Default("") String darkColorThemeId,
     @Default(ThemeColorSystem.system) ThemeColorSystem themeColorSystem,
+
+    /// NSFW設定を継承する
     @Default(NSFWInherit.inherit) NSFWInherit nsfwInherit,
+
+    /// ノートのカスタム絵文字直接タップでのリアクションを有効にする
     @Default(false) bool enableDirectReaction,
+
+    /// TLの自動更新を有効にする
     @Default(AutomaticPush.none) AutomaticPush automaticPush,
+
+    /// 動きのあるMFMを有効にする
     @Default(true) bool enableAnimatedMFM,
+
+    /// 長いノートを省略する
+    @Default(false) bool enableLongTextElipsed,
+
+    /// リアクション済みノートを短くする
+    @Default(true) bool enableFavoritedRenoteElipsed,
   }) = _GeneralSettings;
 
   factory GeneralSettings.fromJson(Map<String, dynamic> json) =>

--- a/lib/model/general_settings.freezed.dart
+++ b/lib/model/general_settings.freezed.dart
@@ -23,10 +23,24 @@ mixin _$GeneralSettings {
   String get lightColorThemeId => throw _privateConstructorUsedError;
   String get darkColorThemeId => throw _privateConstructorUsedError;
   ThemeColorSystem get themeColorSystem => throw _privateConstructorUsedError;
+
+  /// NSFW設定を継承する
   NSFWInherit get nsfwInherit => throw _privateConstructorUsedError;
+
+  /// ノートのカスタム絵文字直接タップでのリアクションを有効にする
   bool get enableDirectReaction => throw _privateConstructorUsedError;
+
+  /// TLの自動更新を有効にする
   AutomaticPush get automaticPush => throw _privateConstructorUsedError;
+
+  /// 動きのあるMFMを有効にする
   bool get enableAnimatedMFM => throw _privateConstructorUsedError;
+
+  /// 長いノートを省略する
+  bool get enableLongTextElipsed => throw _privateConstructorUsedError;
+
+  /// リアクション済みノートを短くする
+  bool get enableFavoritedRenoteElipsed => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -47,7 +61,9 @@ abstract class $GeneralSettingsCopyWith<$Res> {
       NSFWInherit nsfwInherit,
       bool enableDirectReaction,
       AutomaticPush automaticPush,
-      bool enableAnimatedMFM});
+      bool enableAnimatedMFM,
+      bool enableLongTextElipsed,
+      bool enableFavoritedRenoteElipsed});
 }
 
 /// @nodoc
@@ -70,6 +86,8 @@ class _$GeneralSettingsCopyWithImpl<$Res, $Val extends GeneralSettings>
     Object? enableDirectReaction = null,
     Object? automaticPush = null,
     Object? enableAnimatedMFM = null,
+    Object? enableLongTextElipsed = null,
+    Object? enableFavoritedRenoteElipsed = null,
   }) {
     return _then(_value.copyWith(
       lightColorThemeId: null == lightColorThemeId
@@ -100,6 +118,14 @@ class _$GeneralSettingsCopyWithImpl<$Res, $Val extends GeneralSettings>
           ? _value.enableAnimatedMFM
           : enableAnimatedMFM // ignore: cast_nullable_to_non_nullable
               as bool,
+      enableLongTextElipsed: null == enableLongTextElipsed
+          ? _value.enableLongTextElipsed
+          : enableLongTextElipsed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      enableFavoritedRenoteElipsed: null == enableFavoritedRenoteElipsed
+          ? _value.enableFavoritedRenoteElipsed
+          : enableFavoritedRenoteElipsed // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -119,7 +145,9 @@ abstract class _$$_GeneralSettingsCopyWith<$Res>
       NSFWInherit nsfwInherit,
       bool enableDirectReaction,
       AutomaticPush automaticPush,
-      bool enableAnimatedMFM});
+      bool enableAnimatedMFM,
+      bool enableLongTextElipsed,
+      bool enableFavoritedRenoteElipsed});
 }
 
 /// @nodoc
@@ -140,6 +168,8 @@ class __$$_GeneralSettingsCopyWithImpl<$Res>
     Object? enableDirectReaction = null,
     Object? automaticPush = null,
     Object? enableAnimatedMFM = null,
+    Object? enableLongTextElipsed = null,
+    Object? enableFavoritedRenoteElipsed = null,
   }) {
     return _then(_$_GeneralSettings(
       lightColorThemeId: null == lightColorThemeId
@@ -170,6 +200,14 @@ class __$$_GeneralSettingsCopyWithImpl<$Res>
           ? _value.enableAnimatedMFM
           : enableAnimatedMFM // ignore: cast_nullable_to_non_nullable
               as bool,
+      enableLongTextElipsed: null == enableLongTextElipsed
+          ? _value.enableLongTextElipsed
+          : enableLongTextElipsed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      enableFavoritedRenoteElipsed: null == enableFavoritedRenoteElipsed
+          ? _value.enableFavoritedRenoteElipsed
+          : enableFavoritedRenoteElipsed // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -184,7 +222,9 @@ class _$_GeneralSettings implements _GeneralSettings {
       this.nsfwInherit = NSFWInherit.inherit,
       this.enableDirectReaction = false,
       this.automaticPush = AutomaticPush.none,
-      this.enableAnimatedMFM = true});
+      this.enableAnimatedMFM = true,
+      this.enableLongTextElipsed = false,
+      this.enableFavoritedRenoteElipsed = true});
 
   factory _$_GeneralSettings.fromJson(Map<String, dynamic> json) =>
       _$$_GeneralSettingsFromJson(json);
@@ -198,22 +238,40 @@ class _$_GeneralSettings implements _GeneralSettings {
   @override
   @JsonKey()
   final ThemeColorSystem themeColorSystem;
+
+  /// NSFW設定を継承する
   @override
   @JsonKey()
   final NSFWInherit nsfwInherit;
+
+  /// ノートのカスタム絵文字直接タップでのリアクションを有効にする
   @override
   @JsonKey()
   final bool enableDirectReaction;
+
+  /// TLの自動更新を有効にする
   @override
   @JsonKey()
   final AutomaticPush automaticPush;
+
+  /// 動きのあるMFMを有効にする
   @override
   @JsonKey()
   final bool enableAnimatedMFM;
 
+  /// 長いノートを省略する
+  @override
+  @JsonKey()
+  final bool enableLongTextElipsed;
+
+  /// リアクション済みノートを短くする
+  @override
+  @JsonKey()
+  final bool enableFavoritedRenoteElipsed;
+
   @override
   String toString() {
-    return 'GeneralSettings(lightColorThemeId: $lightColorThemeId, darkColorThemeId: $darkColorThemeId, themeColorSystem: $themeColorSystem, nsfwInherit: $nsfwInherit, enableDirectReaction: $enableDirectReaction, automaticPush: $automaticPush, enableAnimatedMFM: $enableAnimatedMFM)';
+    return 'GeneralSettings(lightColorThemeId: $lightColorThemeId, darkColorThemeId: $darkColorThemeId, themeColorSystem: $themeColorSystem, nsfwInherit: $nsfwInherit, enableDirectReaction: $enableDirectReaction, automaticPush: $automaticPush, enableAnimatedMFM: $enableAnimatedMFM, enableLongTextElipsed: $enableLongTextElipsed, enableFavoritedRenoteElipsed: $enableFavoritedRenoteElipsed)';
   }
 
   @override
@@ -234,7 +292,13 @@ class _$_GeneralSettings implements _GeneralSettings {
             (identical(other.automaticPush, automaticPush) ||
                 other.automaticPush == automaticPush) &&
             (identical(other.enableAnimatedMFM, enableAnimatedMFM) ||
-                other.enableAnimatedMFM == enableAnimatedMFM));
+                other.enableAnimatedMFM == enableAnimatedMFM) &&
+            (identical(other.enableLongTextElipsed, enableLongTextElipsed) ||
+                other.enableLongTextElipsed == enableLongTextElipsed) &&
+            (identical(other.enableFavoritedRenoteElipsed,
+                    enableFavoritedRenoteElipsed) ||
+                other.enableFavoritedRenoteElipsed ==
+                    enableFavoritedRenoteElipsed));
   }
 
   @JsonKey(ignore: true)
@@ -247,7 +311,9 @@ class _$_GeneralSettings implements _GeneralSettings {
       nsfwInherit,
       enableDirectReaction,
       automaticPush,
-      enableAnimatedMFM);
+      enableAnimatedMFM,
+      enableLongTextElipsed,
+      enableFavoritedRenoteElipsed);
 
   @JsonKey(ignore: true)
   @override
@@ -271,7 +337,9 @@ abstract class _GeneralSettings implements GeneralSettings {
       final NSFWInherit nsfwInherit,
       final bool enableDirectReaction,
       final AutomaticPush automaticPush,
-      final bool enableAnimatedMFM}) = _$_GeneralSettings;
+      final bool enableAnimatedMFM,
+      final bool enableLongTextElipsed,
+      final bool enableFavoritedRenoteElipsed}) = _$_GeneralSettings;
 
   factory _GeneralSettings.fromJson(Map<String, dynamic> json) =
       _$_GeneralSettings.fromJson;
@@ -283,13 +351,29 @@ abstract class _GeneralSettings implements GeneralSettings {
   @override
   ThemeColorSystem get themeColorSystem;
   @override
+
+  /// NSFW設定を継承する
   NSFWInherit get nsfwInherit;
   @override
+
+  /// ノートのカスタム絵文字直接タップでのリアクションを有効にする
   bool get enableDirectReaction;
   @override
+
+  /// TLの自動更新を有効にする
   AutomaticPush get automaticPush;
   @override
+
+  /// 動きのあるMFMを有効にする
   bool get enableAnimatedMFM;
+  @override
+
+  /// 長いノートを省略する
+  bool get enableLongTextElipsed;
+  @override
+
+  /// リアクション済みノートを短くする
+  bool get enableFavoritedRenoteElipsed;
   @override
   @JsonKey(ignore: true)
   _$$_GeneralSettingsCopyWith<_$_GeneralSettings> get copyWith =>

--- a/lib/model/general_settings.g.dart
+++ b/lib/model/general_settings.g.dart
@@ -21,6 +21,9 @@ _$_GeneralSettings _$$_GeneralSettingsFromJson(Map<String, dynamic> json) =>
           $enumDecodeNullable(_$AutomaticPushEnumMap, json['automaticPush']) ??
               AutomaticPush.none,
       enableAnimatedMFM: json['enableAnimatedMFM'] as bool? ?? true,
+      enableLongTextElipsed: json['enableLongTextElipsed'] as bool? ?? false,
+      enableFavoritedRenoteElipsed:
+          json['enableFavoritedRenoteElipsed'] as bool? ?? true,
     );
 
 Map<String, dynamic> _$$_GeneralSettingsToJson(_$_GeneralSettings instance) =>
@@ -32,6 +35,8 @@ Map<String, dynamic> _$$_GeneralSettingsToJson(_$_GeneralSettings instance) =>
       'enableDirectReaction': instance.enableDirectReaction,
       'automaticPush': _$AutomaticPushEnumMap[instance.automaticPush]!,
       'enableAnimatedMFM': instance.enableAnimatedMFM,
+      'enableLongTextElipsed': instance.enableLongTextElipsed,
+      'enableFavoritedRenoteElipsed': instance.enableFavoritedRenoteElipsed,
     };
 
 const _$ThemeColorSystemEnumMap = {

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -15,13 +15,13 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
-    AntennaNotesRoute.name: (routeData) {
-      final args = routeData.argsAs<AntennaNotesRouteArgs>();
+    NotesAfterRenoteRoute.name: (routeData) {
+      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: AntennaNotesPage(
+        child: NotesAfterRenotePage(
           key: args.key,
-          antenna: args.antenna,
+          note: args.note,
           account: args.account,
         ),
       );
@@ -36,25 +36,31 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    ChannelsRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelsRouteArgs>();
+    AntennaNotesRoute.name: (routeData) {
+      final args = routeData.argsAs<AntennaNotesRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ChannelsPage(
+        child: AntennaNotesPage(
+          key: args.key,
+          antenna: args.antenna,
+          account: args.account,
+        ),
+      );
+    },
+    NotificationRoute.name: (routeData) {
+      final args = routeData.argsAs<NotificationRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: NotificationPage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    ChannelDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelDetailRouteArgs>();
+    LoginRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ChannelDetailPage(
-          key: args.key,
-          account: args.account,
-          channelId: args.channelId,
-        ),
+        child: const LoginPage(),
       );
     },
     ClipDetailRoute.name: (routeData) {
@@ -78,76 +84,6 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    ExploreRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExplorePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    ExploreRoleUsersRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExploreRoleUsersPage(
-          key: args.key,
-          item: args.item,
-          account: args.account,
-        ),
-      );
-    },
-    FavoritedNoteRoute.name: (routeData) {
-      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: FavoritedNotePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    FederationRoute.name: (routeData) {
-      final args = routeData.argsAs<FederationRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: FederationPage(
-          key: args.key,
-          account: args.account,
-          host: args.host,
-        ),
-      );
-    },
-    HashtagRoute.name: (routeData) {
-      final args = routeData.argsAs<HashtagRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: HashtagPage(
-          key: args.key,
-          hashtag: args.hashtag,
-          account: args.account,
-        ),
-      );
-    },
-    LoginRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const LoginPage(),
-      );
-    },
-    NotesAfterRenoteRoute.name: (routeData) {
-      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: NotesAfterRenotePage(
-          key: args.key,
-          note: args.note,
-          account: args.account,
-        ),
-      );
-    },
     NoteCreateRoute.name: (routeData) {
       final args = routeData.argsAs<NoteCreateRouteArgs>();
       return AutoRoutePage<dynamic>(
@@ -164,23 +100,46 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    NoteDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<NoteDetailRouteArgs>();
+    HashtagRoute.name: (routeData) {
+      final args = routeData.argsAs<HashtagRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NoteDetailPage(
+        child: HashtagPage(
           key: args.key,
-          note: args.note,
+          hashtag: args.hashtag,
           account: args.account,
         ),
       );
     },
-    NotificationRoute.name: (routeData) {
-      final args = routeData.argsAs<NotificationRouteArgs>();
+    UserFolloweeRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFolloweeRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotificationPage(
+        child: UserFolloweePage(
           key: args.key,
+          userId: args.userId,
+          account: args.account,
+        ),
+      );
+    },
+    UserRoute.name: (routeData) {
+      final args = routeData.argsAs<UserRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UserPage(
+          key: args.key,
+          userId: args.userId,
+          account: args.account,
+        ),
+      );
+    },
+    UserFollowerRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFollowerRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UserFollowerPage(
+          key: args.key,
+          userId: args.userId,
           account: args.account,
         ),
       );
@@ -197,92 +156,10 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    SearchRoute.name: (routeData) {
-      final args = routeData.argsAs<SearchRouteArgs>();
+    SplashRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: SearchPage(
-          key: args.key,
-          initialSearchText: args.initialSearchText,
-          account: args.account,
-        ),
-      );
-    },
-    AccountListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AccountListPage(),
-      );
-    },
-    AppInfoRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AppInfoPage(),
-      );
-    },
-    GeneralSettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const GeneralSettingsPage(),
-      );
-    },
-    ImportExportRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const ImportExportPage(),
-      );
-    },
-    SettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const SettingsPage(),
-      );
-    },
-    TabSettingsListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const TabSettingsListPage(),
-      );
-    },
-    TabSettingsRoute.name: (routeData) {
-      final args = routeData.argsAs<TabSettingsRouteArgs>(
-          orElse: () => const TabSettingsRouteArgs());
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TabSettingsPage(
-          key: args.key,
-          tabIndex: args.tabIndex,
-        ),
-      );
-    },
-    HardMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<HardMuteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: HardMutePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    InstanceMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<InstanceMuteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: InstanceMutePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    ReactionDeckRoute.name: (routeData) {
-      final args = routeData.argsAs<ReactionDeckRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ReactionDeckPage(
-          key: args.key,
-          account: args.account,
-        ),
+        child: const SplashPage(),
       );
     },
     SeveralAccountGeneralSettingsRoute.name: (routeData) {
@@ -305,41 +182,33 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    SharingAccountSelectRoute.name: (routeData) {
-      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
-          orElse: () => const SharingAccountSelectRouteArgs());
+    InstanceMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<InstanceMuteRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: SharingAccountSelectPage(
+        child: InstanceMutePage(
           key: args.key,
-          sharingText: args.sharingText,
-          filePath: args.filePath,
+          account: args.account,
         ),
       );
     },
-    SplashRoute.name: (routeData) {
+    HardMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<HardMuteRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const SplashPage(),
-      );
-    },
-    TimeLineRoute.name: (routeData) {
-      final args = routeData.argsAs<TimeLineRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TimeLinePage(
+        child: HardMutePage(
           key: args.key,
-          initialTabSetting: args.initialTabSetting,
+          account: args.account,
         ),
       );
     },
-    UsersListRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListRouteArgs>();
+    ReactionDeckRoute.name: (routeData) {
+      final args = routeData.argsAs<ReactionDeckRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UsersListPage(
-          args.account,
+        child: ReactionDeckPage(
           key: args.key,
+          account: args.account,
         ),
       );
     },
@@ -354,40 +223,252 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    UserFolloweeRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFolloweeRouteArgs>();
+    UsersListRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserFolloweePage(
+        child: UsersListPage(
+          args.account,
           key: args.key,
-          userId: args.userId,
+        ),
+      );
+    },
+    ChannelDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelDetailRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ChannelDetailPage(
+          key: args.key,
+          account: args.account,
+          channelId: args.channelId,
+        ),
+      );
+    },
+    ChannelsRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelsRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ChannelsPage(
+          key: args.key,
           account: args.account,
         ),
       );
     },
-    UserFollowerRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFollowerRouteArgs>();
+    FederationRoute.name: (routeData) {
+      final args = routeData.argsAs<FederationRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserFollowerPage(
+        child: FederationPage(
           key: args.key,
-          userId: args.userId,
+          account: args.account,
+          host: args.host,
+        ),
+      );
+    },
+    NoteDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<NoteDetailRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: NoteDetailPage(
+          key: args.key,
+          note: args.note,
           account: args.account,
         ),
       );
     },
-    UserRoute.name: (routeData) {
-      final args = routeData.argsAs<UserRouteArgs>();
+    SearchRoute.name: (routeData) {
+      final args = routeData.argsAs<SearchRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserPage(
+        child: SearchPage(
           key: args.key,
-          userId: args.userId,
+          initialSearchText: args.initialSearchText,
+          account: args.account,
+        ),
+      );
+    },
+    SharingAccountSelectRoute.name: (routeData) {
+      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
+          orElse: () => const SharingAccountSelectRouteArgs());
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: SharingAccountSelectPage(
+          key: args.key,
+          sharingText: args.sharingText,
+          filePath: args.filePath,
+        ),
+      );
+    },
+    ImportExportRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const ImportExportPage(),
+      );
+    },
+    GeneralSettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const GeneralSettingsPage(),
+      );
+    },
+    TabSettingsRoute.name: (routeData) {
+      final args = routeData.argsAs<TabSettingsRouteArgs>(
+          orElse: () => const TabSettingsRouteArgs());
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: TabSettingsPage(
+          key: args.key,
+          tabIndex: args.tabIndex,
+        ),
+      );
+    },
+    TabSettingsListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const TabSettingsListPage(),
+      );
+    },
+    AppInfoRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AppInfoPage(),
+      );
+    },
+    SettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SettingsPage(),
+      );
+    },
+    AccountListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AccountListPage(),
+      );
+    },
+    ExploreRoleUsersRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExploreRoleUsersPage(
+          key: args.key,
+          item: args.item,
+          account: args.account,
+        ),
+      );
+    },
+    ExploreRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExplorePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    TimeLineRoute.name: (routeData) {
+      final args = routeData.argsAs<TimeLineRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: TimeLinePage(
+          key: args.key,
+          initialTabSetting: args.initialTabSetting,
+        ),
+      );
+    },
+    FavoritedNoteRoute.name: (routeData) {
+      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FavoritedNotePage(
+          key: args.key,
           account: args.account,
         ),
       );
     },
   };
+}
+
+/// generated route for
+/// [NotesAfterRenotePage]
+class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
+  NotesAfterRenoteRoute({
+    Key? key,
+    required Note note,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          NotesAfterRenoteRoute.name,
+          args: NotesAfterRenoteRouteArgs(
+            key: key,
+            note: note,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'NotesAfterRenoteRoute';
+
+  static const PageInfo<NotesAfterRenoteRouteArgs> page =
+      PageInfo<NotesAfterRenoteRouteArgs>(name);
+}
+
+class NotesAfterRenoteRouteArgs {
+  const NotesAfterRenoteRouteArgs({
+    this.key,
+    required this.note,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Note note;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
+  }
+}
+
+/// generated route for
+/// [AntennaPage]
+class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
+  AntennaRoute({
+    required Account account,
+    Key? key,
+    List<PageRouteInfo>? children,
+  }) : super(
+          AntennaRoute.name,
+          args: AntennaRouteArgs(
+            account: account,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'AntennaRoute';
+
+  static const PageInfo<AntennaRouteArgs> page =
+      PageInfo<AntennaRouteArgs>(name);
+}
+
+class AntennaRouteArgs {
+  const AntennaRouteArgs({
+    required this.account,
+    this.key,
+  });
+
+  final Account account;
+
+  final Key? key;
+
+  @override
+  String toString() {
+    return 'AntennaRouteArgs{account: $account, key: $key}';
+  }
 }
 
 /// generated route for
@@ -434,122 +515,55 @@ class AntennaNotesRouteArgs {
 }
 
 /// generated route for
-/// [AntennaPage]
-class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
-  AntennaRoute({
-    required Account account,
+/// [NotificationPage]
+class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
+  NotificationRoute({
     Key? key,
+    required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          AntennaRoute.name,
-          args: AntennaRouteArgs(
-            account: account,
+          NotificationRoute.name,
+          args: NotificationRouteArgs(
             key: key,
+            account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'AntennaRoute';
+  static const String name = 'NotificationRoute';
 
-  static const PageInfo<AntennaRouteArgs> page =
-      PageInfo<AntennaRouteArgs>(name);
+  static const PageInfo<NotificationRouteArgs> page =
+      PageInfo<NotificationRouteArgs>(name);
 }
 
-class AntennaRouteArgs {
-  const AntennaRouteArgs({
-    required this.account,
+class NotificationRouteArgs {
+  const NotificationRouteArgs({
     this.key,
+    required this.account,
   });
-
-  final Account account;
 
   final Key? key;
 
+  final Account account;
+
   @override
   String toString() {
-    return 'AntennaRouteArgs{account: $account, key: $key}';
+    return 'NotificationRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [ChannelsPage]
-class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
-  ChannelsRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ChannelsRoute.name,
-          args: ChannelsRouteArgs(
-            key: key,
-            account: account,
-          ),
+/// [LoginPage]
+class LoginRoute extends PageRouteInfo<void> {
+  const LoginRoute({List<PageRouteInfo>? children})
+      : super(
+          LoginRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'ChannelsRoute';
+  static const String name = 'LoginRoute';
 
-  static const PageInfo<ChannelsRouteArgs> page =
-      PageInfo<ChannelsRouteArgs>(name);
-}
-
-class ChannelsRouteArgs {
-  const ChannelsRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ChannelsRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ChannelDetailPage]
-class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
-  ChannelDetailRoute({
-    Key? key,
-    required Account account,
-    required String channelId,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ChannelDetailRoute.name,
-          args: ChannelDetailRouteArgs(
-            key: key,
-            account: account,
-            channelId: channelId,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ChannelDetailRoute';
-
-  static const PageInfo<ChannelDetailRouteArgs> page =
-      PageInfo<ChannelDetailRouteArgs>(name);
-}
-
-class ChannelDetailRouteArgs {
-  const ChannelDetailRouteArgs({
-    this.key,
-    required this.account,
-    required this.channelId,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String channelId;
-
-  @override
-  String toString() {
-    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
-  }
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for
@@ -634,268 +648,6 @@ class ClipListRouteArgs {
 }
 
 /// generated route for
-/// [ExplorePage]
-class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
-  ExploreRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoute.name,
-          args: ExploreRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoute';
-
-  static const PageInfo<ExploreRouteArgs> page =
-      PageInfo<ExploreRouteArgs>(name);
-}
-
-class ExploreRouteArgs {
-  const ExploreRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ExploreRoleUsersPage]
-class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
-  ExploreRoleUsersRoute({
-    Key? key,
-    required RolesListResponse item,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoleUsersRoute.name,
-          args: ExploreRoleUsersRouteArgs(
-            key: key,
-            item: item,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoleUsersRoute';
-
-  static const PageInfo<ExploreRoleUsersRouteArgs> page =
-      PageInfo<ExploreRoleUsersRouteArgs>(name);
-}
-
-class ExploreRoleUsersRouteArgs {
-  const ExploreRoleUsersRouteArgs({
-    this.key,
-    required this.item,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final RolesListResponse item;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
-  }
-}
-
-/// generated route for
-/// [FavoritedNotePage]
-class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
-  FavoritedNoteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FavoritedNoteRoute.name,
-          args: FavoritedNoteRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FavoritedNoteRoute';
-
-  static const PageInfo<FavoritedNoteRouteArgs> page =
-      PageInfo<FavoritedNoteRouteArgs>(name);
-}
-
-class FavoritedNoteRouteArgs {
-  const FavoritedNoteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [FederationPage]
-class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
-  FederationRoute({
-    Key? key,
-    required Account account,
-    required String host,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FederationRoute.name,
-          args: FederationRouteArgs(
-            key: key,
-            account: account,
-            host: host,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FederationRoute';
-
-  static const PageInfo<FederationRouteArgs> page =
-      PageInfo<FederationRouteArgs>(name);
-}
-
-class FederationRouteArgs {
-  const FederationRouteArgs({
-    this.key,
-    required this.account,
-    required this.host,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String host;
-
-  @override
-  String toString() {
-    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
-  }
-}
-
-/// generated route for
-/// [HashtagPage]
-class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
-  HashtagRoute({
-    Key? key,
-    required String hashtag,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          HashtagRoute.name,
-          args: HashtagRouteArgs(
-            key: key,
-            hashtag: hashtag,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'HashtagRoute';
-
-  static const PageInfo<HashtagRouteArgs> page =
-      PageInfo<HashtagRouteArgs>(name);
-}
-
-class HashtagRouteArgs {
-  const HashtagRouteArgs({
-    this.key,
-    required this.hashtag,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String hashtag;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
-  }
-}
-
-/// generated route for
-/// [LoginPage]
-class LoginRoute extends PageRouteInfo<void> {
-  const LoginRoute({List<PageRouteInfo>? children})
-      : super(
-          LoginRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'LoginRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [NotesAfterRenotePage]
-class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
-  NotesAfterRenoteRoute({
-    Key? key,
-    required Note note,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          NotesAfterRenoteRoute.name,
-          args: NotesAfterRenoteRouteArgs(
-            key: key,
-            note: note,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'NotesAfterRenoteRoute';
-
-  static const PageInfo<NotesAfterRenoteRouteArgs> page =
-      PageInfo<NotesAfterRenoteRouteArgs>(name);
-}
-
-class NotesAfterRenoteRouteArgs {
-  const NotesAfterRenoteRouteArgs({
-    this.key,
-    required this.note,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Note note;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
-  }
-}
-
-/// generated route for
 /// [NoteCreatePage]
 class NoteCreateRoute extends PageRouteInfo<NoteCreateRouteArgs> {
   NoteCreateRoute({
@@ -964,83 +716,173 @@ class NoteCreateRouteArgs {
 }
 
 /// generated route for
-/// [NoteDetailPage]
-class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
-  NoteDetailRoute({
+/// [HashtagPage]
+class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
+  HashtagRoute({
     Key? key,
-    required Note note,
+    required String hashtag,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NoteDetailRoute.name,
-          args: NoteDetailRouteArgs(
+          HashtagRoute.name,
+          args: HashtagRouteArgs(
             key: key,
-            note: note,
+            hashtag: hashtag,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NoteDetailRoute';
+  static const String name = 'HashtagRoute';
 
-  static const PageInfo<NoteDetailRouteArgs> page =
-      PageInfo<NoteDetailRouteArgs>(name);
+  static const PageInfo<HashtagRouteArgs> page =
+      PageInfo<HashtagRouteArgs>(name);
 }
 
-class NoteDetailRouteArgs {
-  const NoteDetailRouteArgs({
+class HashtagRouteArgs {
+  const HashtagRouteArgs({
     this.key,
-    required this.note,
+    required this.hashtag,
     required this.account,
   });
 
   final Key? key;
 
-  final Note note;
+  final String hashtag;
 
   final Account account;
 
   @override
   String toString() {
-    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
+    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
   }
 }
 
 /// generated route for
-/// [NotificationPage]
-class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
-  NotificationRoute({
+/// [UserFolloweePage]
+class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
+  UserFolloweeRoute({
     Key? key,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotificationRoute.name,
-          args: NotificationRouteArgs(
+          UserFolloweeRoute.name,
+          args: UserFolloweeRouteArgs(
             key: key,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotificationRoute';
+  static const String name = 'UserFolloweeRoute';
 
-  static const PageInfo<NotificationRouteArgs> page =
-      PageInfo<NotificationRouteArgs>(name);
+  static const PageInfo<UserFolloweeRouteArgs> page =
+      PageInfo<UserFolloweeRouteArgs>(name);
 }
 
-class NotificationRouteArgs {
-  const NotificationRouteArgs({
+class UserFolloweeRouteArgs {
+  const UserFolloweeRouteArgs({
     this.key,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
+  final String userId;
+
   final Account account;
 
   @override
   String toString() {
-    return 'NotificationRouteArgs{key: $key, account: $account}';
+    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
+  }
+}
+
+/// generated route for
+/// [UserPage]
+class UserRoute extends PageRouteInfo<UserRouteArgs> {
+  UserRoute({
+    Key? key,
+    required String userId,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UserRoute.name,
+          args: UserRouteArgs(
+            key: key,
+            userId: userId,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UserRoute';
+
+  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
+}
+
+class UserRouteArgs {
+  const UserRouteArgs({
+    this.key,
+    required this.userId,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String userId;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
+  }
+}
+
+/// generated route for
+/// [UserFollowerPage]
+class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
+  UserFollowerRoute({
+    Key? key,
+    required String userId,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UserFollowerRoute.name,
+          args: UserFollowerRouteArgs(
+            key: key,
+            userId: userId,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UserFollowerRoute';
+
+  static const PageInfo<UserFollowerRouteArgs> page =
+      PageInfo<UserFollowerRouteArgs>(name);
+}
+
+class UserFollowerRouteArgs {
+  const UserFollowerRouteArgs({
+    this.key,
+    required this.userId,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String userId;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }
 
@@ -1093,281 +935,17 @@ class PhotoEditRouteArgs {
 }
 
 /// generated route for
-/// [SearchPage]
-class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
-  SearchRoute({
-    Key? key,
-    String? initialSearchText,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          SearchRoute.name,
-          args: SearchRouteArgs(
-            key: key,
-            initialSearchText: initialSearchText,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'SearchRoute';
-
-  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
-}
-
-class SearchRouteArgs {
-  const SearchRouteArgs({
-    this.key,
-    this.initialSearchText,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String? initialSearchText;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
-  }
-}
-
-/// generated route for
-/// [AccountListPage]
-class AccountListRoute extends PageRouteInfo<void> {
-  const AccountListRoute({List<PageRouteInfo>? children})
+/// [SplashPage]
+class SplashRoute extends PageRouteInfo<void> {
+  const SplashRoute({List<PageRouteInfo>? children})
       : super(
-          AccountListRoute.name,
+          SplashRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'AccountListRoute';
+  static const String name = 'SplashRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AppInfoPage]
-class AppInfoRoute extends PageRouteInfo<void> {
-  const AppInfoRoute({List<PageRouteInfo>? children})
-      : super(
-          AppInfoRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AppInfoRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [GeneralSettingsPage]
-class GeneralSettingsRoute extends PageRouteInfo<void> {
-  const GeneralSettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          GeneralSettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'GeneralSettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [ImportExportPage]
-class ImportExportRoute extends PageRouteInfo<void> {
-  const ImportExportRoute({List<PageRouteInfo>? children})
-      : super(
-          ImportExportRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'ImportExportRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [SettingsPage]
-class SettingsRoute extends PageRouteInfo<void> {
-  const SettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          SettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'SettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [TabSettingsListPage]
-class TabSettingsListRoute extends PageRouteInfo<void> {
-  const TabSettingsListRoute({List<PageRouteInfo>? children})
-      : super(
-          TabSettingsListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [TabSettingsPage]
-class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
-  TabSettingsRoute({
-    Key? key,
-    int? tabIndex,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TabSettingsRoute.name,
-          args: TabSettingsRouteArgs(
-            key: key,
-            tabIndex: tabIndex,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsRoute';
-
-  static const PageInfo<TabSettingsRouteArgs> page =
-      PageInfo<TabSettingsRouteArgs>(name);
-}
-
-class TabSettingsRouteArgs {
-  const TabSettingsRouteArgs({
-    this.key,
-    this.tabIndex,
-  });
-
-  final Key? key;
-
-  final int? tabIndex;
-
-  @override
-  String toString() {
-    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
-  }
-}
-
-/// generated route for
-/// [HardMutePage]
-class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
-  HardMuteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          HardMuteRoute.name,
-          args: HardMuteRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'HardMuteRoute';
-
-  static const PageInfo<HardMuteRouteArgs> page =
-      PageInfo<HardMuteRouteArgs>(name);
-}
-
-class HardMuteRouteArgs {
-  const HardMuteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'HardMuteRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [InstanceMutePage]
-class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
-  InstanceMuteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          InstanceMuteRoute.name,
-          args: InstanceMuteRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'InstanceMuteRoute';
-
-  static const PageInfo<InstanceMuteRouteArgs> page =
-      PageInfo<InstanceMuteRouteArgs>(name);
-}
-
-class InstanceMuteRouteArgs {
-  const InstanceMuteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ReactionDeckPage]
-class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
-  ReactionDeckRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ReactionDeckRoute.name,
-          args: ReactionDeckRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ReactionDeckRoute';
-
-  static const PageInfo<ReactionDeckRouteArgs> page =
-      PageInfo<ReactionDeckRouteArgs>(name);
-}
-
-class ReactionDeckRouteArgs {
-  const ReactionDeckRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
-  }
 }
 
 /// generated route for
@@ -1449,136 +1027,116 @@ class SeveralAccountSettingsRouteArgs {
 }
 
 /// generated route for
-/// [SharingAccountSelectPage]
-class SharingAccountSelectRoute
-    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
-  SharingAccountSelectRoute({
+/// [InstanceMutePage]
+class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
+  InstanceMuteRoute({
     Key? key,
-    String? sharingText,
-    List<String>? filePath,
-    List<PageRouteInfo>? children,
-  }) : super(
-          SharingAccountSelectRoute.name,
-          args: SharingAccountSelectRouteArgs(
-            key: key,
-            sharingText: sharingText,
-            filePath: filePath,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'SharingAccountSelectRoute';
-
-  static const PageInfo<SharingAccountSelectRouteArgs> page =
-      PageInfo<SharingAccountSelectRouteArgs>(name);
-}
-
-class SharingAccountSelectRouteArgs {
-  const SharingAccountSelectRouteArgs({
-    this.key,
-    this.sharingText,
-    this.filePath,
-  });
-
-  final Key? key;
-
-  final String? sharingText;
-
-  final List<String>? filePath;
-
-  @override
-  String toString() {
-    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
-  }
-}
-
-/// generated route for
-/// [SplashPage]
-class SplashRoute extends PageRouteInfo<void> {
-  const SplashRoute({List<PageRouteInfo>? children})
-      : super(
-          SplashRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'SplashRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [TimeLinePage]
-class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
-  TimeLineRoute({
-    Key? key,
-    required TabSetting initialTabSetting,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TimeLineRoute.name,
-          args: TimeLineRouteArgs(
-            key: key,
-            initialTabSetting: initialTabSetting,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TimeLineRoute';
-
-  static const PageInfo<TimeLineRouteArgs> page =
-      PageInfo<TimeLineRouteArgs>(name);
-}
-
-class TimeLineRouteArgs {
-  const TimeLineRouteArgs({
-    this.key,
-    required this.initialTabSetting,
-  });
-
-  final Key? key;
-
-  final TabSetting initialTabSetting;
-
-  @override
-  String toString() {
-    return 'TimeLineRouteArgs{key: $key, initialTabSetting: $initialTabSetting}';
-  }
-}
-
-/// generated route for
-/// [UsersListPage]
-class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
-  UsersListRoute({
     required Account account,
-    Key? key,
     List<PageRouteInfo>? children,
   }) : super(
-          UsersListRoute.name,
-          args: UsersListRouteArgs(
-            account: account,
+          InstanceMuteRoute.name,
+          args: InstanceMuteRouteArgs(
             key: key,
+            account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UsersListRoute';
+  static const String name = 'InstanceMuteRoute';
 
-  static const PageInfo<UsersListRouteArgs> page =
-      PageInfo<UsersListRouteArgs>(name);
+  static const PageInfo<InstanceMuteRouteArgs> page =
+      PageInfo<InstanceMuteRouteArgs>(name);
 }
 
-class UsersListRouteArgs {
-  const UsersListRouteArgs({
-    required this.account,
+class InstanceMuteRouteArgs {
+  const InstanceMuteRouteArgs({
     this.key,
+    required this.account,
   });
+
+  final Key? key;
 
   final Account account;
 
+  @override
+  String toString() {
+    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [HardMutePage]
+class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
+  HardMuteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          HardMuteRoute.name,
+          args: HardMuteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'HardMuteRoute';
+
+  static const PageInfo<HardMuteRouteArgs> page =
+      PageInfo<HardMuteRouteArgs>(name);
+}
+
+class HardMuteRouteArgs {
+  const HardMuteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
   final Key? key;
+
+  final Account account;
 
   @override
   String toString() {
-    return 'UsersListRouteArgs{account: $account, key: $key}';
+    return 'HardMuteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ReactionDeckPage]
+class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
+  ReactionDeckRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ReactionDeckRoute.name,
+          args: ReactionDeckRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ReactionDeckRoute';
+
+  static const PageInfo<ReactionDeckRouteArgs> page =
+      PageInfo<ReactionDeckRouteArgs>(name);
+}
+
+class ReactionDeckRouteArgs {
+  const ReactionDeckRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -1626,129 +1184,571 @@ class UsersListTimelineRouteArgs {
 }
 
 /// generated route for
-/// [UserFolloweePage]
-class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
-  UserFolloweeRoute({
-    Key? key,
-    required String userId,
+/// [UsersListPage]
+class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
+  UsersListRoute({
     required Account account,
+    Key? key,
     List<PageRouteInfo>? children,
   }) : super(
-          UserFolloweeRoute.name,
-          args: UserFolloweeRouteArgs(
-            key: key,
-            userId: userId,
+          UsersListRoute.name,
+          args: UsersListRouteArgs(
             account: account,
+            key: key,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UserFolloweeRoute';
+  static const String name = 'UsersListRoute';
 
-  static const PageInfo<UserFolloweeRouteArgs> page =
-      PageInfo<UserFolloweeRouteArgs>(name);
+  static const PageInfo<UsersListRouteArgs> page =
+      PageInfo<UsersListRouteArgs>(name);
 }
 
-class UserFolloweeRouteArgs {
-  const UserFolloweeRouteArgs({
-    this.key,
-    required this.userId,
+class UsersListRouteArgs {
+  const UsersListRouteArgs({
     required this.account,
+    this.key,
   });
-
-  final Key? key;
-
-  final String userId;
 
   final Account account;
 
+  final Key? key;
+
   @override
   String toString() {
-    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
+    return 'UsersListRouteArgs{account: $account, key: $key}';
   }
 }
 
 /// generated route for
-/// [UserFollowerPage]
-class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
-  UserFollowerRoute({
+/// [ChannelDetailPage]
+class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
+  ChannelDetailRoute({
     Key? key,
-    required String userId,
     required Account account,
+    required String channelId,
     List<PageRouteInfo>? children,
   }) : super(
-          UserFollowerRoute.name,
-          args: UserFollowerRouteArgs(
+          ChannelDetailRoute.name,
+          args: ChannelDetailRouteArgs(
             key: key,
-            userId: userId,
             account: account,
+            channelId: channelId,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UserFollowerRoute';
+  static const String name = 'ChannelDetailRoute';
 
-  static const PageInfo<UserFollowerRouteArgs> page =
-      PageInfo<UserFollowerRouteArgs>(name);
+  static const PageInfo<ChannelDetailRouteArgs> page =
+      PageInfo<ChannelDetailRouteArgs>(name);
 }
 
-class UserFollowerRouteArgs {
-  const UserFollowerRouteArgs({
+class ChannelDetailRouteArgs {
+  const ChannelDetailRouteArgs({
     this.key,
-    required this.userId,
     required this.account,
+    required this.channelId,
   });
 
   final Key? key;
 
-  final String userId;
-
   final Account account;
+
+  final String channelId;
 
   @override
   String toString() {
-    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
+    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
   }
 }
 
 /// generated route for
-/// [UserPage]
-class UserRoute extends PageRouteInfo<UserRouteArgs> {
-  UserRoute({
+/// [ChannelsPage]
+class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
+  ChannelsRoute({
     Key? key,
-    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          UserRoute.name,
-          args: UserRouteArgs(
+          ChannelsRoute.name,
+          args: ChannelsRouteArgs(
             key: key,
-            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UserRoute';
+  static const String name = 'ChannelsRoute';
 
-  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
+  static const PageInfo<ChannelsRouteArgs> page =
+      PageInfo<ChannelsRouteArgs>(name);
 }
 
-class UserRouteArgs {
-  const UserRouteArgs({
+class ChannelsRouteArgs {
+  const ChannelsRouteArgs({
     this.key,
-    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String userId;
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ChannelsRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FederationPage]
+class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
+  FederationRoute({
+    Key? key,
+    required Account account,
+    required String host,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FederationRoute.name,
+          args: FederationRouteArgs(
+            key: key,
+            account: account,
+            host: host,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FederationRoute';
+
+  static const PageInfo<FederationRouteArgs> page =
+      PageInfo<FederationRouteArgs>(name);
+}
+
+class FederationRouteArgs {
+  const FederationRouteArgs({
+    this.key,
+    required this.account,
+    required this.host,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String host;
+
+  @override
+  String toString() {
+    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
+  }
+}
+
+/// generated route for
+/// [NoteDetailPage]
+class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
+  NoteDetailRoute({
+    Key? key,
+    required Note note,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          NoteDetailRoute.name,
+          args: NoteDetailRouteArgs(
+            key: key,
+            note: note,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'NoteDetailRoute';
+
+  static const PageInfo<NoteDetailRouteArgs> page =
+      PageInfo<NoteDetailRouteArgs>(name);
+}
+
+class NoteDetailRouteArgs {
+  const NoteDetailRouteArgs({
+    this.key,
+    required this.note,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Note note;
 
   final Account account;
 
   @override
   String toString() {
-    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
+    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
+  }
+}
+
+/// generated route for
+/// [SearchPage]
+class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
+  SearchRoute({
+    Key? key,
+    String? initialSearchText,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          SearchRoute.name,
+          args: SearchRouteArgs(
+            key: key,
+            initialSearchText: initialSearchText,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'SearchRoute';
+
+  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+}
+
+class SearchRouteArgs {
+  const SearchRouteArgs({
+    this.key,
+    this.initialSearchText,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String? initialSearchText;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
+  }
+}
+
+/// generated route for
+/// [SharingAccountSelectPage]
+class SharingAccountSelectRoute
+    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
+  SharingAccountSelectRoute({
+    Key? key,
+    String? sharingText,
+    List<String>? filePath,
+    List<PageRouteInfo>? children,
+  }) : super(
+          SharingAccountSelectRoute.name,
+          args: SharingAccountSelectRouteArgs(
+            key: key,
+            sharingText: sharingText,
+            filePath: filePath,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'SharingAccountSelectRoute';
+
+  static const PageInfo<SharingAccountSelectRouteArgs> page =
+      PageInfo<SharingAccountSelectRouteArgs>(name);
+}
+
+class SharingAccountSelectRouteArgs {
+  const SharingAccountSelectRouteArgs({
+    this.key,
+    this.sharingText,
+    this.filePath,
+  });
+
+  final Key? key;
+
+  final String? sharingText;
+
+  final List<String>? filePath;
+
+  @override
+  String toString() {
+    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
+  }
+}
+
+/// generated route for
+/// [ImportExportPage]
+class ImportExportRoute extends PageRouteInfo<void> {
+  const ImportExportRoute({List<PageRouteInfo>? children})
+      : super(
+          ImportExportRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'ImportExportRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [GeneralSettingsPage]
+class GeneralSettingsRoute extends PageRouteInfo<void> {
+  const GeneralSettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          GeneralSettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'GeneralSettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsPage]
+class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
+  TabSettingsRoute({
+    Key? key,
+    int? tabIndex,
+    List<PageRouteInfo>? children,
+  }) : super(
+          TabSettingsRoute.name,
+          args: TabSettingsRouteArgs(
+            key: key,
+            tabIndex: tabIndex,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsRoute';
+
+  static const PageInfo<TabSettingsRouteArgs> page =
+      PageInfo<TabSettingsRouteArgs>(name);
+}
+
+class TabSettingsRouteArgs {
+  const TabSettingsRouteArgs({
+    this.key,
+    this.tabIndex,
+  });
+
+  final Key? key;
+
+  final int? tabIndex;
+
+  @override
+  String toString() {
+    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
+  }
+}
+
+/// generated route for
+/// [TabSettingsListPage]
+class TabSettingsListRoute extends PageRouteInfo<void> {
+  const TabSettingsListRoute({List<PageRouteInfo>? children})
+      : super(
+          TabSettingsListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [AppInfoPage]
+class AppInfoRoute extends PageRouteInfo<void> {
+  const AppInfoRoute({List<PageRouteInfo>? children})
+      : super(
+          AppInfoRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AppInfoRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [SettingsPage]
+class SettingsRoute extends PageRouteInfo<void> {
+  const SettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          SettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [AccountListPage]
+class AccountListRoute extends PageRouteInfo<void> {
+  const AccountListRoute({List<PageRouteInfo>? children})
+      : super(
+          AccountListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AccountListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [ExploreRoleUsersPage]
+class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
+  ExploreRoleUsersRoute({
+    Key? key,
+    required RolesListResponse item,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoleUsersRoute.name,
+          args: ExploreRoleUsersRouteArgs(
+            key: key,
+            item: item,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoleUsersRoute';
+
+  static const PageInfo<ExploreRoleUsersRouteArgs> page =
+      PageInfo<ExploreRoleUsersRouteArgs>(name);
+}
+
+class ExploreRoleUsersRouteArgs {
+  const ExploreRoleUsersRouteArgs({
+    this.key,
+    required this.item,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final RolesListResponse item;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ExplorePage]
+class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
+  ExploreRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoute.name,
+          args: ExploreRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoute';
+
+  static const PageInfo<ExploreRouteArgs> page =
+      PageInfo<ExploreRouteArgs>(name);
+}
+
+class ExploreRouteArgs {
+  const ExploreRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [TimeLinePage]
+class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
+  TimeLineRoute({
+    Key? key,
+    required TabSetting initialTabSetting,
+    List<PageRouteInfo>? children,
+  }) : super(
+          TimeLineRoute.name,
+          args: TimeLineRouteArgs(
+            key: key,
+            initialTabSetting: initialTabSetting,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'TimeLineRoute';
+
+  static const PageInfo<TimeLineRouteArgs> page =
+      PageInfo<TimeLineRouteArgs>(name);
+}
+
+class TimeLineRouteArgs {
+  const TimeLineRouteArgs({
+    this.key,
+    required this.initialTabSetting,
+  });
+
+  final Key? key;
+
+  final TabSetting initialTabSetting;
+
+  @override
+  String toString() {
+    return 'TimeLineRouteArgs{key: $key, initialTabSetting: $initialTabSetting}';
+  }
+}
+
+/// generated route for
+/// [FavoritedNotePage]
+class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
+  FavoritedNoteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FavoritedNoteRoute.name,
+          args: FavoritedNoteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FavoritedNoteRoute';
+
+  static const PageInfo<FavoritedNoteRouteArgs> page =
+      PageInfo<FavoritedNoteRouteArgs>(name);
+}
+
+class FavoritedNoteRouteArgs {
+  const FavoritedNoteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
   }
 }

--- a/lib/view/channels_page/channel_detail_info.dart
+++ b/lib/view/channels_page/channel_detail_info.dart
@@ -153,7 +153,7 @@ class ChannelDetailInfoState extends ConsumerState<ChannelDetailInfo> {
                         child: const Text("フォローする"))
               ],
             )),
-        MfmText(data.description ?? ""),
+        MfmText(mfmText: data.description ?? ""),
         for (final pinnedNote in data.pinnedNotes ?? [])
           MisskeyNote(note: pinnedNote)
       ],

--- a/lib/view/common/misskey_notes/mfm_text.dart
+++ b/lib/view/common/misskey_notes/mfm_text.dart
@@ -5,6 +5,7 @@ import 'package:flutter_highlighting/flutter_highlighting.dart';
 import 'package:flutter_highlighting/themes/github-dark.dart';
 import 'package:flutter_highlighting/themes/github.dart';
 import 'package:highlighting/languages/all.dart';
+import 'package:mfm_parser/mfm_parser.dart';
 import 'package:miria/model/misskey_emoji_data.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
@@ -19,7 +20,8 @@ import 'package:misskey_dart/misskey_dart.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class MfmText extends ConsumerStatefulWidget {
-  final String mfmText;
+  final String? mfmText;
+  final List<MfmNode>? mfmNode;
   final String? host;
   final TextStyle? style;
   final Map<String, String> emoji;
@@ -29,16 +31,19 @@ class MfmText extends ConsumerStatefulWidget {
   final Function(MisskeyEmojiData)? onEmojiTap;
   final bool isEnableAnimatedMFM;
 
-  const MfmText(this.mfmText,
-      {super.key,
-      this.host,
-      this.style,
-      this.emoji = const {},
-      this.isNyaize = false,
-      this.suffixSpan = const [],
-      this.prefixSpan = const [],
-      this.onEmojiTap,
-      this.isEnableAnimatedMFM = true});
+  const MfmText({
+    super.key,
+    this.mfmText,
+    this.mfmNode,
+    this.host,
+    this.style,
+    this.emoji = const {},
+    this.isNyaize = false,
+    this.suffixSpan = const [],
+    this.prefixSpan = const [],
+    this.onEmojiTap,
+    this.isEnableAnimatedMFM = true,
+  }) : assert(mfmText != null || mfmNode != null);
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => MfmTextState();
@@ -139,7 +144,8 @@ class MfmTextState extends ConsumerState<MfmText> {
   @override
   Widget build(BuildContext context) {
     return Mfm(
-      widget.mfmText,
+      mfmText: widget.mfmText,
+      mfmNode: widget.mfmNode,
       emojiBuilder: (context, emojiName, style) {
         final emojiData = MisskeyEmojiData.fromEmojiName(
             emojiName: ":$emojiName:",

--- a/lib/view/common/misskey_notes/misskey_file_view.dart
+++ b/lib/view/common/misskey_notes/misskey_file_view.dart
@@ -9,7 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'network_image.dart';
 
-class MisskeyFileView extends ConsumerWidget {
+class MisskeyFileView extends ConsumerStatefulWidget {
   final List<DriveFile> files;
 
   final double height;
@@ -21,8 +21,15 @@ class MisskeyFileView extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final targetFiles = files;
+  ConsumerState<ConsumerStatefulWidget> createState() => MisskeyFileViewState();
+}
+
+class MisskeyFileViewState extends ConsumerState<MisskeyFileView> {
+  late bool isElipsed = widget.files.length >= 5;
+
+  @override
+  Widget build(BuildContext context) {
+    final targetFiles = widget.files;
 
     if (targetFiles.isEmpty) {
       return Container();
@@ -30,8 +37,8 @@ class MisskeyFileView extends ConsumerWidget {
       final targetFile = targetFiles.first;
       return Center(
         child: ConstrainedBox(
-            constraints:
-                BoxConstraints(maxHeight: height, maxWidth: double.infinity),
+            constraints: BoxConstraints(
+                maxHeight: widget.height, maxWidth: double.infinity),
             child: MisskeyImage(
               isSensitive: targetFile.isSensitive,
               thumbnailUrl:
@@ -43,24 +50,39 @@ class MisskeyFileView extends ConsumerWidget {
             )),
       );
     } else {
-      return GridView.count(
-        crossAxisCount: 2,
-        shrinkWrap: true,
-        physics: const NeverScrollableScrollPhysics(),
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        mainAxisSize: MainAxisSize.max,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          for (final targetFile in targetFiles
-              .mapIndexed((index, element) => (element: element, index: index)))
-            SizedBox(
-                height: height,
-                width: double.infinity,
-                child: MisskeyImage(
-                  isSensitive: targetFile.element.isSensitive,
-                  thumbnailUrl: targetFile.element.thumbnailUrl?.toString(),
-                  targetFiles: targetFiles.map((e) => e.url).toList(),
-                  fileType: targetFile.element.type,
-                  name: targetFile.element.name,
-                  position: targetFile.index,
-                ))
+          GridView.count(
+            crossAxisCount: 2,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            children: [
+              for (final targetFile in targetFiles
+                  .mapIndexed(
+                      (index, element) => (element: element, index: index))
+                  .take(isElipsed ? 4 : targetFiles.length))
+                SizedBox(
+                    height: widget.height,
+                    width: double.infinity,
+                    child: MisskeyImage(
+                      isSensitive: targetFile.element.isSensitive,
+                      thumbnailUrl: targetFile.element.thumbnailUrl?.toString(),
+                      targetFiles: targetFiles.map((e) => e.url).toList(),
+                      fileType: targetFile.element.type,
+                      name: targetFile.element.name,
+                      position: targetFile.index,
+                    ))
+            ],
+          ),
+          if (isElipsed)
+            ElevatedButton(
+                onPressed: () => setState(() {
+                      isElipsed = !isElipsed;
+                    }),
+                child: const Text("続きを表示"))
         ],
       );
     }

--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -143,11 +143,10 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
   late bool isLongVisible;
   bool isLongVisibleInitialized = false;
 
-  bool shouldCollaposed(Note displayNote) {
-    final text = displayNote.text;
-    if (text == null) return false;
-    final parseResult = const parser.MfmParser().parse(text);
-    final result = nodeMaxTextLength(parseResult);
+  List<parser.MfmNode>? displayTextNodes;
+
+  bool shouldCollaposed(List<parser.MfmNode> node) {
+    final result = nodeMaxTextLength(node);
     return result.$1 >= 500 || result.$2 >= 6;
   }
 
@@ -207,10 +206,13 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
     if (widget.recursive == 3) {
       return Container();
     }
+
+    displayTextNodes ??= const parser.MfmParser().parse(displayNote.text ?? "");
+
     if (!isLongVisibleInitialized) {
       isLongVisible = widget.isForceVisibleLong ||
           displayNote.cw?.isNotEmpty == true ||
-          !shouldCollaposed(displayNote);
+          !shouldCollaposed(displayTextNodes!);
 
       isLongVisibleInitialized = true;
     }
@@ -319,7 +321,7 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                           ),
                           if (displayNote.cw != null) ...[
                             MfmText(
-                              displayNote.cw ?? "",
+                              mfmText: displayNote.cw ?? "",
                               host: displayNote.user.host,
                               emoji: displayNote.emojis,
                               isEnableAnimatedMFM: ref
@@ -359,7 +361,7 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
                               displayNote.cw != null && isCwOpened) ...[
                             if (isLongVisible)
                               MfmText(
-                                displayNote.text ?? "",
+                                mfmNode: displayTextNodes,
                                 host: displayNote.user.host,
                                 emoji: displayNote.emojis,
                                 isEnableAnimatedMFM: ref

--- a/lib/view/federation_page/federation_announcements.dart
+++ b/lib/view/federation_page/federation_announcements.dart
@@ -77,7 +77,7 @@ class Announcement extends StatelessWidget {
                 ),
                 const Padding(padding: EdgeInsets.only(top: 10)),
                 MfmText(
-                  data.text,
+                  mfmText: data.text,
                   host: AccountScope.of(context).host == host ? null : host,
                 )
               ],

--- a/lib/view/note_create_page/mfm_preview.dart
+++ b/lib/view/note_create_page/mfm_preview.dart
@@ -21,7 +21,7 @@ class MfmPreview extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.all(5),
       child: MfmText(
-        "$replyTo$previewText",
+        mfmText: "$replyTo$previewText",
         isNyaize: AccountScope.of(context).i.isCat,
       ),
     );

--- a/lib/view/note_detail_page/note_detail_page.dart
+++ b/lib/view/note_detail_page/note_detail_page.dart
@@ -6,7 +6,6 @@ import 'package:miria/extensions/date_time_extension.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/view/common/account_scope.dart';
-import 'package:miria/view/common/common_drawer.dart';
 import 'package:miria/view/common/misskey_notes/misskey_note.dart';
 import 'package:miria/view/common/pushable_listview.dart';
 import 'package:misskey_dart/misskey_dart.dart';

--- a/lib/view/photo_edit_page/license_confirm_dialog.dart
+++ b/lib/view/photo_edit_page/license_confirm_dialog.dart
@@ -68,7 +68,8 @@ class LicenseConfirmDialogState extends ConsumerState<LicenseConfirmDialog> {
                 const Text(
                   "このカスタム絵文字はこのようにライセンスされています。",
                 ),
-                MfmText(data.license ?? "※このカスタム絵文字に対してライセンスは設定されていません。")
+                MfmText(
+                    mfmText: data.license ?? "※このカスタム絵文字に対してライセンスは設定されていません。")
               ],
             ),
           ),

--- a/lib/view/settings_page/app_info_page/app_info_page.dart
+++ b/lib/view/settings_page/app_info_page/app_info_page.dart
@@ -37,7 +37,7 @@ class AppInfoPageState extends ConsumerState<AppInfoPage> {
             account: ref.read(accountRepository).account.first,
             child: Column(
               children: [
-                MfmText('''
+                MfmText(mfmText: '''
 <center>\$[x3 Miria]</center>
 パッケージ名：${packageInfo?.packageName ?? ""}
 バージョン:${packageInfo?.version ?? ""}+${packageInfo?.buildNumber.toString() ?? ""}

--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -22,6 +22,8 @@ class GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
   AutomaticPush automaticPush = AutomaticPush.none;
   bool enableDirectReaction = false;
   bool enableAnimatedMFM = true;
+  bool enableLongTextElipsed = false;
+  bool enableFavoritedRenoteElipsed = true;
 
   @override
   void initState() {
@@ -50,18 +52,24 @@ class GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
       enableDirectReaction = settings.enableDirectReaction;
       automaticPush = settings.automaticPush;
       enableAnimatedMFM = settings.enableAnimatedMFM;
+      enableLongTextElipsed = settings.enableLongTextElipsed;
+      enableFavoritedRenoteElipsed = settings.enableFavoritedRenoteElipsed;
     });
   }
 
   Future<void> save() async {
-    ref.read(generalSettingsRepositoryProvider).update(GeneralSettings(
-        lightColorThemeId: lightModeTheme,
-        darkColorThemeId: darkModeTheme,
-        themeColorSystem: colorSystem,
-        nsfwInherit: nsfwInherit,
-        enableDirectReaction: enableDirectReaction,
-        automaticPush: automaticPush,
-        enableAnimatedMFM: enableAnimatedMFM));
+    ref.read(generalSettingsRepositoryProvider).update(
+          GeneralSettings(
+              lightColorThemeId: lightModeTheme,
+              darkColorThemeId: darkModeTheme,
+              themeColorSystem: colorSystem,
+              nsfwInherit: nsfwInherit,
+              enableDirectReaction: enableDirectReaction,
+              automaticPush: automaticPush,
+              enableAnimatedMFM: enableAnimatedMFM,
+              enableFavoritedRenoteElipsed: enableFavoritedRenoteElipsed,
+              enableLongTextElipsed: enableLongTextElipsed),
+        );
   }
 
   @override
@@ -77,63 +85,82 @@ class GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Card(
-                  child: Padding(
-                      padding: const EdgeInsets.all(15),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.max,
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text("全般",
-                              style: Theme.of(context).textTheme.titleLarge),
-                          const Padding(padding: EdgeInsets.only(top: 10)),
-                          const Text("閲覧注意のついたノートの表示"),
-                          DropdownButton<NSFWInherit>(
-                            items: [
-                              for (final element in NSFWInherit.values)
-                                DropdownMenuItem(
-                                  value: element,
-                                  child: Text(element.displayName),
-                                )
-                            ],
-                            value: nsfwInherit,
-                            onChanged: (value) => setState(
-                              () {
-                                nsfwInherit = value ?? NSFWInherit.inherit;
-                                save();
-                              },
-                            ),
-                          ),
-                          const Padding(padding: EdgeInsets.only(top: 10)),
-                          const Text("一覧の自動更新"),
-                          DropdownButton<AutomaticPush>(
-                            items: [
-                              for (final element in AutomaticPush.values)
-                                DropdownMenuItem(
-                                  value: element,
-                                  child: Text(element.displayName),
-                                )
-                            ],
-                            value: automaticPush,
-                            onChanged: (value) => setState(
-                              () {
-                                automaticPush = value ?? AutomaticPush.none;
-                                save();
-                              },
-                            ),
-                          ),
-                          const Padding(padding: EdgeInsets.only(top: 10)),
-                          const Text("動きのあるMFM"),
-                          CheckboxListTile(
-                            value: enableAnimatedMFM,
-                            onChanged: (value) => setState(() {
-                              enableAnimatedMFM = value ?? true;
-                              save();
-                            }),
-                            title: const Text("動きのあるMFMを有効にします。"),
-                          )
+                child: Padding(
+                  padding: const EdgeInsets.all(15),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.max,
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text("全般", style: Theme.of(context).textTheme.titleLarge),
+                      const Padding(padding: EdgeInsets.only(top: 10)),
+                      const Text("閲覧注意のついたノートの表示"),
+                      DropdownButton<NSFWInherit>(
+                        items: [
+                          for (final element in NSFWInherit.values)
+                            DropdownMenuItem(
+                              value: element,
+                              child: Text(element.displayName),
+                            )
                         ],
-                      ))),
+                        value: nsfwInherit,
+                        onChanged: (value) => setState(
+                          () {
+                            nsfwInherit = value ?? NSFWInherit.inherit;
+                            save();
+                          },
+                        ),
+                      ),
+                      const Padding(padding: EdgeInsets.only(top: 10)),
+                      const Text("一覧の自動更新"),
+                      DropdownButton<AutomaticPush>(
+                        items: [
+                          for (final element in AutomaticPush.values)
+                            DropdownMenuItem(
+                              value: element,
+                              child: Text(element.displayName),
+                            )
+                        ],
+                        value: automaticPush,
+                        onChanged: (value) => setState(
+                          () {
+                            automaticPush = value ?? AutomaticPush.none;
+                            save();
+                          },
+                        ),
+                      ),
+                      const Padding(padding: EdgeInsets.only(top: 10)),
+                      const Text("動きのあるMFM"),
+                      CheckboxListTile(
+                        value: enableAnimatedMFM,
+                        onChanged: (value) => setState(() {
+                          enableAnimatedMFM = value ?? true;
+                          save();
+                        }),
+                        title: const Text("動きのあるMFMを有効にします。"),
+                      ),
+                      const Padding(padding: EdgeInsets.only(top: 10)),
+                      const Text("ノートの省略"),
+                      CheckboxListTile(
+                        value: enableFavoritedRenoteElipsed,
+                        onChanged: (value) => setState(() {
+                          enableFavoritedRenoteElipsed = value ?? true;
+                          save();
+                        }),
+                        title: const Text("リアクション済みノートのRenoteを省略します。"),
+                      ),
+                      CheckboxListTile(
+                        value: enableLongTextElipsed,
+                        onChanged: (value) => setState(() {
+                          enableLongTextElipsed = value ?? true;
+                          save();
+                        }),
+                        title: const Text("長いノートを省略します。"),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
               Card(
                 child: Padding(
                   padding: const EdgeInsets.all(15),

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -264,7 +264,7 @@ class UserDetailState extends ConsumerState<UserDetail> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       MfmText(
-                        response.name ?? response.username,
+                        mfmText: response.name ?? response.username,
                         style: Theme.of(context).textTheme.headlineSmall,
                         emoji: response.emojis ?? {},
                       ),
@@ -359,8 +359,10 @@ class UserDetailState extends ConsumerState<UserDetail> {
             ),
           Align(
             alignment: Alignment.center,
-            child: MfmText(response.description ?? "",
-                emoji: response.emojis ?? {}),
+            child: MfmText(
+              mfmText: response.description ?? "",
+              emoji: response.emojis ?? {},
+            ),
           ),
           const Padding(padding: EdgeInsets.only(top: 20)),
           Table(
@@ -408,13 +410,16 @@ class UserDetailState extends ConsumerState<UserDetail> {
                 for (final field in response.fields ?? <UserField>[])
                   TableRow(children: [
                     TableCell(
+                      child: MfmText(
+                        mfmText: field.name,
+                        emoji: response.emojis ?? {},
+                      ),
+                    ),
+                    TableCell(
                         child: MfmText(
-                      field.name,
+                      mfmText: field.value,
                       emoji: response.emojis ?? {},
                     )),
-                    TableCell(
-                        child:
-                            MfmText(field.value, emoji: response.emojis ?? {})),
                   ])
               ],
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -773,7 +773,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "864e30194775acf00dfc8c5d131e98ce3ce8a852"
+      resolved-ref: "9f520855f3717b35cb273991de143c2df960eb7f"
       url: "https://github.com/shiosyakeyakini-info/mfm_renderer.git"
     source: git
     version: "0.0.1"
@@ -790,7 +790,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: ed08e82295645d3267ee7bbb73d74e8f0a30a6ed
+      resolved-ref: "03c8d0202a2921cec1d2c634738fa94e4895c6b3"
       url: "https://github.com/shiosyakeyakini-info/misskey_dart.git"
     source: git
     version: "1.0.0"


### PR DESCRIPTION
#180 対応

- 表示するメディアを初期表示では最大4に、5個以上は「続きを表示」ボタンで表示する
- 「リアクション済みノートのRenoteを省略」できるように
- 「長いノートを省略」できるように
  - 連続した改行が6個以上（いろいろみた結果単純な改行よりこっちの方がいいかもと思った）
  - 500文字以上のテキスト、ただしカスタム絵文字は1個として数える、MFM構文の箇所は含まない
    - 高さで制限できなくてMFMを反映しない描画として省略表示にしたため、MFMアートが初期表示で表示されにくくなってしまうので、長くはないけど複雑なMFMは尊重してそのまま出してあげたい
    - このため、先にMFMのパースをしてから文字数を数えるようにした