### PR TITLE
KosugiMaruが使えるように修正

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,17 +96,17 @@ flutter:
     - assets/fonts/
     - assets/images/
 
-fonts:
-  - family: KosugiMaru
-    fonts:
-      - asset: assets/fonts/KosugiMaru-Regular.ttf
-        weight: 300
-      - asset: assets/fonts/KosugiMaru-Regular.ttf
-        weight: 400
-      - asset: assets/fonts/KosugiMaru-Regular.ttf
-        weight: 500
-      - asset: assets/fonts/KosugiMaru-Regular.ttf
-        weight: 600
+  fonts:
+    - family: KosugiMaru
+      fonts:
+        - asset: assets/fonts/KosugiMaru-Regular.ttf
+          weight: 300
+        - asset: assets/fonts/KosugiMaru-Regular.ttf
+          weight: 400
+        - asset: assets/fonts/KosugiMaru-Regular.ttf
+          weight: 500
+        - asset: assets/fonts/KosugiMaru-Regular.ttf
+          weight: 600
 
 flutter_launcher_icons:
   android: "launcher_icon"


### PR DESCRIPTION
`assets/fonts/`内の`KosugiMaru`フォントが使用できるように修正しました。
（`fonts:`を`fltter:`以下になるように移動しました）