### PR TITLE
Miria #5, #84, #132 対応

### DIFF
--- a/lib/view/common/misskey_notes/mfm_text.dart
+++ b/lib/view/common/misskey_notes/mfm_text.dart
@@ -146,16 +146,18 @@ class MfmTextState extends ConsumerState<MfmText> {
     return Mfm(
       mfmText: widget.mfmText,
       mfmNode: widget.mfmNode,
-      emojiBuilder: (context, emojiName, style) {
+      emojiBuilder: (builderContext, emojiName, style) {
         final emojiData = MisskeyEmojiData.fromEmojiName(
             emojiName: ":$emojiName:",
-            repository:
-                ref.read(emojiRepositoryProvider(AccountScope.of(context))),
+            repository: ref
+                .read(emojiRepositoryProvider(AccountScope.of(builderContext))),
             emojiInfo: widget.emoji);
         return DefaultTextStyle(
-          style: style ?? DefaultTextStyle.of(context).style,
+          style: style ?? DefaultTextStyle.of(builderContext).style,
           child: GestureDetector(
-            onTap: () => widget.onEmojiTap?.call(emojiData),
+            onTap: MfmBlurScope.of(builderContext)
+                ? null
+                : () => widget.onEmojiTap?.call(emojiData),
             child: EmojiInk(
               child: CustomEmoji(
                 emojiData: emojiData,
@@ -167,12 +169,15 @@ class MfmTextState extends ConsumerState<MfmText> {
         );
       },
       unicodeEmojiBuilder:
-          (BuildContext context, String emoji, TextStyle? style) => TextSpan(
-              text: emoji,
-              style: style,
-              recognizer: TapGestureRecognizer()
-                ..onTap = () =>
-                    widget.onEmojiTap?.call(UnicodeEmojiData(char: emoji))),
+          (BuildContext builderContext, String emoji, TextStyle? style) =>
+              TextSpan(
+                  text: emoji,
+                  style: style,
+                  recognizer: MfmBlurScope.of(builderContext)
+                      ? null
+                      : (TapGestureRecognizer()
+                        ..onTap = () => widget.onEmojiTap
+                            ?.call(UnicodeEmojiData(char: emoji)))),
       codeBlockBuilder: (context, code, lang) => CodeBlock(
         code: code,
         language: lang,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -773,7 +773,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "9f520855f3717b35cb273991de143c2df960eb7f"
+      resolved-ref: c2b6c5afe43d516ac2189e15406b71390a4a88db
       url: "https://github.com/shiosyakeyakini-info/mfm_renderer.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
#5 $[blur が複数ある場合の挙動が違う
 → InheritedWidgetで$[blur の状態をMFMのなかで共有するようにした

#84 $[blur の中身が消えることがある
 → ImageFilteredの値を0にするのではなく、ウィジェットを挟まないようにした

#132 $[blurより下の絵文字タップが勝つ
 → そのコンテキストが$[blurにラップされていたら、絵文字タップの処理はしないようにした