### PR TITLE
アカウントを並び替えられるように

### DIFF
--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -53,7 +53,7 @@ final localTimeLineProvider =
     ref.read(generalSettingsRepositoryProvider),
     tabSetting,
     ref.read(mainStreamRepositoryProvider(account)),
-    ref.read(accountRepository),
+    ref.read(accountRepositoryProvider.notifier),
     ref.read(emojiRepositoryProvider(account)),
   );
 });
@@ -70,7 +70,7 @@ final homeTimeLineProvider =
     ref.read(generalSettingsRepositoryProvider),
     tabSetting,
     ref.read(mainStreamRepositoryProvider(account)),
-    ref.read(accountRepository),
+    ref.read(accountRepositoryProvider.notifier),
     ref.read(emojiRepositoryProvider(account)),
   );
 });
@@ -100,7 +100,7 @@ final hybridTimeLineProvider =
     ref.read(generalSettingsRepositoryProvider),
     tabSetting,
     ref.read(mainStreamRepositoryProvider(account)),
-    ref.read(accountRepository),
+    ref.read(accountRepositoryProvider.notifier),
     ref.read(emojiRepositoryProvider(account)),
   );
 });
@@ -117,7 +117,7 @@ final roleTimelineProvider =
     ref.read(generalSettingsRepositoryProvider),
     tabSetting,
     ref.read(mainStreamRepositoryProvider(account)),
-    ref.read(accountRepository),
+    ref.read(accountRepositoryProvider.notifier),
     ref.read(emojiRepositoryProvider(account)),
   );
 });
@@ -134,7 +134,7 @@ final channelTimelineProvider =
     ref.read(generalSettingsRepositoryProvider),
     tabSetting,
     ref.read(mainStreamRepositoryProvider(account)),
-    ref.read(accountRepository),
+    ref.read(accountRepositoryProvider.notifier),
     ref.read(emojiRepositoryProvider(account)),
   );
 });
@@ -151,7 +151,7 @@ final userListTimelineProvider =
     ref.read(generalSettingsRepositoryProvider),
     tabSetting,
     ref.read(mainStreamRepositoryProvider(account)),
-    ref.read(accountRepository),
+    ref.read(accountRepositoryProvider.notifier),
     ref.read(emojiRepositoryProvider(account)),
   );
 });
@@ -168,7 +168,7 @@ final antennaTimelineProvider =
     ref.read(generalSettingsRepositoryProvider),
     tabSetting,
     ref.read(mainStreamRepositoryProvider(account)),
-    ref.read(accountRepository),
+    ref.read(accountRepositoryProvider.notifier),
     ref.read(emojiRepositoryProvider(account)),
   );
 });
@@ -179,7 +179,7 @@ final mainStreamRepositoryProvider =
             ref.read(misskeyProvider(account)),
             ref.read(emojiRepositoryProvider(account)),
             account,
-            ref.read(accountRepository)));
+            ref.read(accountRepositoryProvider.notifier)));
 
 final favoriteProvider = ChangeNotifierProvider.autoDispose
     .family<FavoriteRepository, Account>((ref, account) => FavoriteRepository(
@@ -198,15 +198,21 @@ final emojiRepositoryProvider = Provider.family<EmojiRepository, Account>(
         accountSettingsRepository:
             ref.read(accountSettingsRepositoryProvider)));
 
-final accountRepository = ChangeNotifierProvider((ref) => AccountRepository(
-    ref.read(tabSettingsRepositoryProvider),
-    ref.read(accountSettingsRepositoryProvider),
-    ref.read));
+final accountRepositoryProvider =
+    NotifierProvider<AccountRepository, List<Account>>(AccountRepository.new);
 
-final accountProvider = Provider.family<Account, Acct>((ref, acct) {
-  final repository = ref.watch(accountRepository);
-  return repository.account.firstWhere((element) => element.acct == acct);
-});
+final accountsProvider =
+    Provider<List<Account>>((ref) => ref.watch(accountRepositoryProvider));
+
+final accountProvider = Provider.family<Account, Acct>(
+  (ref, acct) => ref.watch(
+    accountsProvider.select(
+      (accounts) => accounts.firstWhere(
+        (account) => account.acct == acct,
+      ),
+    ),
+  ),
+);
 
 final tabSettingsRepositoryProvider =
     ChangeNotifierProvider((ref) => TabSettingsRepository());

--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -169,6 +169,10 @@ class AccountRepository extends Notifier<List<Account>> {
   }
 
   Future<void> _addAccount(Account account) async {
+    if (state.map((e) => e.acct).contains(account.acct)) {
+      throw SpecifiedException("${account.acct}で既にログインしています");
+    }
+
     state = [...state, account];
     _validatedAccts.add(account.acct);
     await ref.read(emojiRepositoryProvider(account)).loadFromSourceIfNeed();

--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -181,6 +181,18 @@ class AccountRepository extends Notifier<List<Account>> {
     await _addIfTabSettingNothing();
   }
 
+  Future<void> reorder(int oldIndex, int newIndex) async {
+    if (oldIndex < newIndex) {
+      newIndex -= 1;
+    }
+    final newState = state.toList();
+    final item = newState.removeAt(oldIndex);
+    newState.insert(newIndex, item);
+    state = newState;
+
+    await _save();
+  }
+
   Future<void> _save() async {
     const prefs = FlutterSecureStorage();
     await prefs.write(

--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -2,34 +2,24 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/model/acct.dart';
-import 'package:miria/model/tab_icon.dart';
-import 'package:miria/model/tab_setting.dart';
-import 'package:miria/model/tab_type.dart';
 import 'package:miria/providers.dart';
-import 'package:miria/repository/account_settings_repository.dart';
-import 'package:miria/repository/tab_settings_repository.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:uuid/uuid.dart';
 
-class AccountRepository extends ChangeNotifier {
-  final List<Account> _account = [];
-  final accountDataValidated = <bool>[];
+class AccountRepository extends Notifier<List<Account>> {
+  final _validatedAccts = <Acct>{};
+  String _sessionId = "";
 
-  Iterable<Account> get account => _account;
-
-  final TabSettingsRepository tabSettingsRepository;
-  final AccountSettingsRepository accountSettingsRepository;
-  final T Function<T>(ProviderListenable<T> provider) reader;
-
-  AccountRepository(
-      this.tabSettingsRepository, this.accountSettingsRepository, this.reader);
+  @override
+  List<Account> build() {
+    return [];
+  }
 
   Future<void> load() async {
     const prefs = FlutterSecureStorage();
@@ -38,16 +28,10 @@ class AccountRepository extends ChangeNotifier {
       return;
     }
     try {
-      _account
-        ..clear()
-        ..addAll(
-            (jsonDecode(storedData) as List).map((e) => Account.fromJson(e)));
-
-      accountDataValidated
-        ..clear()
-        ..addAll(Iterable.generate(_account.length, (index) => false));
-
-      notifyListeners();
+      state = (jsonDecode(storedData) as List)
+          .map((e) => Account.fromJson(e))
+          .toList();
+      _validatedAccts.clear();
     } catch (e) {
       if (kDebugMode) {
         print(e);
@@ -56,73 +40,57 @@ class AccountRepository extends ChangeNotifier {
   }
 
   Future<void> loadFromSourceIfNeed(Acct acct) async {
-    final index =
-        _account.map((account) => account.acct).toList().indexOf(acct);
-    if (index == -1) return;
-    if (accountDataValidated.isNotEmpty && accountDataValidated[index]) return;
-    final i = await reader(misskeyProvider(_account[index])).i.i();
-    _account[index] = _account[index].copyWith(i: i);
+    if (_validatedAccts.contains(acct)) return;
 
-    accountDataValidated[index] = true;
-    reader(notesProvider(_account[index])).updateMute(i.mutedWords);
-    notifyListeners();
+    final index = state.indexWhere((e) => e.acct == acct);
+    if (index < 0) return;
+    final account = state[index];
+    final i = await ref.read(misskeyProvider(account)).i.i();
+    ref.read(notesProvider(account)).updateMute(i.mutedWords);
+
+    final accounts = List.of(state);
+    accounts[index] = account.copyWith(i: i);
+    state = accounts;
+    _validatedAccts.add(acct);
   }
 
   Future<void> createUnreadAnnouncement(
-      Account account, AnnouncementsResponse announcement) async {
-    final i = _account[_account.indexOf(account)].i.copyWith(
-        unreadAnnouncements: [
-          ..._account[_account.indexOf(account)].i.unreadAnnouncements,
-          announcement
-        ]);
-    _account[_account.indexOf(account)] =
-        _account[_account.indexOf(account)].copyWith(i: i);
-    notifyListeners();
+    Account account,
+    AnnouncementsResponse announcement,
+  ) async {
+    final index = state.indexOf(account);
+    final i = state[index].i.copyWith(
+      unreadAnnouncements: [
+        ...state[index].i.unreadAnnouncements,
+        announcement
+      ],
+    );
+
+    final accounts = List.of(state);
+    accounts[index] = account.copyWith(i: i);
+    state = accounts;
   }
 
   Future<void> removeUnreadAnnouncement(Account account) async {
-    final i =
-        _account[_account.indexOf(account)].i.copyWith(unreadAnnouncements: []);
-    _account[_account.indexOf(account)] =
-        _account[_account.indexOf(account)].copyWith(i: i);
-    notifyListeners();
-  }
+    final index = state.indexOf(account);
+    final i = state[index].i.copyWith(
+      unreadAnnouncements: [],
+    );
 
-  //一つ目のアカウントが追加されたときに自動で追加されるタブ
-  Future<void> _addIfTabSettingNothing() async {
-    if (_account.length == 1) {
-      final account = _account.first;
-      await tabSettingsRepository.save([
-        TabSetting(
-          icon: TabIcon(codePoint: Icons.home.codePoint),
-          tabType: TabType.homeTimeline,
-          name: "ホームタイムライン",
-          acct: account.acct,
-        ),
-        TabSetting(
-          icon: TabIcon(codePoint: Icons.public.codePoint),
-          tabType: TabType.localTimeline,
-          name: "ローカルタイムライン",
-          acct: account.acct,
-        ),
-        TabSetting(
-          icon: TabIcon(codePoint: Icons.rocket_launch.codePoint),
-          tabType: TabType.globalTimeline,
-          name: "グローバルタイムライン",
-          acct: account.acct,
-        ),
-      ]);
-    }
+    final accounts = List.of(state);
+    accounts[index] = account.copyWith(i: i);
+    state = accounts;
   }
 
   Future<void> remove(Account account) async {
-    _account.remove(account);
-    await tabSettingsRepository.removeAccount(account);
-    await accountSettingsRepository.removeAccount(account);
-    await save();
+    state = state.where((e) => e != account).toList();
+    _validatedAccts.remove(account.acct);
+    await ref.read(tabSettingsRepositoryProvider).removeAccount(account);
+    await ref.read(accountSettingsRepositoryProvider).removeAccount(account);
+    await _save();
   }
 
-  Future<void> validateMisskey(String server) async {
+  Future<void> _validateMisskey(String server) async {
     //先にnodeInfoを取得する
     final Response nodeInfo;
 
@@ -138,12 +106,12 @@ class AccountRepository extends ChangeNotifier {
     }
 
     try {
-      nodeInfo = await reader(dioProvider).getUri(uri);
+      nodeInfo = await ref.read(dioProvider).getUri(uri);
     } catch (e) {
       throw SpecifiedException("$server はMisskeyサーバーとして認識できませんでした。");
     }
     final nodeInfoHref = nodeInfo.data["links"][0]["href"];
-    final nodeInfoHrefResponse = await reader(dioProvider).get(nodeInfoHref);
+    final nodeInfoHrefResponse = await ref.read(dioProvider).get(nodeInfoHref);
     final nodeInfoResult = nodeInfoHrefResponse.data;
 
     final software = nodeInfoResult["software"]["name"];
@@ -154,8 +122,9 @@ class AccountRepository extends ChangeNotifier {
 
     final version = nodeInfoResult["software"]["version"];
 
-    final endpoints =
-        await reader(misskeyProvider(Account.demoAccount(server))).endpoints();
+    final endpoints = await ref
+        .read(misskeyProvider(Account.demoAccount(server)))
+        .endpoints();
     if (!endpoints.contains("emojis")) {
       throw SpecifiedException("Miriaと互換性のないソフトウェアです。\n$software $version");
     }
@@ -167,50 +136,61 @@ class AccountRepository extends ChangeNotifier {
         await MisskeyServer().loginAsPassword(server, userId, password);
     final i = await Misskey(token: token, host: server).i.i();
     final account = Account(host: server, token: token, userId: userId, i: i);
-    addAccount(account);
-    await _addIfTabSettingNothing();
+    _addAccount(account);
   }
 
   Future<void> loginAsToken(String server, String token) async {
-    await validateMisskey(server);
+    await _validateMisskey(server);
     final i = await Misskey(token: token, host: server).i.i();
-    addAccount(Account(host: server, userId: i.username, token: token, i: i));
-    await _addIfTabSettingNothing();
+    _addAccount(Account(host: server, userId: i.username, token: token, i: i));
   }
 
-  String sessionId = "";
-
   Future<void> openMiAuth(String server) async {
-    await validateMisskey(server);
+    await _validateMisskey(server);
 
-    sessionId = const Uuid().v4();
+    _sessionId = const Uuid().v4();
     await launchUrl(
-      MisskeyServer().buildMiAuthURL(server, sessionId,
-          name: "Miria", permission: Permission.values),
+      MisskeyServer().buildMiAuthURL(
+        server,
+        _sessionId,
+        name: "Miria",
+        permission: Permission.values,
+      ),
       mode: LaunchMode.externalApplication,
     );
   }
 
   Future<void> validateMiAuth(String server) async {
-    final token = await MisskeyServer().checkMiAuthToken(server, sessionId);
+    final token = await MisskeyServer().checkMiAuthToken(server, _sessionId);
     final i = await Misskey(token: token, host: server).i.i();
-    await addAccount(
-        Account(host: server, userId: i.username, token: token, i: i));
+    await _addAccount(
+      Account(host: server, userId: i.username, token: token, i: i),
+    );
+  }
+
+  Future<void> _addAccount(Account account) async {
+    state = [...state, account];
+    _validatedAccts.add(account.acct);
+    await ref.read(emojiRepositoryProvider(account)).loadFromSourceIfNeed();
+
+    await _save();
     await _addIfTabSettingNothing();
   }
 
-  Future<void> addAccount(Account account) async {
-    _account.add(account);
-    accountDataValidated.add(true);
-    await reader(emojiRepositoryProvider(account)).loadFromSourceIfNeed();
-
-    await save();
-  }
-
-  Future<void> save() async {
+  Future<void> _save() async {
     const prefs = FlutterSecureStorage();
     await prefs.write(
-        key: "accounts",
-        value: jsonEncode(_account.map((e) => e.toJson()).toList()));
+      key: "accounts",
+      value: jsonEncode(state.map((e) => e.toJson()).toList()),
+    );
+  }
+
+  Future<void> _addIfTabSettingNothing() async {
+    if (state.length == 1) {
+      final account = state.first;
+      ref
+          .read(tabSettingsRepositoryProvider)
+          .initializeTabSettings(account.acct);
+    }
   }
 }

--- a/lib/repository/import_export_repository.dart
+++ b/lib/repository/import_export_repository.dart
@@ -68,7 +68,7 @@ class ImportExportRepository extends ChangeNotifier {
     final importedSettings = ExportedSetting.fromJson(json);
 
     // アカウント設定よみこみ
-    final accounts = reader(accountRepository).account;
+    final accounts = reader(accountsProvider);
     for (final accountSetting in importedSettings.accountSettings) {
       // この端末でログイン済みのアカウントであれば
       if (accounts.any((account) => account.acct == accountSetting.acct)) {

--- a/lib/repository/tab_settings_repository.dart
+++ b/lib/repository/tab_settings_repository.dart
@@ -1,8 +1,12 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:miria/model/account.dart';
+import 'package:miria/model/acct.dart';
+import 'package:miria/model/tab_icon.dart';
 import 'package:miria/model/tab_setting.dart';
+import 'package:miria/model/tab_type.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class TabSettingsRepository extends ChangeNotifier {
@@ -40,5 +44,28 @@ class TabSettingsRepository extends ChangeNotifier {
     _tabSettings.removeWhere((tabSetting) => tabSetting.acct == account.acct);
     await save(_tabSettings);
     notifyListeners();
+  }
+
+  Future<void> initializeTabSettings(Acct acct) async {
+    await save([
+      TabSetting(
+        icon: TabIcon(codePoint: Icons.home.codePoint),
+        tabType: TabType.homeTimeline,
+        name: "ホームタイムライン",
+        acct: acct,
+      ),
+      TabSetting(
+        icon: TabIcon(codePoint: Icons.public.codePoint),
+        tabType: TabType.localTimeline,
+        name: "ローカルタイムライン",
+        acct: acct,
+      ),
+      TabSetting(
+        icon: TabIcon(codePoint: Icons.rocket_launch.codePoint),
+        tabType: TabType.globalTimeline,
+        name: "グローバルタイムライン",
+        acct: acct,
+      ),
+    ]);
   }
 }

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -15,24 +15,13 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
-    NotesAfterRenoteRoute.name: (routeData) {
-      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
+    AnnouncementRoute.name: (routeData) {
+      final args = routeData.argsAs<AnnouncementRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotesAfterRenotePage(
+        child: AnnouncementPage(
           key: args.key,
-          note: args.note,
           account: args.account,
-        ),
-      );
-    },
-    AntennaRoute.name: (routeData) {
-      final args = routeData.argsAs<AntennaRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: AntennaPage(
-          account: args.account,
-          key: args.key,
         ),
       );
     },
@@ -47,20 +36,35 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    NotificationRoute.name: (routeData) {
-      final args = routeData.argsAs<NotificationRouteArgs>();
+    AntennaRoute.name: (routeData) {
+      final args = routeData.argsAs<AntennaRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotificationPage(
+        child: AntennaPage(
+          account: args.account,
+          key: args.key,
+        ),
+      );
+    },
+    ChannelsRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelsRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ChannelsPage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    LoginRoute.name: (routeData) {
+    ChannelDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const LoginPage(),
+        child: ChannelDetailPage(
+          key: args.key,
+          account: args.account,
+          channelId: args.channelId,
+        ),
       );
     },
     ClipDetailRoute.name: (routeData) {
@@ -84,6 +88,87 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    ExploreRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExplorePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ExploreRoleUsersRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExploreRoleUsersPage(
+          key: args.key,
+          item: args.item,
+          account: args.account,
+        ),
+      );
+    },
+    FavoritedNoteRoute.name: (routeData) {
+      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FavoritedNotePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    FederationRoute.name: (routeData) {
+      final args = routeData.argsAs<FederationRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FederationPage(
+          key: args.key,
+          account: args.account,
+          host: args.host,
+        ),
+      );
+    },
+    HashtagRoute.name: (routeData) {
+      final args = routeData.argsAs<HashtagRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: HashtagPage(
+          key: args.key,
+          hashtag: args.hashtag,
+          account: args.account,
+        ),
+      );
+    },
+    LoginRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const LoginPage(),
+      );
+    },
+    MisskeyRouteRoute.name: (routeData) {
+      final args = routeData.argsAs<MisskeyRouteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: MisskeyPagePage(
+          key: args.key,
+          account: args.account,
+          page: args.page,
+        ),
+      );
+    },
+    NotesAfterRenoteRoute.name: (routeData) {
+      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: NotesAfterRenotePage(
+          key: args.key,
+          note: args.note,
+          account: args.account,
+        ),
+      );
+    },
     NoteCreateRoute.name: (routeData) {
       final args = routeData.argsAs<NoteCreateRouteArgs>();
       return AutoRoutePage<dynamic>(
@@ -101,46 +186,23 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    HashtagRoute.name: (routeData) {
-      final args = routeData.argsAs<HashtagRouteArgs>();
+    NoteDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<NoteDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: HashtagPage(
+        child: NoteDetailPage(
           key: args.key,
-          hashtag: args.hashtag,
+          note: args.note,
           account: args.account,
         ),
       );
     },
-    UserFolloweeRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFolloweeRouteArgs>();
+    NotificationRoute.name: (routeData) {
+      final args = routeData.argsAs<NotificationRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserFolloweePage(
+        child: NotificationPage(
           key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserRoute.name: (routeData) {
-      final args = routeData.argsAs<UserRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserPage(
-          key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserFollowerRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFollowerRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserFollowerPage(
-          key: args.key,
-          userId: args.userId,
           account: args.account,
         ),
       );
@@ -157,20 +219,92 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    AnnouncementRoute.name: (routeData) {
-      final args = routeData.argsAs<AnnouncementRouteArgs>();
+    SearchRoute.name: (routeData) {
+      final args = routeData.argsAs<SearchRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: AnnouncementPage(
+        child: SearchPage(
+          key: args.key,
+          initialSearchText: args.initialSearchText,
+          account: args.account,
+        ),
+      );
+    },
+    AccountListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AccountListPage(),
+      );
+    },
+    AppInfoRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AppInfoPage(),
+      );
+    },
+    GeneralSettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const GeneralSettingsPage(),
+      );
+    },
+    ImportExportRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const ImportExportPage(),
+      );
+    },
+    SettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SettingsPage(),
+      );
+    },
+    TabSettingsListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const TabSettingsListPage(),
+      );
+    },
+    TabSettingsRoute.name: (routeData) {
+      final args = routeData.argsAs<TabSettingsRouteArgs>(
+          orElse: () => const TabSettingsRouteArgs());
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: TabSettingsPage(
+          key: args.key,
+          tabIndex: args.tabIndex,
+        ),
+      );
+    },
+    HardMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<HardMuteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: HardMutePage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    SplashRoute.name: (routeData) {
+    InstanceMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<InstanceMuteRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const SplashPage(),
+        child: InstanceMutePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ReactionDeckRoute.name: (routeData) {
+      final args = routeData.argsAs<ReactionDeckRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ReactionDeckPage(
+          key: args.key,
+          account: args.account,
+        ),
       );
     },
     SeveralAccountGeneralSettingsRoute.name: (routeData) {
@@ -193,54 +327,31 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    InstanceMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<InstanceMuteRouteArgs>();
+    SharingAccountSelectRoute.name: (routeData) {
+      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
+          orElse: () => const SharingAccountSelectRouteArgs());
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: InstanceMutePage(
+        child: SharingAccountSelectPage(
           key: args.key,
-          account: args.account,
+          sharingText: args.sharingText,
+          filePath: args.filePath,
         ),
       );
     },
-    HardMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<HardMuteRouteArgs>();
+    SplashRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: HardMutePage(
-          key: args.key,
-          account: args.account,
-        ),
+        child: const SplashPage(),
       );
     },
-    ReactionDeckRoute.name: (routeData) {
-      final args = routeData.argsAs<ReactionDeckRouteArgs>();
+    TimeLineRoute.name: (routeData) {
+      final args = routeData.argsAs<TimeLineRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ReactionDeckPage(
+        child: TimeLinePage(
           key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    UsersListTimelineRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListTimelineRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UsersListTimelinePage(
-          args.account,
-          args.list,
-          key: args.key,
-        ),
-      );
-    },
-    UsersListRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UsersListPage(
-          args.account,
-          key: args.key,
+          initialTabSetting: args.initialTabSetting,
         ),
       );
     },
@@ -255,167 +366,56 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    ChannelDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelDetailRouteArgs>();
+    UsersListRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ChannelDetailPage(
+        child: UsersListPage(
+          args.account,
           key: args.key,
-          account: args.account,
-          channelId: args.channelId,
         ),
       );
     },
-    ChannelsRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelsRouteArgs>();
+    UsersListTimelineRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListTimelineRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ChannelsPage(
+        child: UsersListTimelinePage(
+          args.account,
+          args.list,
           key: args.key,
-          account: args.account,
         ),
       );
     },
-    FederationRoute.name: (routeData) {
-      final args = routeData.argsAs<FederationRouteArgs>();
+    UserFolloweeRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFolloweeRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: FederationPage(
+        child: UserFolloweePage(
           key: args.key,
-          account: args.account,
-          host: args.host,
-        ),
-      );
-    },
-    NoteDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<NoteDetailRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: NoteDetailPage(
-          key: args.key,
-          note: args.note,
+          userId: args.userId,
           account: args.account,
         ),
       );
     },
-    SearchRoute.name: (routeData) {
-      final args = routeData.argsAs<SearchRouteArgs>();
+    UserFollowerRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFollowerRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: SearchPage(
+        child: UserFollowerPage(
           key: args.key,
-          initialSearchText: args.initialSearchText,
+          userId: args.userId,
           account: args.account,
         ),
       );
     },
-    SharingAccountSelectRoute.name: (routeData) {
-      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
-          orElse: () => const SharingAccountSelectRouteArgs());
+    UserRoute.name: (routeData) {
+      final args = routeData.argsAs<UserRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: SharingAccountSelectPage(
+        child: UserPage(
           key: args.key,
-          sharingText: args.sharingText,
-          filePath: args.filePath,
-        ),
-      );
-    },
-    MisskeyRouteRoute.name: (routeData) {
-      final args = routeData.argsAs<MisskeyRouteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: MisskeyPagePage(
-          key: args.key,
-          account: args.account,
-          page: args.page,
-        ),
-      );
-    },
-    ImportExportRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const ImportExportPage(),
-      );
-    },
-    GeneralSettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const GeneralSettingsPage(),
-      );
-    },
-    TabSettingsRoute.name: (routeData) {
-      final args = routeData.argsAs<TabSettingsRouteArgs>(
-          orElse: () => const TabSettingsRouteArgs());
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TabSettingsPage(
-          key: args.key,
-          tabIndex: args.tabIndex,
-        ),
-      );
-    },
-    TabSettingsListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const TabSettingsListPage(),
-      );
-    },
-    AppInfoRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AppInfoPage(),
-      );
-    },
-    SettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const SettingsPage(),
-      );
-    },
-    AccountListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AccountListPage(),
-      );
-    },
-    ExploreRoleUsersRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExploreRoleUsersPage(
-          key: args.key,
-          item: args.item,
-          account: args.account,
-        ),
-      );
-    },
-    ExploreRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExplorePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    TimeLineRoute.name: (routeData) {
-      final args = routeData.argsAs<TimeLineRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TimeLinePage(
-          key: args.key,
-          initialTabSetting: args.initialTabSetting,
-        ),
-      );
-    },
-    FavoritedNoteRoute.name: (routeData) {
-      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: FavoritedNotePage(
-          key: args.key,
+          userId: args.userId,
           account: args.account,
         ),
       );
@@ -424,83 +424,40 @@ abstract class _$AppRouter extends RootStackRouter {
 }
 
 /// generated route for
-/// [NotesAfterRenotePage]
-class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
-  NotesAfterRenoteRoute({
+/// [AnnouncementPage]
+class AnnouncementRoute extends PageRouteInfo<AnnouncementRouteArgs> {
+  AnnouncementRoute({
     Key? key,
-    required Note note,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotesAfterRenoteRoute.name,
-          args: NotesAfterRenoteRouteArgs(
+          AnnouncementRoute.name,
+          args: AnnouncementRouteArgs(
             key: key,
-            note: note,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotesAfterRenoteRoute';
+  static const String name = 'AnnouncementRoute';
 
-  static const PageInfo<NotesAfterRenoteRouteArgs> page =
-      PageInfo<NotesAfterRenoteRouteArgs>(name);
+  static const PageInfo<AnnouncementRouteArgs> page =
+      PageInfo<AnnouncementRouteArgs>(name);
 }
 
-class NotesAfterRenoteRouteArgs {
-  const NotesAfterRenoteRouteArgs({
+class AnnouncementRouteArgs {
+  const AnnouncementRouteArgs({
     this.key,
-    required this.note,
     required this.account,
   });
 
   final Key? key;
 
-  final Note note;
-
   final Account account;
 
   @override
   String toString() {
-    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
-  }
-}
-
-/// generated route for
-/// [AntennaPage]
-class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
-  AntennaRoute({
-    required Account account,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          AntennaRoute.name,
-          args: AntennaRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'AntennaRoute';
-
-  static const PageInfo<AntennaRouteArgs> page =
-      PageInfo<AntennaRouteArgs>(name);
-}
-
-class AntennaRouteArgs {
-  const AntennaRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'AntennaRouteArgs{account: $account, key: $key}';
+    return 'AnnouncementRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -548,29 +505,67 @@ class AntennaNotesRouteArgs {
 }
 
 /// generated route for
-/// [NotificationPage]
-class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
-  NotificationRoute({
+/// [AntennaPage]
+class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
+  AntennaRoute({
+    required Account account,
+    Key? key,
+    List<PageRouteInfo>? children,
+  }) : super(
+          AntennaRoute.name,
+          args: AntennaRouteArgs(
+            account: account,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'AntennaRoute';
+
+  static const PageInfo<AntennaRouteArgs> page =
+      PageInfo<AntennaRouteArgs>(name);
+}
+
+class AntennaRouteArgs {
+  const AntennaRouteArgs({
+    required this.account,
+    this.key,
+  });
+
+  final Account account;
+
+  final Key? key;
+
+  @override
+  String toString() {
+    return 'AntennaRouteArgs{account: $account, key: $key}';
+  }
+}
+
+/// generated route for
+/// [ChannelsPage]
+class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
+  ChannelsRoute({
     Key? key,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotificationRoute.name,
-          args: NotificationRouteArgs(
+          ChannelsRoute.name,
+          args: ChannelsRouteArgs(
             key: key,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotificationRoute';
+  static const String name = 'ChannelsRoute';
 
-  static const PageInfo<NotificationRouteArgs> page =
-      PageInfo<NotificationRouteArgs>(name);
+  static const PageInfo<ChannelsRouteArgs> page =
+      PageInfo<ChannelsRouteArgs>(name);
 }
 
-class NotificationRouteArgs {
-  const NotificationRouteArgs({
+class ChannelsRouteArgs {
+  const ChannelsRouteArgs({
     this.key,
     required this.account,
   });
@@ -581,22 +576,51 @@ class NotificationRouteArgs {
 
   @override
   String toString() {
-    return 'NotificationRouteArgs{key: $key, account: $account}';
+    return 'ChannelsRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [LoginPage]
-class LoginRoute extends PageRouteInfo<void> {
-  const LoginRoute({List<PageRouteInfo>? children})
-      : super(
-          LoginRoute.name,
+/// [ChannelDetailPage]
+class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
+  ChannelDetailRoute({
+    Key? key,
+    required Account account,
+    required String channelId,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ChannelDetailRoute.name,
+          args: ChannelDetailRouteArgs(
+            key: key,
+            account: account,
+            channelId: channelId,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'LoginRoute';
+  static const String name = 'ChannelDetailRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static const PageInfo<ChannelDetailRouteArgs> page =
+      PageInfo<ChannelDetailRouteArgs>(name);
+}
+
+class ChannelDetailRouteArgs {
+  const ChannelDetailRouteArgs({
+    this.key,
+    required this.account,
+    required this.channelId,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String channelId;
+
+  @override
+  String toString() {
+    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
+  }
 }
 
 /// generated route for
@@ -681,6 +705,311 @@ class ClipListRouteArgs {
 }
 
 /// generated route for
+/// [ExplorePage]
+class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
+  ExploreRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoute.name,
+          args: ExploreRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoute';
+
+  static const PageInfo<ExploreRouteArgs> page =
+      PageInfo<ExploreRouteArgs>(name);
+}
+
+class ExploreRouteArgs {
+  const ExploreRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ExploreRoleUsersPage]
+class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
+  ExploreRoleUsersRoute({
+    Key? key,
+    required RolesListResponse item,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoleUsersRoute.name,
+          args: ExploreRoleUsersRouteArgs(
+            key: key,
+            item: item,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoleUsersRoute';
+
+  static const PageInfo<ExploreRoleUsersRouteArgs> page =
+      PageInfo<ExploreRoleUsersRouteArgs>(name);
+}
+
+class ExploreRoleUsersRouteArgs {
+  const ExploreRoleUsersRouteArgs({
+    this.key,
+    required this.item,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final RolesListResponse item;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FavoritedNotePage]
+class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
+  FavoritedNoteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FavoritedNoteRoute.name,
+          args: FavoritedNoteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FavoritedNoteRoute';
+
+  static const PageInfo<FavoritedNoteRouteArgs> page =
+      PageInfo<FavoritedNoteRouteArgs>(name);
+}
+
+class FavoritedNoteRouteArgs {
+  const FavoritedNoteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FederationPage]
+class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
+  FederationRoute({
+    Key? key,
+    required Account account,
+    required String host,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FederationRoute.name,
+          args: FederationRouteArgs(
+            key: key,
+            account: account,
+            host: host,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FederationRoute';
+
+  static const PageInfo<FederationRouteArgs> page =
+      PageInfo<FederationRouteArgs>(name);
+}
+
+class FederationRouteArgs {
+  const FederationRouteArgs({
+    this.key,
+    required this.account,
+    required this.host,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String host;
+
+  @override
+  String toString() {
+    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
+  }
+}
+
+/// generated route for
+/// [HashtagPage]
+class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
+  HashtagRoute({
+    Key? key,
+    required String hashtag,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          HashtagRoute.name,
+          args: HashtagRouteArgs(
+            key: key,
+            hashtag: hashtag,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'HashtagRoute';
+
+  static const PageInfo<HashtagRouteArgs> page =
+      PageInfo<HashtagRouteArgs>(name);
+}
+
+class HashtagRouteArgs {
+  const HashtagRouteArgs({
+    this.key,
+    required this.hashtag,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String hashtag;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+  }
+}
+
+/// generated route for
+/// [LoginPage]
+class LoginRoute extends PageRouteInfo<void> {
+  const LoginRoute({List<PageRouteInfo>? children})
+      : super(
+          LoginRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'LoginRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [MisskeyPagePage]
+class MisskeyRouteRoute extends PageRouteInfo<MisskeyRouteRouteArgs> {
+  MisskeyRouteRoute({
+    Key? key,
+    required Account account,
+    required Page page,
+    List<PageRouteInfo>? children,
+  }) : super(
+          MisskeyRouteRoute.name,
+          args: MisskeyRouteRouteArgs(
+            key: key,
+            account: account,
+            page: page,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'MisskeyRouteRoute';
+
+  static const PageInfo<MisskeyRouteRouteArgs> page =
+      PageInfo<MisskeyRouteRouteArgs>(name);
+}
+
+class MisskeyRouteRouteArgs {
+  const MisskeyRouteRouteArgs({
+    this.key,
+    required this.account,
+    required this.page,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final Page page;
+
+  @override
+  String toString() {
+    return 'MisskeyRouteRouteArgs{key: $key, account: $account, page: $page}';
+  }
+}
+
+/// generated route for
+/// [NotesAfterRenotePage]
+class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
+  NotesAfterRenoteRoute({
+    Key? key,
+    required Note note,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          NotesAfterRenoteRoute.name,
+          args: NotesAfterRenoteRouteArgs(
+            key: key,
+            note: note,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'NotesAfterRenoteRoute';
+
+  static const PageInfo<NotesAfterRenoteRouteArgs> page =
+      PageInfo<NotesAfterRenoteRouteArgs>(name);
+}
+
+class NotesAfterRenoteRouteArgs {
+  const NotesAfterRenoteRouteArgs({
+    this.key,
+    required this.note,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Note note;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
+  }
+}
+
+/// generated route for
 /// [NoteCreatePage]
 class NoteCreateRoute extends PageRouteInfo<NoteCreateRouteArgs> {
   NoteCreateRoute({
@@ -754,173 +1083,83 @@ class NoteCreateRouteArgs {
 }
 
 /// generated route for
-/// [HashtagPage]
-class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
-  HashtagRoute({
+/// [NoteDetailPage]
+class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
+  NoteDetailRoute({
     Key? key,
-    required String hashtag,
+    required Note note,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          HashtagRoute.name,
-          args: HashtagRouteArgs(
+          NoteDetailRoute.name,
+          args: NoteDetailRouteArgs(
             key: key,
-            hashtag: hashtag,
+            note: note,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'HashtagRoute';
+  static const String name = 'NoteDetailRoute';
 
-  static const PageInfo<HashtagRouteArgs> page =
-      PageInfo<HashtagRouteArgs>(name);
+  static const PageInfo<NoteDetailRouteArgs> page =
+      PageInfo<NoteDetailRouteArgs>(name);
 }
 
-class HashtagRouteArgs {
-  const HashtagRouteArgs({
+class NoteDetailRouteArgs {
+  const NoteDetailRouteArgs({
     this.key,
-    required this.hashtag,
+    required this.note,
     required this.account,
   });
 
   final Key? key;
 
-  final String hashtag;
+  final Note note;
 
   final Account account;
 
   @override
   String toString() {
-    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
   }
 }
 
 /// generated route for
-/// [UserFolloweePage]
-class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
-  UserFolloweeRoute({
+/// [NotificationPage]
+class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
+  NotificationRoute({
     Key? key,
-    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          UserFolloweeRoute.name,
-          args: UserFolloweeRouteArgs(
+          NotificationRoute.name,
+          args: NotificationRouteArgs(
             key: key,
-            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UserFolloweeRoute';
+  static const String name = 'NotificationRoute';
 
-  static const PageInfo<UserFolloweeRouteArgs> page =
-      PageInfo<UserFolloweeRouteArgs>(name);
+  static const PageInfo<NotificationRouteArgs> page =
+      PageInfo<NotificationRouteArgs>(name);
 }
 
-class UserFolloweeRouteArgs {
-  const UserFolloweeRouteArgs({
+class NotificationRouteArgs {
+  const NotificationRouteArgs({
     this.key,
-    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String userId;
-
   final Account account;
 
   @override
   String toString() {
-    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserPage]
-class UserRoute extends PageRouteInfo<UserRouteArgs> {
-  UserRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserRoute.name,
-          args: UserRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserRoute';
-
-  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
-}
-
-class UserRouteArgs {
-  const UserRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserFollowerPage]
-class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
-  UserFollowerRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserFollowerRoute.name,
-          args: UserFollowerRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserFollowerRoute';
-
-  static const PageInfo<UserFollowerRouteArgs> page =
-      PageInfo<UserFollowerRouteArgs>(name);
-}
-
-class UserFollowerRouteArgs {
-  const UserFollowerRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
+    return 'NotificationRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -973,29 +1212,193 @@ class PhotoEditRouteArgs {
 }
 
 /// generated route for
-/// [AnnouncementPage]
-class AnnouncementRoute extends PageRouteInfo<AnnouncementRouteArgs> {
-  AnnouncementRoute({
+/// [SearchPage]
+class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
+  SearchRoute({
+    Key? key,
+    String? initialSearchText,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          SearchRoute.name,
+          args: SearchRouteArgs(
+            key: key,
+            initialSearchText: initialSearchText,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'SearchRoute';
+
+  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+}
+
+class SearchRouteArgs {
+  const SearchRouteArgs({
+    this.key,
+    this.initialSearchText,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String? initialSearchText;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
+  }
+}
+
+/// generated route for
+/// [AccountListPage]
+class AccountListRoute extends PageRouteInfo<void> {
+  const AccountListRoute({List<PageRouteInfo>? children})
+      : super(
+          AccountListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AccountListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [AppInfoPage]
+class AppInfoRoute extends PageRouteInfo<void> {
+  const AppInfoRoute({List<PageRouteInfo>? children})
+      : super(
+          AppInfoRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AppInfoRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [GeneralSettingsPage]
+class GeneralSettingsRoute extends PageRouteInfo<void> {
+  const GeneralSettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          GeneralSettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'GeneralSettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [ImportExportPage]
+class ImportExportRoute extends PageRouteInfo<void> {
+  const ImportExportRoute({List<PageRouteInfo>? children})
+      : super(
+          ImportExportRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'ImportExportRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [SettingsPage]
+class SettingsRoute extends PageRouteInfo<void> {
+  const SettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          SettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsListPage]
+class TabSettingsListRoute extends PageRouteInfo<void> {
+  const TabSettingsListRoute({List<PageRouteInfo>? children})
+      : super(
+          TabSettingsListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsPage]
+class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
+  TabSettingsRoute({
+    Key? key,
+    int? tabIndex,
+    List<PageRouteInfo>? children,
+  }) : super(
+          TabSettingsRoute.name,
+          args: TabSettingsRouteArgs(
+            key: key,
+            tabIndex: tabIndex,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsRoute';
+
+  static const PageInfo<TabSettingsRouteArgs> page =
+      PageInfo<TabSettingsRouteArgs>(name);
+}
+
+class TabSettingsRouteArgs {
+  const TabSettingsRouteArgs({
+    this.key,
+    this.tabIndex,
+  });
+
+  final Key? key;
+
+  final int? tabIndex;
+
+  @override
+  String toString() {
+    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
+  }
+}
+
+/// generated route for
+/// [HardMutePage]
+class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
+  HardMuteRoute({
     Key? key,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          AnnouncementRoute.name,
-          args: AnnouncementRouteArgs(
+          HardMuteRoute.name,
+          args: HardMuteRouteArgs(
             key: key,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'AnnouncementRoute';
+  static const String name = 'HardMuteRoute';
 
-  static const PageInfo<AnnouncementRouteArgs> page =
-      PageInfo<AnnouncementRouteArgs>(name);
+  static const PageInfo<HardMuteRouteArgs> page =
+      PageInfo<HardMuteRouteArgs>(name);
 }
 
-class AnnouncementRouteArgs {
-  const AnnouncementRouteArgs({
+class HardMuteRouteArgs {
+  const HardMuteRouteArgs({
     this.key,
     required this.account,
   });
@@ -1006,22 +1409,84 @@ class AnnouncementRouteArgs {
 
   @override
   String toString() {
-    return 'AnnouncementRouteArgs{key: $key, account: $account}';
+    return 'HardMuteRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [SplashPage]
-class SplashRoute extends PageRouteInfo<void> {
-  const SplashRoute({List<PageRouteInfo>? children})
-      : super(
-          SplashRoute.name,
+/// [InstanceMutePage]
+class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
+  InstanceMuteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          InstanceMuteRoute.name,
+          args: InstanceMuteRouteArgs(
+            key: key,
+            account: account,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'SplashRoute';
+  static const String name = 'InstanceMuteRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static const PageInfo<InstanceMuteRouteArgs> page =
+      PageInfo<InstanceMuteRouteArgs>(name);
+}
+
+class InstanceMuteRouteArgs {
+  const InstanceMuteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ReactionDeckPage]
+class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
+  ReactionDeckRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ReactionDeckRoute.name,
+          args: ReactionDeckRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ReactionDeckRoute';
+
+  static const PageInfo<ReactionDeckRouteArgs> page =
+      PageInfo<ReactionDeckRouteArgs>(name);
+}
+
+class ReactionDeckRouteArgs {
+  const ReactionDeckRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
+  }
 }
 
 /// generated route for
@@ -1103,197 +1568,98 @@ class SeveralAccountSettingsRouteArgs {
 }
 
 /// generated route for
-/// [InstanceMutePage]
-class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
-  InstanceMuteRoute({
+/// [SharingAccountSelectPage]
+class SharingAccountSelectRoute
+    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
+  SharingAccountSelectRoute({
     Key? key,
-    required Account account,
+    String? sharingText,
+    List<String>? filePath,
     List<PageRouteInfo>? children,
   }) : super(
-          InstanceMuteRoute.name,
-          args: InstanceMuteRouteArgs(
+          SharingAccountSelectRoute.name,
+          args: SharingAccountSelectRouteArgs(
             key: key,
-            account: account,
+            sharingText: sharingText,
+            filePath: filePath,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'InstanceMuteRoute';
+  static const String name = 'SharingAccountSelectRoute';
 
-  static const PageInfo<InstanceMuteRouteArgs> page =
-      PageInfo<InstanceMuteRouteArgs>(name);
+  static const PageInfo<SharingAccountSelectRouteArgs> page =
+      PageInfo<SharingAccountSelectRouteArgs>(name);
 }
 
-class InstanceMuteRouteArgs {
-  const InstanceMuteRouteArgs({
+class SharingAccountSelectRouteArgs {
+  const SharingAccountSelectRouteArgs({
     this.key,
-    required this.account,
+    this.sharingText,
+    this.filePath,
   });
 
   final Key? key;
 
-  final Account account;
+  final String? sharingText;
+
+  final List<String>? filePath;
 
   @override
   String toString() {
-    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
   }
 }
 
 /// generated route for
-/// [HardMutePage]
-class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
-  HardMuteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          HardMuteRoute.name,
-          args: HardMuteRouteArgs(
-            key: key,
-            account: account,
-          ),
+/// [SplashPage]
+class SplashRoute extends PageRouteInfo<void> {
+  const SplashRoute({List<PageRouteInfo>? children})
+      : super(
+          SplashRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'HardMuteRoute';
+  static const String name = 'SplashRoute';
 
-  static const PageInfo<HardMuteRouteArgs> page =
-      PageInfo<HardMuteRouteArgs>(name);
-}
-
-class HardMuteRouteArgs {
-  const HardMuteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'HardMuteRouteArgs{key: $key, account: $account}';
-  }
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for
-/// [ReactionDeckPage]
-class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
-  ReactionDeckRoute({
+/// [TimeLinePage]
+class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
+  TimeLineRoute({
     Key? key,
-    required Account account,
+    required TabSetting initialTabSetting,
     List<PageRouteInfo>? children,
   }) : super(
-          ReactionDeckRoute.name,
-          args: ReactionDeckRouteArgs(
+          TimeLineRoute.name,
+          args: TimeLineRouteArgs(
             key: key,
-            account: account,
+            initialTabSetting: initialTabSetting,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ReactionDeckRoute';
+  static const String name = 'TimeLineRoute';
 
-  static const PageInfo<ReactionDeckRouteArgs> page =
-      PageInfo<ReactionDeckRouteArgs>(name);
+  static const PageInfo<TimeLineRouteArgs> page =
+      PageInfo<TimeLineRouteArgs>(name);
 }
 
-class ReactionDeckRouteArgs {
-  const ReactionDeckRouteArgs({
+class TimeLineRouteArgs {
+  const TimeLineRouteArgs({
     this.key,
-    required this.account,
+    required this.initialTabSetting,
   });
 
   final Key? key;
 
-  final Account account;
+  final TabSetting initialTabSetting;
 
   @override
   String toString() {
-    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UsersListTimelinePage]
-class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
-  UsersListTimelineRoute({
-    required Account account,
-    required UsersList list,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListTimelineRoute.name,
-          args: UsersListTimelineRouteArgs(
-            account: account,
-            list: list,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListTimelineRoute';
-
-  static const PageInfo<UsersListTimelineRouteArgs> page =
-      PageInfo<UsersListTimelineRouteArgs>(name);
-}
-
-class UsersListTimelineRouteArgs {
-  const UsersListTimelineRouteArgs({
-    required this.account,
-    required this.list,
-    this.key,
-  });
-
-  final Account account;
-
-  final UsersList list;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'UsersListTimelineRouteArgs{account: $account, list: $list, key: $key}';
-  }
-}
-
-/// generated route for
-/// [UsersListPage]
-class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
-  UsersListRoute({
-    required Account account,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListRoute.name,
-          args: UsersListRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListRoute';
-
-  static const PageInfo<UsersListRouteArgs> page =
-      PageInfo<UsersListRouteArgs>(name);
-}
-
-class UsersListRouteArgs {
-  const UsersListRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'UsersListRouteArgs{account: $account, key: $key}';
+    return 'TimeLineRouteArgs{key: $key, initialTabSetting: $initialTabSetting}';
   }
 }
 
@@ -1341,576 +1707,210 @@ class UsersListDetailRouteArgs {
 }
 
 /// generated route for
-/// [ChannelDetailPage]
-class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
-  ChannelDetailRoute({
-    Key? key,
+/// [UsersListPage]
+class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
+  UsersListRoute({
     required Account account,
-    required String channelId,
+    Key? key,
     List<PageRouteInfo>? children,
   }) : super(
-          ChannelDetailRoute.name,
-          args: ChannelDetailRouteArgs(
-            key: key,
+          UsersListRoute.name,
+          args: UsersListRouteArgs(
             account: account,
-            channelId: channelId,
+            key: key,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ChannelDetailRoute';
+  static const String name = 'UsersListRoute';
 
-  static const PageInfo<ChannelDetailRouteArgs> page =
-      PageInfo<ChannelDetailRouteArgs>(name);
+  static const PageInfo<UsersListRouteArgs> page =
+      PageInfo<UsersListRouteArgs>(name);
 }
 
-class ChannelDetailRouteArgs {
-  const ChannelDetailRouteArgs({
-    this.key,
+class UsersListRouteArgs {
+  const UsersListRouteArgs({
     required this.account,
-    required this.channelId,
+    this.key,
   });
-
-  final Key? key;
 
   final Account account;
 
-  final String channelId;
+  final Key? key;
 
   @override
   String toString() {
-    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
+    return 'UsersListRouteArgs{account: $account, key: $key}';
   }
 }
 
 /// generated route for
-/// [ChannelsPage]
-class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
-  ChannelsRoute({
-    Key? key,
+/// [UsersListTimelinePage]
+class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
+  UsersListTimelineRoute({
     required Account account,
+    required UsersList list,
+    Key? key,
     List<PageRouteInfo>? children,
   }) : super(
-          ChannelsRoute.name,
-          args: ChannelsRouteArgs(
-            key: key,
+          UsersListTimelineRoute.name,
+          args: UsersListTimelineRouteArgs(
             account: account,
+            list: list,
+            key: key,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ChannelsRoute';
+  static const String name = 'UsersListTimelineRoute';
 
-  static const PageInfo<ChannelsRouteArgs> page =
-      PageInfo<ChannelsRouteArgs>(name);
+  static const PageInfo<UsersListTimelineRouteArgs> page =
+      PageInfo<UsersListTimelineRouteArgs>(name);
 }
 
-class ChannelsRouteArgs {
-  const ChannelsRouteArgs({
-    this.key,
+class UsersListTimelineRouteArgs {
+  const UsersListTimelineRouteArgs({
     required this.account,
+    required this.list,
+    this.key,
   });
-
-  final Key? key;
 
   final Account account;
 
+  final UsersList list;
+
+  final Key? key;
+
   @override
   String toString() {
-    return 'ChannelsRouteArgs{key: $key, account: $account}';
+    return 'UsersListTimelineRouteArgs{account: $account, list: $list, key: $key}';
   }
 }
 
 /// generated route for
-/// [FederationPage]
-class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
-  FederationRoute({
+/// [UserFolloweePage]
+class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
+  UserFolloweeRoute({
     Key? key,
-    required Account account,
-    required String host,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FederationRoute.name,
-          args: FederationRouteArgs(
-            key: key,
-            account: account,
-            host: host,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FederationRoute';
-
-  static const PageInfo<FederationRouteArgs> page =
-      PageInfo<FederationRouteArgs>(name);
-}
-
-class FederationRouteArgs {
-  const FederationRouteArgs({
-    this.key,
-    required this.account,
-    required this.host,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String host;
-
-  @override
-  String toString() {
-    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
-  }
-}
-
-/// generated route for
-/// [NoteDetailPage]
-class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
-  NoteDetailRoute({
-    Key? key,
-    required Note note,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NoteDetailRoute.name,
-          args: NoteDetailRouteArgs(
+          UserFolloweeRoute.name,
+          args: UserFolloweeRouteArgs(
             key: key,
-            note: note,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NoteDetailRoute';
+  static const String name = 'UserFolloweeRoute';
 
-  static const PageInfo<NoteDetailRouteArgs> page =
-      PageInfo<NoteDetailRouteArgs>(name);
+  static const PageInfo<UserFolloweeRouteArgs> page =
+      PageInfo<UserFolloweeRouteArgs>(name);
 }
 
-class NoteDetailRouteArgs {
-  const NoteDetailRouteArgs({
+class UserFolloweeRouteArgs {
+  const UserFolloweeRouteArgs({
     this.key,
-    required this.note,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final Note note;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
+    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }
 
 /// generated route for
-/// [SearchPage]
-class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
-  SearchRoute({
+/// [UserFollowerPage]
+class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
+  UserFollowerRoute({
     Key? key,
-    String? initialSearchText,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          SearchRoute.name,
-          args: SearchRouteArgs(
+          UserFollowerRoute.name,
+          args: UserFollowerRouteArgs(
             key: key,
-            initialSearchText: initialSearchText,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'SearchRoute';
+  static const String name = 'UserFollowerRoute';
 
-  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+  static const PageInfo<UserFollowerRouteArgs> page =
+      PageInfo<UserFollowerRouteArgs>(name);
 }
 
-class SearchRouteArgs {
-  const SearchRouteArgs({
+class UserFollowerRouteArgs {
+  const UserFollowerRouteArgs({
     this.key,
-    this.initialSearchText,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String? initialSearchText;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
+    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }
 
 /// generated route for
-/// [SharingAccountSelectPage]
-class SharingAccountSelectRoute
-    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
-  SharingAccountSelectRoute({
+/// [UserPage]
+class UserRoute extends PageRouteInfo<UserRouteArgs> {
+  UserRoute({
     Key? key,
-    String? sharingText,
-    List<String>? filePath,
-    List<PageRouteInfo>? children,
-  }) : super(
-          SharingAccountSelectRoute.name,
-          args: SharingAccountSelectRouteArgs(
-            key: key,
-            sharingText: sharingText,
-            filePath: filePath,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'SharingAccountSelectRoute';
-
-  static const PageInfo<SharingAccountSelectRouteArgs> page =
-      PageInfo<SharingAccountSelectRouteArgs>(name);
-}
-
-class SharingAccountSelectRouteArgs {
-  const SharingAccountSelectRouteArgs({
-    this.key,
-    this.sharingText,
-    this.filePath,
-  });
-
-  final Key? key;
-
-  final String? sharingText;
-
-  final List<String>? filePath;
-
-  @override
-  String toString() {
-    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
-  }
-}
-
-/// generated route for
-/// [MisskeyPagePage]
-class MisskeyRouteRoute extends PageRouteInfo<MisskeyRouteRouteArgs> {
-  MisskeyRouteRoute({
-    Key? key,
-    required Account account,
-    required Page page,
-    List<PageRouteInfo>? children,
-  }) : super(
-          MisskeyRouteRoute.name,
-          args: MisskeyRouteRouteArgs(
-            key: key,
-            account: account,
-            page: page,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'MisskeyRouteRoute';
-
-  static const PageInfo<MisskeyRouteRouteArgs> page =
-      PageInfo<MisskeyRouteRouteArgs>(name);
-}
-
-class MisskeyRouteRouteArgs {
-  const MisskeyRouteRouteArgs({
-    this.key,
-    required this.account,
-    required this.page,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final Page page;
-
-  @override
-  String toString() {
-    return 'MisskeyRouteRouteArgs{key: $key, account: $account, page: $page}';
-  }
-}
-
-/// generated route for
-/// [ImportExportPage]
-class ImportExportRoute extends PageRouteInfo<void> {
-  const ImportExportRoute({List<PageRouteInfo>? children})
-      : super(
-          ImportExportRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'ImportExportRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [GeneralSettingsPage]
-class GeneralSettingsRoute extends PageRouteInfo<void> {
-  const GeneralSettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          GeneralSettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'GeneralSettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [TabSettingsPage]
-class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
-  TabSettingsRoute({
-    Key? key,
-    int? tabIndex,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TabSettingsRoute.name,
-          args: TabSettingsRouteArgs(
-            key: key,
-            tabIndex: tabIndex,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsRoute';
-
-  static const PageInfo<TabSettingsRouteArgs> page =
-      PageInfo<TabSettingsRouteArgs>(name);
-}
-
-class TabSettingsRouteArgs {
-  const TabSettingsRouteArgs({
-    this.key,
-    this.tabIndex,
-  });
-
-  final Key? key;
-
-  final int? tabIndex;
-
-  @override
-  String toString() {
-    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
-  }
-}
-
-/// generated route for
-/// [TabSettingsListPage]
-class TabSettingsListRoute extends PageRouteInfo<void> {
-  const TabSettingsListRoute({List<PageRouteInfo>? children})
-      : super(
-          TabSettingsListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AppInfoPage]
-class AppInfoRoute extends PageRouteInfo<void> {
-  const AppInfoRoute({List<PageRouteInfo>? children})
-      : super(
-          AppInfoRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AppInfoRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [SettingsPage]
-class SettingsRoute extends PageRouteInfo<void> {
-  const SettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          SettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'SettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AccountListPage]
-class AccountListRoute extends PageRouteInfo<void> {
-  const AccountListRoute({List<PageRouteInfo>? children})
-      : super(
-          AccountListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AccountListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [ExploreRoleUsersPage]
-class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
-  ExploreRoleUsersRoute({
-    Key? key,
-    required RolesListResponse item,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          ExploreRoleUsersRoute.name,
-          args: ExploreRoleUsersRouteArgs(
+          UserRoute.name,
+          args: UserRouteArgs(
             key: key,
-            item: item,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ExploreRoleUsersRoute';
+  static const String name = 'UserRoute';
 
-  static const PageInfo<ExploreRoleUsersRouteArgs> page =
-      PageInfo<ExploreRoleUsersRouteArgs>(name);
+  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
 }
 
-class ExploreRoleUsersRouteArgs {
-  const ExploreRoleUsersRouteArgs({
+class UserRouteArgs {
+  const UserRouteArgs({
     this.key,
-    required this.item,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final RolesListResponse item;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ExplorePage]
-class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
-  ExploreRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoute.name,
-          args: ExploreRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoute';
-
-  static const PageInfo<ExploreRouteArgs> page =
-      PageInfo<ExploreRouteArgs>(name);
-}
-
-class ExploreRouteArgs {
-  const ExploreRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [TimeLinePage]
-class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
-  TimeLineRoute({
-    Key? key,
-    required TabSetting initialTabSetting,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TimeLineRoute.name,
-          args: TimeLineRouteArgs(
-            key: key,
-            initialTabSetting: initialTabSetting,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TimeLineRoute';
-
-  static const PageInfo<TimeLineRouteArgs> page =
-      PageInfo<TimeLineRouteArgs>(name);
-}
-
-class TimeLineRouteArgs {
-  const TimeLineRouteArgs({
-    this.key,
-    required this.initialTabSetting,
-  });
-
-  final Key? key;
-
-  final TabSetting initialTabSetting;
-
-  @override
-  String toString() {
-    return 'TimeLineRouteArgs{key: $key, initialTabSetting: $initialTabSetting}';
-  }
-}
-
-/// generated route for
-/// [FavoritedNotePage]
-class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
-  FavoritedNoteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FavoritedNoteRoute.name,
-          args: FavoritedNoteRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FavoritedNoteRoute';
-
-  static const PageInfo<FavoritedNoteRouteArgs> page =
-      PageInfo<FavoritedNoteRouteArgs>(name);
-}
-
-class FavoritedNoteRouteArgs {
-  const FavoritedNoteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
+    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }

--- a/lib/view/common/common_drawer.dart
+++ b/lib/view/common/common_drawer.dart
@@ -15,104 +15,115 @@ class CommonDrawer extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final accounts = ref.watch(accountsProvider);
+
     return Drawer(
       child: Padding(
         padding: const EdgeInsets.all(5),
         child: ListView(
           children: [
-            for (final account in ref.read(accountRepository).account) ...[
+            for (final account in accounts) ...[
               AccountScope(
                 account: account,
                 child: ExpansionTile(
-                    leading: AvatarIcon.fromIResponse(account.i),
-                    initiallyExpanded: account.acct == initialOpenAcct,
-                    title: SimpleMfmText(account.i.name ?? account.i.username,
-                        style: Theme.of(context).textTheme.titleMedium),
-                    subtitle: Text(
-                      "@${account.userId}@${account.host}",
-                      style: Theme.of(context).textTheme.bodySmall,
+                  leading: AvatarIcon.fromIResponse(account.i),
+                  initiallyExpanded: account.acct == initialOpenAcct,
+                  title: SimpleMfmText(
+                    account.i.name ?? account.i.username,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  subtitle: Text(
+                    account.acct.toString(),
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  children: [
+                    ListTile(
+                      leading: const Icon(Icons.notifications),
+                      title: const Text("通知"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(NotificationRoute(account: account));
+                      },
                     ),
-                    children: [
-                      ListTile(
-                          leading: const Icon(Icons.notifications),
-                          title: const Text("通知"),
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            context
-                                .pushRoute(NotificationRoute(account: account));
-                          }),
-                      ListTile(
-                        leading: const Icon(Icons.star),
-                        title: const Text("お気に入り"),
-                        onTap: () {
-                          Navigator.of(context).pop();
-                          context
-                              .pushRoute(FavoritedNoteRoute(account: account));
-                        },
-                      ),
-                      ListTile(
-                          leading: const Icon(Icons.list),
-                          title: const Text("リスト"),
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            context.pushRoute(UsersListRoute(account: account));
-                          }),
-                      ListTile(
-                          leading: const Icon(Icons.settings_input_antenna),
-                          title: const Text("アンテナ"),
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            context.pushRoute(AntennaRoute(account: account));
-                          }),
-                      ListTile(
-                          leading: const Icon(Icons.attach_file),
-                          title: const Text("クリップ"),
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            context.pushRoute(ClipListRoute(account: account));
-                          }),
-                      ListTile(
-                          leading: const Icon(Icons.tv),
-                          title: const Text("チャンネル"),
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            context.pushRoute(ChannelsRoute(account: account));
-                          }),
-                      ListTile(
-                          leading: const Icon(Icons.search),
-                          title: const Text("検索"),
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            context.pushRoute(SearchRoute(account: account));
-                          }),
-                      ListTile(
-                        leading: const Icon(Icons.tag),
-                        title: const Text("みつける"),
-                        onTap: () {
-                          Navigator.of(context).pop();
-                          context.pushRoute(ExploreRoute(account: account));
-                        },
-                      ),
-                      ListTile(
-                        leading: const Icon(Icons.settings),
-                        title:
-                            Text("${account.i.name ?? account.i.username} の設定"),
-                        onTap: () {
-                          Navigator.of(context).pop();
-                          context.pushRoute(
-                              SeveralAccountSettingsRoute(account: account));
-                        },
-                      )
-                    ]),
-              )
+                    ListTile(
+                      leading: const Icon(Icons.star),
+                      title: const Text("お気に入り"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(FavoritedNoteRoute(account: account));
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.list),
+                      title: const Text("リスト"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(UsersListRoute(account: account));
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.settings_input_antenna),
+                      title: const Text("アンテナ"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(AntennaRoute(account: account));
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.attach_file),
+                      title: const Text("クリップ"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(ClipListRoute(account: account));
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.tv),
+                      title: const Text("チャンネル"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(ChannelsRoute(account: account));
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.search),
+                      title: const Text("検索"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(SearchRoute(account: account));
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.tag),
+                      title: const Text("みつける"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(ExploreRoute(account: account));
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.settings),
+                      title:
+                          Text("${account.i.name ?? account.i.username} の設定"),
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        context.pushRoute(
+                          SeveralAccountSettingsRoute(account: account),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
             ],
             ListTile(
-                leading: const Icon(Icons.settings),
-                title: const Text("設定"),
-                onTap: () {
-                  Navigator.of(context).pop();
-                  context.pushRoute(const SettingsRoute());
-                }),
+              leading: const Icon(Icons.settings),
+              title: const Text("設定"),
+              onTap: () {
+                Navigator.of(context).pop();
+                context.pushRoute(const SettingsRoute());
+              },
+            ),
           ],
         ),
       ),

--- a/lib/view/common/main_stream.dart
+++ b/lib/view/common/main_stream.dart
@@ -21,8 +21,7 @@ class MainStreamState extends ConsumerState<MainStream> {
 
   @override
   Widget build(BuildContext context) {
-    final accounts =
-        ref.watch(accountRepository.select((value) => value.account));
+    final accounts = ref.watch(accountsProvider);
 
     if (isConnected) {
       for (final account in accounts) {

--- a/lib/view/common/misskey_notes/open_another_account.dart
+++ b/lib/view/common/misskey_notes/open_another_account.dart
@@ -91,8 +91,7 @@ class AccountSelectDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final accounts =
-        ref.watch(accountRepository.select((value) => value.account));
+    final accounts = ref.watch(accountsProvider);
     return AlertDialog(
       title: const Text("開くアカウント選んでや"),
       content: SizedBox(
@@ -108,7 +107,7 @@ class AccountSelectDialog extends ConsumerWidget {
                   title: SimpleMfmText(account.i.name ?? account.i.username,
                       style: Theme.of(context).textTheme.titleMedium),
                   subtitle: Text(
-                    "@${account.userId}@${account.host}",
+                    account.acct.toString(),
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                   onTap: () {

--- a/lib/view/common/sharing_intent_listener.dart
+++ b/lib/view/common/sharing_intent_listener.dart
@@ -69,7 +69,7 @@ class SharingIntentListenerState extends ConsumerState<SharingIntentListener> {
 
   @override
   Widget build(BuildContext context) {
-    account = ref.watch(accountRepository.select((value) => value.account));
+    account = ref.watch(accountsProvider);
     return widget.child;
   }
 }

--- a/lib/view/login_page/api_key_login.dart
+++ b/lib/view/login_page/api_key_login.dart
@@ -30,7 +30,7 @@ class APiKeyLoginState extends ConsumerState<ApiKeyLogin> {
     try {
       IndicatorView.showIndicator(context);
       await ref
-          .read(accountRepository)
+          .read(accountRepositoryProvider.notifier)
           .loginAsToken(serverController.text, apiKeyController.text);
 
       if (!mounted) return;

--- a/lib/view/login_page/mi_auth_login.dart
+++ b/lib/view/login_page/mi_auth_login.dart
@@ -28,7 +28,9 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
   Future<void> login() async {
     try {
       IndicatorView.showIndicator(context);
-      await ref.read(accountRepository).validateMiAuth(serverController.text);
+      await ref
+          .read(accountRepositoryProvider.notifier)
+          .validateMiAuth(serverController.text);
       if (!mounted) return;
       context.pushRoute(
         TimeLineRoute(
@@ -84,7 +86,7 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
               ElevatedButton(
                 onPressed: () {
                   ref
-                      .read(accountRepository)
+                      .read(accountRepositoryProvider.notifier)
                       .openMiAuth(serverController.text)
                       .expectFailure(context);
                   setState(() {

--- a/lib/view/login_page/password_login.dart
+++ b/lib/view/login_page/password_login.dart
@@ -26,7 +26,7 @@ class PasswordLoginState extends ConsumerState<PasswordLogin> {
   }
 
   Future<void> login() async {
-    await ref.read(accountRepository).loginAsPassword(
+    await ref.read(accountRepositoryProvider.notifier).loginAsPassword(
         serverController.text, userController.text, passwordController.text);
 
     if (!mounted) return;

--- a/lib/view/settings_page/account_settings_page/account_list.dart
+++ b/lib/view/settings_page/account_settings_page/account_list.dart
@@ -6,16 +6,11 @@ import 'package:miria/view/common/avatar_icon.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 @RoutePage()
-class AccountListPage extends ConsumerStatefulWidget {
+class AccountListPage extends ConsumerWidget {
   const AccountListPage({super.key});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => AccountListPageState();
-}
-
-class AccountListPageState extends ConsumerState<AccountListPage> {
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final accounts = ref.watch(accountsProvider);
     return Scaffold(
       appBar: AppBar(
@@ -31,46 +26,68 @@ class AccountListPageState extends ConsumerState<AccountListPage> {
         ],
       ),
       body: Column(
+        mainAxisSize: MainAxisSize.max,
         children: [
           Expanded(
-            child: ListView.builder(
+            child: ReorderableListView.builder(
+              buildDefaultDragHandles: false,
               itemCount: accounts.length,
-              itemBuilder: (context, index) => ListTile(
-                leading: AvatarIcon.fromIResponse(accounts[index].i),
-                onLongPress: () {
-                  showDialog(
-                      context: context,
-                      builder: (context) => AlertDialog(
-                            content: const Text("ほんまに削除してええな？"),
-                            actions: [
-                              OutlinedButton(
-                                  onPressed: () {
-                                    Navigator.of(context).pop();
-                                  },
-                                  child: const Text("やっぱりせえへん")),
-                              ElevatedButton(
-                                  onPressed: () async {
-                                    await ref
-                                        .read(
-                                          accountRepositoryProvider.notifier,
-                                        )
-                                        .remove(accounts[index]);
-                                    if (!mounted) return;
-                                    setState(() {});
-                                    Navigator.of(context).pop();
-                                  },
-                                  child: const Text("ええで"))
-                            ],
-                          ));
-                },
-                title: Text(
-                    accounts[index].i.name ?? accounts[index].i.username,
-                    style: Theme.of(context).textTheme.titleMedium),
-                subtitle: Text(
-                  "@${accounts[index].userId}@${accounts[index].host}",
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ),
+              itemBuilder: (context, index) {
+                final account = accounts[index];
+                return ReorderableDragStartListener(
+                  key: Key("$index"),
+                  index: index,
+                  child: ListTile(
+                    leading: AvatarIcon.fromIResponse(account.i),
+                    title: Text(
+                      account.i.name ?? account.i.username,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    subtitle: Text(
+                      account.acct.toString(),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () {
+                            showDialog(
+                              context: context,
+                              builder: (context) => AlertDialog(
+                                content: const Text("ほんまに削除してええな？"),
+                                actions: [
+                                  OutlinedButton(
+                                    onPressed: () {
+                                      Navigator.of(context).pop();
+                                    },
+                                    child: const Text("やっぱりせえへん"),
+                                  ),
+                                  ElevatedButton(
+                                    onPressed: () async {
+                                      await ref
+                                          .read(
+                                            accountRepositoryProvider.notifier,
+                                          )
+                                          .remove(account);
+                                      if (!context.mounted) return;
+                                      Navigator.of(context).pop();
+                                    },
+                                    child: const Text("ええで"),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
+                        const Icon(Icons.drag_handle),
+                      ],
+                    ),
+                  ),
+                );
+              },
+              onReorder: ref.read(accountRepositoryProvider.notifier).reorder,
             ),
           ),
           Align(
@@ -78,14 +95,15 @@ class AccountListPageState extends ConsumerState<AccountListPage> {
             child: Padding(
               padding: const EdgeInsets.all(10),
               child: ElevatedButton(
-                  onPressed: () {
-                    context.router
-                      ..removeWhere((route) => true)
-                      ..push(const SplashRoute());
-                  },
-                  child: const Text("アカウント設定をおわる")),
+                onPressed: () {
+                  context.router
+                    ..removeWhere((route) => true)
+                    ..push(const SplashRoute());
+                },
+                child: const Text("アカウント設定をおわる"),
+              ),
             ),
-          )
+          ),
         ],
       ),
     );

--- a/lib/view/settings_page/account_settings_page/account_list.dart
+++ b/lib/view/settings_page/account_settings_page/account_list.dart
@@ -1,4 +1,3 @@
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/providers.dart';
@@ -17,7 +16,7 @@ class AccountListPage extends ConsumerStatefulWidget {
 class AccountListPageState extends ConsumerState<AccountListPage> {
   @override
   Widget build(BuildContext context) {
-    final accounts = ref.watch(accountRepository).account.toList();
+    final accounts = ref.watch(accountsProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text("アカウント設定"),
@@ -52,7 +51,9 @@ class AccountListPageState extends ConsumerState<AccountListPage> {
                               ElevatedButton(
                                   onPressed: () async {
                                     await ref
-                                        .read(accountRepository)
+                                        .read(
+                                          accountRepositoryProvider.notifier,
+                                        )
                                         .remove(accounts[index]);
                                     if (!mounted) return;
                                     setState(() {});

--- a/lib/view/settings_page/account_settings_page/account_list.dart
+++ b/lib/view/settings_page/account_settings_page/account_list.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:miria/model/account.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
 import 'package:miria/view/common/avatar_icon.dart';
@@ -34,58 +37,19 @@ class AccountListPage extends ConsumerWidget {
               itemCount: accounts.length,
               itemBuilder: (context, index) {
                 final account = accounts[index];
-                return ReorderableDragStartListener(
-                  key: Key("$index"),
-                  index: index,
-                  child: ListTile(
-                    leading: AvatarIcon.fromIResponse(account.i),
-                    title: Text(
-                      account.i.name ?? account.i.username,
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    subtitle: Text(
-                      account.acct.toString(),
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        IconButton(
-                          icon: const Icon(Icons.delete),
-                          onPressed: () {
-                            showDialog(
-                              context: context,
-                              builder: (context) => AlertDialog(
-                                content: const Text("ほんまに削除してええな？"),
-                                actions: [
-                                  OutlinedButton(
-                                    onPressed: () {
-                                      Navigator.of(context).pop();
-                                    },
-                                    child: const Text("やっぱりせえへん"),
-                                  ),
-                                  ElevatedButton(
-                                    onPressed: () async {
-                                      await ref
-                                          .read(
-                                            accountRepositoryProvider.notifier,
-                                          )
-                                          .remove(account);
-                                      if (!context.mounted) return;
-                                      Navigator.of(context).pop();
-                                    },
-                                    child: const Text("ええで"),
-                                  ),
-                                ],
-                              ),
-                            );
-                          },
-                        ),
-                        const Icon(Icons.drag_handle),
-                      ],
-                    ),
-                  ),
-                );
+                if (Platform.isAndroid || Platform.isIOS) {
+                  return ReorderableDelayedDragStartListener(
+                    key: Key("$index"),
+                    index: index,
+                    child: AccountListItem(account),
+                  );
+                } else {
+                  return ReorderableDragStartListener(
+                    key: Key("$index"),
+                    index: index,
+                    child: AccountListItem(account),
+                  );
+                }
               },
               onReorder: ref.read(accountRepositoryProvider.notifier).reorder,
             ),
@@ -104,6 +68,64 @@ class AccountListPage extends ConsumerWidget {
               ),
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class AccountListItem extends ConsumerWidget {
+  const AccountListItem(this.account, {super.key});
+
+  final Account account;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      leading: AvatarIcon.fromIResponse(account.i),
+      title: Text(
+        account.i.name ?? account.i.username,
+        style: Theme.of(context).textTheme.titleMedium,
+      ),
+      subtitle: Text(
+        account.acct.toString(),
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.delete),
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  content: const Text("ほんまに削除してええな？"),
+                  actions: [
+                    OutlinedButton(
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                      child: const Text("やっぱりせえへん"),
+                    ),
+                    ElevatedButton(
+                      onPressed: () async {
+                        await ref
+                            .read(
+                              accountRepositoryProvider.notifier,
+                            )
+                            .remove(account);
+                        if (!context.mounted) return;
+                        Navigator.of(context).pop();
+                      },
+                      child: const Text("ええで"),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          const Icon(Icons.drag_handle),
         ],
       ),
     );

--- a/lib/view/settings_page/app_info_page/app_info_page.dart
+++ b/lib/view/settings_page/app_info_page/app_info_page.dart
@@ -1,7 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:miria/providers.dart';
+import 'package:miria/model/account.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/misskey_notes/mfm_text.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -34,7 +34,7 @@ class AppInfoPageState extends ConsumerState<AppInfoPage> {
         child: Padding(
           padding: const EdgeInsets.all(10),
           child: AccountScope(
-            account: ref.read(accountRepository).account.first,
+            account: Account.demoAccount(""),
             child: Column(
               children: [
                 MfmText(mfmText: '''

--- a/lib/view/settings_page/import_export_page/import_export_page.dart
+++ b/lib/view/settings_page/import_export_page/import_export_page.dart
@@ -20,103 +20,105 @@ class ImportExportPageState extends ConsumerState<ImportExportPage> {
 
   @override
   Widget build(BuildContext context) {
+    final accounts = ref.watch(accountsProvider);
+
     return Scaffold(
       appBar: AppBar(title: const Text("設定のインポート・エクスポート")),
       body: Padding(
         padding: const EdgeInsets.only(left: 10, right: 10),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              "設定のインポート",
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-            const Text(
-              "設定ファイルをドライブから読み込みます。設定ファイルには保存されたときのすべてのアカウントの設定情報が記録されていますが、そのうちこの端末でログインしているアカウントの情報のみを読み込みます。",
-            ),
-            Row(
-              children: [
-                Expanded(
-                  child: DropdownButton(
-                    isExpanded: true,
-                    items: [
-                      for (final account in ref.read(accountRepository).account)
-                        DropdownMenuItem(
-                          value: account,
-                          child: Text("@${account.userId}@${account.host}"),
-                        ),
-                    ],
-                    value: selectedImportAccount,
-                    onChanged: (Account? value) {
-                      setState(() {
-                        selectedImportAccount = value;
-                      });
-                    },
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                "設定のインポート",
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const Text(
+                "設定ファイルをドライブから読み込みます。設定ファイルには保存されたときのすべてのアカウントの設定情報が記録されていますが、そのうちこの端末でログインしているアカウントの情報のみを読み込みます。",
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: DropdownButton(
+                      isExpanded: true,
+                      items: [
+                        for (final account in accounts)
+                          DropdownMenuItem(
+                            value: account,
+                            child: Text(account.acct.toString()),
+                          ),
+                      ],
+                      value: selectedImportAccount,
+                      onChanged: (Account? value) {
+                        setState(() {
+                          selectedImportAccount = value;
+                        });
+                      },
+                    ),
                   ),
-                ),
-                ElevatedButton(
-                  onPressed: () async {
-                    final account = selectedImportAccount;
-                    if (account == null) {
-                      await SimpleMessageDialog.show(context, "アカウントを選んでや");
-                      return;
-                    }
-                    await ref
-                        .read(importExportRepository)
-                        .import(context, account);
-                  },
-                  child: const Text("選択"),
-                ),
-              ],
-            ),
-            const Padding(padding: EdgeInsets.only(top: 30)),
-            Text(
-              "設定のエクスポート",
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-            const Text(
-              "設定ファイルをドライブに保存します。設定ファイルにはこの端末でログインしているすべてのアカウントの、ログイン情報以外の情報が記録されます。",
-            ),
-            const Text("設定ファイルは1回のエクスポートにつき1つのアカウントに対して保存します。"),
-            Row(
-              children: [
-                Expanded(
-                  child: DropdownButton(
-                    isExpanded: true,
-                    items: [
-                      for (final account in ref.read(accountRepository).account)
-                        DropdownMenuItem(
-                          value: account,
-                          child: Text("@${account.userId}@${account.host}"),
-                        ),
-                    ],
-                    value: selectedExportAccount,
-                    onChanged: (Account? value) {
-                      setState(() {
-                        selectedExportAccount = value;
-                      });
+                  ElevatedButton(
+                    onPressed: () async {
+                      final account = selectedImportAccount;
+                      if (account == null) {
+                        await SimpleMessageDialog.show(context, "アカウントを選んでや");
+                        return;
+                      }
+                      await ref
+                          .read(importExportRepository)
+                          .import(context, account);
                     },
+                    child: const Text("選択"),
                   ),
-                ),
-                ElevatedButton(
-                  onPressed: () {
-                    final account = selectedExportAccount;
-                    if (account == null) {
-                      SimpleMessageDialog.show(
-                        context,
-                        "設定ファイルを保存するアカウントを選んでや",
-                      );
-                      return;
-                    }
-                    ref.read(importExportRepository).export(context, account);
-                  },
-                  child: const Text("保存"),
-                ),
-              ],
-            ),
-          ],
-        ),
+                ],
+              ),
+              const Padding(padding: EdgeInsets.only(top: 30)),
+              Text(
+                "設定のエクスポート",
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const Text(
+                "設定ファイルをドライブに保存します。設定ファイルにはこの端末でログインしているすべてのアカウントの、ログイン情報以外の情報が記録されます。",
+              ),
+              const Text("設定ファイルは1回のエクスポートにつき1つのアカウントに対して保存します。"),
+              Row(
+                children: [
+                  Expanded(
+                    child: DropdownButton(
+                      isExpanded: true,
+                      items: [
+                        for (final account in accounts)
+                          DropdownMenuItem(
+                            value: account,
+                            child: Text(account.acct.toString()),
+                          ),
+                      ],
+                      value: selectedExportAccount,
+                      onChanged: (Account? value) {
+                        setState(() {
+                          selectedExportAccount = value;
+                        });
+                      },
+                    ),
+                  ),
+                  ElevatedButton(
+                      onPressed: () {
+                        final account = selectedExportAccount;
+                        if (account == null) {
+                          SimpleMessageDialog.show(
+                            context,
+                            "設定ファイルを保存するアカウントを選んでや",
+                          );
+                          return;
+                        }
+                        ref
+                            .read(importExportRepository)
+                            .export(context, account);
+                      },
+                      child: const Text("保存")),
+                ],
+              ),
+            ]),
       ),
     );
   }

--- a/lib/view/settings_page/tab_settings_page/tab_settings_list_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_list_page.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:miria/model/tab_setting.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -41,24 +44,25 @@ class TabSettingsListPage extends ConsumerWidget {
               itemCount: tabSettings.length,
               itemBuilder: (context, index) {
                 final tabSetting = tabSettings[index];
-                final account = ref.watch(accountProvider(tabSetting.acct));
-                return ReorderableDragStartListener(
-                  key: Key("$index"),
-                  index: index,
-                  child: ListTile(
-                    leading: AccountScope(
-                      account: account,
-                      child: TabIconView(icon: tabSetting.icon),
+                if (Platform.isAndroid || Platform.isIOS) {
+                  return ReorderableDelayedDragStartListener(
+                    key: Key("$index"),
+                    index: index,
+                    child: TabSettingsListItem(
+                      tabSetting: tabSetting,
+                      index: index,
                     ),
-                    title: Text(tabSetting.name),
-                    subtitle: Text(
-                      "${tabSetting.tabType.displayName} / ${account.acct}",
+                  );
+                } else {
+                  return ReorderableDragStartListener(
+                    key: Key("$index"),
+                    index: index,
+                    child: TabSettingsListItem(
+                      tabSetting: tabSetting,
+                      index: index,
                     ),
-                    trailing: const Icon(Icons.drag_handle),
-                    onTap: () =>
-                        context.pushRoute(TabSettingsRoute(tabIndex: index)),
-                  ),
-                );
+                  );
+                }
               },
               onReorder: (oldIndex, newIndex) {
                 if (oldIndex < newIndex) {
@@ -86,6 +90,34 @@ class TabSettingsListPage extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class TabSettingsListItem extends ConsumerWidget {
+  const TabSettingsListItem({
+    super.key,
+    required this.tabSetting,
+    required this.index,
+  });
+
+  final TabSetting tabSetting;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final account = ref.watch(accountProvider(tabSetting.acct));
+    return ListTile(
+      leading: AccountScope(
+        account: account,
+        child: TabIconView(icon: tabSetting.icon),
+      ),
+      title: Text(tabSetting.name),
+      subtitle: Text(
+        "${tabSetting.tabType.displayName} / ${tabSetting.acct}",
+      ),
+      trailing: const Icon(Icons.drag_handle),
+      onTap: () => context.pushRoute(TabSettingsRoute(tabIndex: index)),
     );
   }
 }

--- a/lib/view/settings_page/tab_settings_page/tab_settings_list_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_list_page.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:miria/model/tab_setting.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,35 +7,29 @@ import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/tab_icon_view.dart';
 
 @RoutePage()
-class TabSettingsListPage extends ConsumerStatefulWidget {
+class TabSettingsListPage extends ConsumerWidget {
   const TabSettingsListPage({super.key});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      TabSettingsListPageState();
-}
-
-class TabSettingsListPageState extends ConsumerState<TabSettingsListPage> {
-  void save(List<TabSetting> newTabSetting) {
-    ref.read(tabSettingsRepositoryProvider).save(newTabSetting);
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tabSettings = ref
-        .watch(tabSettingsRepositoryProvider
-            .select((repository) => repository.tabSettings))
+        .watch(
+          tabSettingsRepositoryProvider
+              .select((repository) => repository.tabSettings),
+        )
         .toList();
+
     return Scaffold(
       appBar: AppBar(
         leading: Container(),
         title: const Text("タブ設定"),
         actions: [
           IconButton(
-              onPressed: () {
-                context.pushRoute(TabSettingsRoute());
-              },
-              icon: const Icon(Icons.add)),
+            onPressed: () {
+              context.pushRoute(TabSettingsRoute());
+            },
+            icon: const Icon(Icons.add),
+          ),
         ],
       ),
       body: Column(
@@ -44,48 +37,53 @@ class TabSettingsListPageState extends ConsumerState<TabSettingsListPage> {
         children: [
           Expanded(
             child: ReorderableListView.builder(
-                itemBuilder: (context, index) {
-                  final tabSetting = tabSettings[index];
-                  final account = ref.watch(accountProvider(tabSetting.acct));
-                  return ListTile(
-                    key: Key("$index"),
+              buildDefaultDragHandles: false,
+              itemCount: tabSettings.length,
+              itemBuilder: (context, index) {
+                final tabSetting = tabSettings[index];
+                final account = ref.watch(accountProvider(tabSetting.acct));
+                return ReorderableDragStartListener(
+                  key: Key("$index"),
+                  index: index,
+                  child: ListTile(
                     leading: AccountScope(
                       account: account,
-                      child: TabIconView(icon: tabSettings[index].icon),
+                      child: TabIconView(icon: tabSetting.icon),
                     ),
-                    title: Text(tabSettings[index].name),
+                    title: Text(tabSetting.name),
                     subtitle: Text(
                       "${tabSetting.tabType.displayName} / ${account.acct}",
                     ),
+                    trailing: const Icon(Icons.drag_handle),
                     onTap: () =>
                         context.pushRoute(TabSettingsRoute(tabIndex: index)),
-                  );
-                },
-                itemCount: tabSettings.length,
-                onReorder: (oldIndex, newIndex) {
-                  setState(() {
-                    if (oldIndex < newIndex) {
-                      newIndex -= 1;
-                    }
-                    final item = tabSettings.removeAt(oldIndex);
-                    tabSettings.insert(newIndex, item);
-                    save(tabSettings);
-                  });
-                }),
+                  ),
+                );
+              },
+              onReorder: (oldIndex, newIndex) {
+                if (oldIndex < newIndex) {
+                  newIndex -= 1;
+                }
+                final item = tabSettings.removeAt(oldIndex);
+                tabSettings.insert(newIndex, item);
+                ref.read(tabSettingsRepositoryProvider).save(tabSettings);
+              },
+            ),
           ),
           Align(
             alignment: Alignment.center,
             child: Padding(
               padding: const EdgeInsets.all(10),
               child: ElevatedButton(
-                  onPressed: () {
-                    context.router
-                      ..removeWhere((route) => true)
-                      ..push(const SplashRoute());
-                  },
-                  child: const Text("反映する")),
+                onPressed: () {
+                  context.router
+                    ..removeWhere((route) => true)
+                    ..push(const SplashRoute());
+                },
+                child: const Text("反映する"),
+              ),
             ),
-          )
+          ),
         ],
       ),
     );

--- a/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
@@ -29,7 +29,7 @@ class TabSettingsPage extends ConsumerStatefulWidget {
 }
 
 class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
-  late Account? selectedAccount = ref.read(accountRepository).account.first;
+  late Account? selectedAccount = ref.read(accountsProvider).first;
   TabType? selectedTabType = TabType.localTimeline;
   RolesListResponse? selectedRole;
   CommunityChannel? selectedChannel;
@@ -115,6 +115,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final accounts = ref.watch(accountsProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text("タブ設定"),
@@ -145,11 +146,11 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
               const Text("アカウント"),
               DropdownButton<Account>(
                 items: [
-                  for (final account in ref.read(accountRepository).account)
+                  for (final account in accounts)
                     DropdownMenuItem(
                       value: account,
-                      child: Text("${account.userId}@${account.host}"),
-                    )
+                      child: Text(account.acct.toString()),
+                    ),
                 ],
                 onChanged: (value) {
                   setState(() {

--- a/lib/view/sharing_account_select_page/account_select_page.dart
+++ b/lib/view/sharing_account_select_page/account_select_page.dart
@@ -6,22 +6,15 @@ import 'package:miria/router/app_router.dart';
 import 'package:miria/view/common/avatar_icon.dart';
 
 @RoutePage()
-class SharingAccountSelectPage extends ConsumerStatefulWidget {
+class SharingAccountSelectPage extends ConsumerWidget {
   final String? sharingText;
   final List<String>? filePath;
 
   const SharingAccountSelectPage({super.key, this.sharingText, this.filePath});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      SharingAccountSelectPageState();
-}
-
-class SharingAccountSelectPageState
-    extends ConsumerState<SharingAccountSelectPage> {
-  @override
-  Widget build(BuildContext context) {
-    final accounts = ref.watch(accountRepository).account.toList();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accounts = ref.watch(accountsProvider);
     return Scaffold(
       appBar: AppBar(title: const Text("共有するアカウントを選択")),
       body: ListView.builder(
@@ -32,15 +25,15 @@ class SharingAccountSelectPageState
             onTap: () {
               context.replaceRoute(NoteCreateRoute(
                 initialAccount: account,
-                initialText: widget.sharingText,
-                initialMediaFiles: widget.filePath,
+                initialText: sharingText,
+                initialMediaFiles: filePath,
               ));
             },
             leading: AvatarIcon.fromIResponse(account.i),
             title: Text(account.i.name ?? account.i.username,
                 style: Theme.of(context).textTheme.titleMedium),
             subtitle: Text(
-              "@${account.userId}@${account.host}",
+              account.acct.toString(),
               style: Theme.of(context).textTheme.bodySmall,
             ),
           );

--- a/lib/view/splash_page/splash_page.dart
+++ b/lib/view/splash_page/splash_page.dart
@@ -24,12 +24,12 @@ class SplashPageState extends ConsumerState<SplashPage> {
   String initialSharingText = "";
 
   Future<void> initialize() async {
-    await ref.read(accountRepository).load();
+    await ref.read(accountRepositoryProvider.notifier).load();
     await ref.read(tabSettingsRepositoryProvider).load();
     await ref.read(accountSettingsRepositoryProvider).load();
     await ref.read(generalSettingsRepositoryProvider).load();
 
-    for (final account in ref.read(accountRepository).account) {
+    for (final account in ref.read(accountsProvider)) {
       await ref.read(emojiRepositoryProvider(account)).loadFromLocalCache();
     }
 
@@ -55,7 +55,8 @@ class SplashPageState extends ConsumerState<SplashPage> {
           future: initialize(),
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.done) {
-              final isSigned = ref.read(accountRepository).account.isNotEmpty;
+              final accounts = ref.read(accountsProvider);
+              final isSigned = accounts.isNotEmpty;
               final hasTabSetting = ref
                   .read(tabSettingsRepositoryProvider)
                   .tabSettings
@@ -69,7 +70,6 @@ class SplashPageState extends ConsumerState<SplashPage> {
                         .first));
                 if (initialSharingMedias.isNotEmpty ||
                     initialSharingText.isNotEmpty) {
-                  final accounts = ref.read(accountRepository).account;
                   if (accounts.length == 1) {
                     context.pushRoute(NoteCreateRoute(
                       initialMediaFiles: initialSharingMedias,
@@ -87,9 +87,10 @@ class SplashPageState extends ConsumerState<SplashPage> {
                 // KeyChainに保存したデータだけアンインストールしても残るので
                 // この状況が発生する
                 Future(() async {
-                  final accounts = ref.read(accountRepository).account.toList();
                   for (final account in accounts) {
-                    await ref.read(accountRepository).remove(account);
+                    await ref
+                        .read(accountRepositoryProvider.notifier)
+                        .remove(account);
                   }
                   if (!mounted) return;
 

--- a/lib/view/time_line_page/time_line_page.dart
+++ b/lib/view/time_line_page/time_line_page.dart
@@ -273,7 +273,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                     TabType.globalTimeline,
                     TabType.homeTimeline,
                   ].contains(currentTabSetting.tabType)) ...[
-                    AnnoucementInfo(index: currentIndex),
+                    AnnoucementInfo(tabSetting: currentTabSetting),
                     IconButton(
                       onPressed: () {
                         showDialog(
@@ -298,7 +298,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                         .reconnect(),
                     icon:
                         socketTimeline != null && socketTimeline.isReconnecting
-                            ? CircularProgressIndicator()
+                            ? const CircularProgressIndicator()
                             : const Icon(Icons.refresh),
                   )
                 ],
@@ -329,7 +329,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisSize: MainAxisSize.max,
                       children: [
-                        BannerArea(index: currentIndex),
+                        BannerArea(tabSetting: currentTabSetting),
                         Expanded(
                           child: MisskeyTimeline(
                             controller: scrollControllers[index],
@@ -387,20 +387,15 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
 }
 
 class BannerArea extends ConsumerWidget {
-  final int index;
+  final TabSetting tabSetting;
 
-  const BannerArea({super.key, required this.index});
+  const BannerArea({super.key, required this.tabSetting});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final acct = ref.watch(
-      tabSettingsRepositoryProvider
-          .select((repository) => repository.tabSettings.toList()[index].acct),
-    );
     final bannerAnnouncement = ref.watch(
-      accountProvider(acct).select(
-        (account) => account.i.unreadAnnouncements,
-      ),
+      accountProvider(tabSetting.acct)
+          .select((account) => account.i.unreadAnnouncements),
     );
 
     // ダイアログの実装が大変なので（状態管理とか）いったんバナーと一緒に扱う
@@ -438,32 +433,23 @@ class BannerArea extends ConsumerWidget {
 }
 
 class AnnoucementInfo extends ConsumerWidget {
-  final int index;
+  final TabSetting tabSetting;
 
-  const AnnoucementInfo({super.key, required this.index});
+  const AnnoucementInfo({super.key, required this.tabSetting});
 
   void announcementsRoute(BuildContext context, WidgetRef ref) {
-    final acct = ref
-        .read(tabSettingsRepositoryProvider)
-        .tabSettings
-        .toList()[index]
-        .acct;
-    final account = ref.read(accountProvider(acct));
+    final account = ref.read(accountProvider(tabSetting.acct));
     context.pushRoute(AnnouncementRoute(account: account));
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final acct = ref.watch(
-      tabSettingsRepositoryProvider
-          .select((repository) => repository.tabSettings.toList()[index].acct),
-    );
     final hasUnread = ref.watch(
-      accountProvider(acct)
+      accountProvider(tabSetting.acct)
           .select((account) => account.i.unreadAnnouncements.isNotEmpty),
     );
 
-    if (hasUnread == true) {
+    if (hasUnread) {
       return IconButton(
           onPressed: () => announcementsRoute(context, ref),
           icon: Stack(children: [

--- a/test/repository/account_repository/open_mi_auth_test.dart
+++ b/test/repository/account_repository/open_mi_auth_test.dart
@@ -2,7 +2,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:miria/providers.dart';
-import 'package:miria/repository/account_repository.dart';
 import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:mockito/mockito.dart';
 
@@ -13,9 +12,9 @@ import 'auth_test_data.dart';
 void main() {
   test("誤ったホスト名を入力するとエラーを返すこと", () async {
     final provider = ProviderContainer(
-        overrides: [dioProvider.overrideWithValue(MockDio())]);
-    final accountRepository = AccountRepository(MockTabSettingsRepository(),
-        MockAccountSettingsRepository(), provider.read);
+      overrides: [dioProvider.overrideWithValue(MockDio())],
+    );
+    final accountRepository = provider.read(accountRepositoryProvider.notifier);
 
     expect(() => accountRepository.openMiAuth("https://misskey.io/"),
         throwsA(isA<SpecifiedException>()));
@@ -26,8 +25,7 @@ void main() {
     when(dio.getUri(any)).thenAnswer((_) async => throw TestData.response404);
     final provider =
         ProviderContainer(overrides: [dioProvider.overrideWithValue(dio)]);
-    final accountRepository = AccountRepository(MockTabSettingsRepository(),
-        MockAccountSettingsRepository(), provider.read);
+    final accountRepository = provider.read(accountRepositoryProvider.notifier);
 
     expect(() async => await accountRepository.openMiAuth("sawakai.space"),
         throwsA(isA<SpecifiedException>()));
@@ -51,8 +49,7 @@ void main() {
         misskeyProvider.overrideWith((ref, arg) => mockMisskey),
       ],
     );
-    final accountRepository = AccountRepository(MockTabSettingsRepository(),
-        MockAccountSettingsRepository(), provider.read);
+    final accountRepository = provider.read(accountRepositoryProvider.notifier);
 
     await expectLater(
         () async => await accountRepository.openMiAuth("calckey.jp"),
@@ -83,8 +80,7 @@ void main() {
         misskeyProvider.overrideWith((ref, arg) => mockMisskey),
       ],
     );
-    final accountRepository = AccountRepository(MockTabSettingsRepository(),
-        MockAccountSettingsRepository(), provider.read);
+    final accountRepository = provider.read(accountRepositoryProvider.notifier);
 
     await expectLater(
         () async => await accountRepository.openMiAuth("misskey.dev"),

--- a/test/test_util/mock.mocks.dart
+++ b/test/test_util/mock.mocks.dart
@@ -3,46 +3,45 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i17;
-import 'dart:collection' as _i31;
-import 'dart:io' as _i12;
-import 'dart:typed_data' as _i28;
+import 'dart:async' as _i16;
+import 'dart:collection' as _i29;
+import 'dart:io' as _i11;
+import 'dart:typed_data' as _i26;
 import 'dart:ui' as _i19;
 
-import 'package:dio/dio.dart' as _i11;
-import 'package:file/file.dart' as _i14;
-import 'package:file_picker/file_picker.dart' as _i36;
-import 'package:flutter_cache_manager/flutter_cache_manager.dart' as _i15;
-import 'package:flutter_riverpod/flutter_riverpod.dart' as _i25;
-import 'package:miria/model/account.dart' as _i18;
+import 'package:dio/dio.dart' as _i10;
+import 'package:file/file.dart' as _i12;
+import 'package:file_picker/file_picker.dart' as _i35;
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' as _i13;
+import 'package:flutter_riverpod/flutter_riverpod.dart' as _i4;
+import 'package:miria/model/account.dart' as _i17;
 import 'package:miria/model/account_settings.dart' as _i2;
-import 'package:miria/model/acct.dart' as _i20;
+import 'package:miria/model/acct.dart' as _i18;
 import 'package:miria/model/general_settings.dart' as _i3;
 import 'package:miria/model/misskey_emoji_data.dart' as _i22;
-import 'package:miria/model/tab_setting.dart' as _i16;
+import 'package:miria/model/tab_setting.dart' as _i15;
 import 'package:miria/repository/account_repository.dart' as _i24;
-import 'package:miria/repository/account_settings_repository.dart' as _i5;
+import 'package:miria/repository/account_settings_repository.dart' as _i20;
 import 'package:miria/repository/emoji_repository.dart' as _i21;
 import 'package:miria/repository/general_settings_repository.dart' as _i23;
-import 'package:miria/repository/note_repository.dart' as _i27;
-import 'package:miria/repository/tab_settings_repository.dart' as _i4;
-import 'package:misskey_dart/misskey_dart.dart' as _i6;
-import 'package:misskey_dart/src/data/ping_response.dart' as _i10;
-import 'package:misskey_dart/src/data/stats_response.dart' as _i9;
-import 'package:misskey_dart/src/data/streaming/streaming_request.dart' as _i30;
-import 'package:misskey_dart/src/enums/broadcast_event_type.dart' as _i34;
-import 'package:misskey_dart/src/enums/channel.dart' as _i29;
-import 'package:misskey_dart/src/enums/channel_event_type.dart' as _i32;
-import 'package:misskey_dart/src/enums/note_updated_event_type.dart' as _i33;
-import 'package:misskey_dart/src/misskey_flash.dart' as _i8;
-import 'package:misskey_dart/src/services/api_service.dart' as _i7;
+import 'package:miria/repository/note_repository.dart' as _i25;
+import 'package:miria/repository/tab_settings_repository.dart' as _i14;
+import 'package:misskey_dart/misskey_dart.dart' as _i5;
+import 'package:misskey_dart/src/data/ping_response.dart' as _i9;
+import 'package:misskey_dart/src/data/stats_response.dart' as _i8;
+import 'package:misskey_dart/src/data/streaming/streaming_request.dart' as _i28;
+import 'package:misskey_dart/src/enums/broadcast_event_type.dart' as _i33;
+import 'package:misskey_dart/src/enums/channel.dart' as _i27;
+import 'package:misskey_dart/src/enums/channel_event_type.dart' as _i31;
+import 'package:misskey_dart/src/enums/note_updated_event_type.dart' as _i32;
+import 'package:misskey_dart/src/misskey_flash.dart' as _i7;
+import 'package:misskey_dart/src/services/api_service.dart' as _i6;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i26;
+import 'package:mockito/src/dummies.dart' as _i30;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart'
-    as _i37;
-import 'package:web_socket_channel/web_socket_channel.dart' as _i13;
+    as _i36;
 
-import 'mock.dart' as _i35;
+import 'mock.dart' as _i34;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -77,9 +76,9 @@ class _FakeGeneralSettings_1 extends _i1.SmartFake
         );
 }
 
-class _FakeTabSettingsRepository_2 extends _i1.SmartFake
-    implements _i4.TabSettingsRepository {
-  _FakeTabSettingsRepository_2(
+class _FakeNotifierProviderRef_2<T> extends _i1.SmartFake
+    implements _i4.NotifierProviderRef<T> {
+  _FakeNotifierProviderRef_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -88,9 +87,8 @@ class _FakeTabSettingsRepository_2 extends _i1.SmartFake
         );
 }
 
-class _FakeAccountSettingsRepository_3 extends _i1.SmartFake
-    implements _i5.AccountSettingsRepository {
-  _FakeAccountSettingsRepository_3(
+class _FakeMisskey_3 extends _i1.SmartFake implements _i5.Misskey {
+  _FakeMisskey_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -99,8 +97,8 @@ class _FakeAccountSettingsRepository_3 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskey_4 extends _i1.SmartFake implements _i6.Misskey {
-  _FakeMisskey_4(
+class _FakeApiService_4 extends _i1.SmartFake implements _i6.ApiService {
+  _FakeApiService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -109,8 +107,9 @@ class _FakeMisskey_4 extends _i1.SmartFake implements _i6.Misskey {
         );
 }
 
-class _FakeApiService_5 extends _i1.SmartFake implements _i7.ApiService {
-  _FakeApiService_5(
+class _FakeStreamingService_5 extends _i1.SmartFake
+    implements _i5.StreamingService {
+  _FakeStreamingService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -119,9 +118,8 @@ class _FakeApiService_5 extends _i1.SmartFake implements _i7.ApiService {
         );
 }
 
-class _FakeStreamingService_6 extends _i1.SmartFake
-    implements _i6.StreamingService {
-  _FakeStreamingService_6(
+class _FakeMisskeyNotes_6 extends _i1.SmartFake implements _i5.MisskeyNotes {
+  _FakeMisskeyNotes_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -130,8 +128,9 @@ class _FakeStreamingService_6 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyNotes_7 extends _i1.SmartFake implements _i6.MisskeyNotes {
-  _FakeMisskeyNotes_7(
+class _FakeMisskeyChannels_7 extends _i1.SmartFake
+    implements _i5.MisskeyChannels {
+  _FakeMisskeyChannels_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -140,9 +139,8 @@ class _FakeMisskeyNotes_7 extends _i1.SmartFake implements _i6.MisskeyNotes {
         );
 }
 
-class _FakeMisskeyChannels_8 extends _i1.SmartFake
-    implements _i6.MisskeyChannels {
-  _FakeMisskeyChannels_8(
+class _FakeMisskeyUsers_8 extends _i1.SmartFake implements _i5.MisskeyUsers {
+  _FakeMisskeyUsers_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,8 +149,8 @@ class _FakeMisskeyChannels_8 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyUsers_9 extends _i1.SmartFake implements _i6.MisskeyUsers {
-  _FakeMisskeyUsers_9(
+class _FakeMisskeyI_9 extends _i1.SmartFake implements _i5.MisskeyI {
+  _FakeMisskeyI_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -161,8 +159,8 @@ class _FakeMisskeyUsers_9 extends _i1.SmartFake implements _i6.MisskeyUsers {
         );
 }
 
-class _FakeMisskeyI_10 extends _i1.SmartFake implements _i6.MisskeyI {
-  _FakeMisskeyI_10(
+class _FakeMisskeyClips_10 extends _i1.SmartFake implements _i5.MisskeyClips {
+  _FakeMisskeyClips_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -171,8 +169,9 @@ class _FakeMisskeyI_10 extends _i1.SmartFake implements _i6.MisskeyI {
         );
 }
 
-class _FakeMisskeyClips_11 extends _i1.SmartFake implements _i6.MisskeyClips {
-  _FakeMisskeyClips_11(
+class _FakeMisskeyAntenna_11 extends _i1.SmartFake
+    implements _i5.MisskeyAntenna {
+  _FakeMisskeyAntenna_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -181,9 +180,8 @@ class _FakeMisskeyClips_11 extends _i1.SmartFake implements _i6.MisskeyClips {
         );
 }
 
-class _FakeMisskeyAntenna_12 extends _i1.SmartFake
-    implements _i6.MisskeyAntenna {
-  _FakeMisskeyAntenna_12(
+class _FakeMisskeyDrive_12 extends _i1.SmartFake implements _i5.MisskeyDrive {
+  _FakeMisskeyDrive_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,8 +190,9 @@ class _FakeMisskeyAntenna_12 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyDrive_13 extends _i1.SmartFake implements _i6.MisskeyDrive {
-  _FakeMisskeyDrive_13(
+class _FakeMisskeyFollowing_13 extends _i1.SmartFake
+    implements _i5.MisskeyFollowing {
+  _FakeMisskeyFollowing_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,9 +201,9 @@ class _FakeMisskeyDrive_13 extends _i1.SmartFake implements _i6.MisskeyDrive {
         );
 }
 
-class _FakeMisskeyFollowing_14 extends _i1.SmartFake
-    implements _i6.MisskeyFollowing {
-  _FakeMisskeyFollowing_14(
+class _FakeMisskeyBlocking_14 extends _i1.SmartFake
+    implements _i5.MisskeyBlocking {
+  _FakeMisskeyBlocking_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,9 +212,8 @@ class _FakeMisskeyFollowing_14 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyBlocking_15 extends _i1.SmartFake
-    implements _i6.MisskeyBlocking {
-  _FakeMisskeyBlocking_15(
+class _FakeMisskeyMute_15 extends _i1.SmartFake implements _i5.MisskeyMute {
+  _FakeMisskeyMute_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -224,8 +222,9 @@ class _FakeMisskeyBlocking_15 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyMute_16 extends _i1.SmartFake implements _i6.MisskeyMute {
-  _FakeMisskeyMute_16(
+class _FakeMisskeyRenoteMute_16 extends _i1.SmartFake
+    implements _i5.MisskeyRenoteMute {
+  _FakeMisskeyRenoteMute_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -234,9 +233,9 @@ class _FakeMisskeyMute_16 extends _i1.SmartFake implements _i6.MisskeyMute {
         );
 }
 
-class _FakeMisskeyRenoteMute_17 extends _i1.SmartFake
-    implements _i6.MisskeyRenoteMute {
-  _FakeMisskeyRenoteMute_17(
+class _FakeMisskeyFederation_17 extends _i1.SmartFake
+    implements _i5.MisskeyFederation {
+  _FakeMisskeyFederation_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -245,9 +244,8 @@ class _FakeMisskeyRenoteMute_17 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyFederation_18 extends _i1.SmartFake
-    implements _i6.MisskeyFederation {
-  _FakeMisskeyFederation_18(
+class _FakeMisskeyRoles_18 extends _i1.SmartFake implements _i5.MisskeyRoles {
+  _FakeMisskeyRoles_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -256,8 +254,9 @@ class _FakeMisskeyFederation_18 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyRoles_19 extends _i1.SmartFake implements _i6.MisskeyRoles {
-  _FakeMisskeyRoles_19(
+class _FakeMisskeyHashtags_19 extends _i1.SmartFake
+    implements _i5.MisskeyHashtags {
+  _FakeMisskeyHashtags_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -266,9 +265,8 @@ class _FakeMisskeyRoles_19 extends _i1.SmartFake implements _i6.MisskeyRoles {
         );
 }
 
-class _FakeMisskeyHashtags_20 extends _i1.SmartFake
-    implements _i6.MisskeyHashtags {
-  _FakeMisskeyHashtags_20(
+class _FakeMisskeyAp_20 extends _i1.SmartFake implements _i5.MisskeyAp {
+  _FakeMisskeyAp_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,8 +275,8 @@ class _FakeMisskeyHashtags_20 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyAp_21 extends _i1.SmartFake implements _i6.MisskeyAp {
-  _FakeMisskeyAp_21(
+class _FakeMisskeyPages_21 extends _i1.SmartFake implements _i5.MisskeyPages {
+  _FakeMisskeyPages_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -287,8 +285,8 @@ class _FakeMisskeyAp_21 extends _i1.SmartFake implements _i6.MisskeyAp {
         );
 }
 
-class _FakeMisskeyPages_22 extends _i1.SmartFake implements _i6.MisskeyPages {
-  _FakeMisskeyPages_22(
+class _FakeMisskeyFlash_22 extends _i1.SmartFake implements _i7.MisskeyFlash {
+  _FakeMisskeyFlash_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -297,8 +295,9 @@ class _FakeMisskeyPages_22 extends _i1.SmartFake implements _i6.MisskeyPages {
         );
 }
 
-class _FakeMisskeyFlash_23 extends _i1.SmartFake implements _i8.MisskeyFlash {
-  _FakeMisskeyFlash_23(
+class _FakeEmojisResponse_23 extends _i1.SmartFake
+    implements _i5.EmojisResponse {
+  _FakeEmojisResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -307,9 +306,8 @@ class _FakeMisskeyFlash_23 extends _i1.SmartFake implements _i8.MisskeyFlash {
         );
 }
 
-class _FakeEmojisResponse_24 extends _i1.SmartFake
-    implements _i6.EmojisResponse {
-  _FakeEmojisResponse_24(
+class _FakeEmojiResponse_24 extends _i1.SmartFake implements _i5.EmojiResponse {
+  _FakeEmojiResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -318,8 +316,8 @@ class _FakeEmojisResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeEmojiResponse_25 extends _i1.SmartFake implements _i6.EmojiResponse {
-  _FakeEmojiResponse_25(
+class _FakeMetaResponse_25 extends _i1.SmartFake implements _i5.MetaResponse {
+  _FakeMetaResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -328,8 +326,8 @@ class _FakeEmojiResponse_25 extends _i1.SmartFake implements _i6.EmojiResponse {
         );
 }
 
-class _FakeMetaResponse_26 extends _i1.SmartFake implements _i6.MetaResponse {
-  _FakeMetaResponse_26(
+class _FakeStatsResponse_26 extends _i1.SmartFake implements _i8.StatsResponse {
+  _FakeStatsResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +336,8 @@ class _FakeMetaResponse_26 extends _i1.SmartFake implements _i6.MetaResponse {
         );
 }
 
-class _FakeStatsResponse_27 extends _i1.SmartFake implements _i9.StatsResponse {
-  _FakeStatsResponse_27(
+class _FakePingResponse_27 extends _i1.SmartFake implements _i9.PingResponse {
+  _FakePingResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,8 +346,9 @@ class _FakeStatsResponse_27 extends _i1.SmartFake implements _i9.StatsResponse {
         );
 }
 
-class _FakePingResponse_28 extends _i1.SmartFake implements _i10.PingResponse {
-  _FakePingResponse_28(
+class _FakeServerInfoResponse_28 extends _i1.SmartFake
+    implements _i5.ServerInfoResponse {
+  _FakeServerInfoResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -358,9 +357,9 @@ class _FakePingResponse_28 extends _i1.SmartFake implements _i10.PingResponse {
         );
 }
 
-class _FakeServerInfoResponse_29 extends _i1.SmartFake
-    implements _i6.ServerInfoResponse {
-  _FakeServerInfoResponse_29(
+class _FakeGetOnlineUsersCountResponse_29 extends _i1.SmartFake
+    implements _i5.GetOnlineUsersCountResponse {
+  _FakeGetOnlineUsersCountResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,9 +368,9 @@ class _FakeServerInfoResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeGetOnlineUsersCountResponse_30 extends _i1.SmartFake
-    implements _i6.GetOnlineUsersCountResponse {
-  _FakeGetOnlineUsersCountResponse_30(
+class _FakeSocketController_30 extends _i1.SmartFake
+    implements _i5.SocketController {
+  _FakeSocketController_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,9 +379,8 @@ class _FakeGetOnlineUsersCountResponse_30 extends _i1.SmartFake
         );
 }
 
-class _FakeSocketController_31 extends _i1.SmartFake
-    implements _i6.SocketController {
-  _FakeSocketController_31(
+class _FakeAntenna_31 extends _i1.SmartFake implements _i5.Antenna {
+  _FakeAntenna_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,8 +389,9 @@ class _FakeSocketController_31 extends _i1.SmartFake
         );
 }
 
-class _FakeAntenna_32 extends _i1.SmartFake implements _i6.Antenna {
-  _FakeAntenna_32(
+class _FakeApShowResponse_32 extends _i1.SmartFake
+    implements _i5.ApShowResponse {
+  _FakeApShowResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -401,9 +400,9 @@ class _FakeAntenna_32 extends _i1.SmartFake implements _i6.Antenna {
         );
 }
 
-class _FakeApShowResponse_33 extends _i1.SmartFake
-    implements _i6.ApShowResponse {
-  _FakeApShowResponse_33(
+class _FakeCommunityChannel_33 extends _i1.SmartFake
+    implements _i5.CommunityChannel {
+  _FakeCommunityChannel_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,9 +411,8 @@ class _FakeApShowResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeCommunityChannel_34 extends _i1.SmartFake
-    implements _i6.CommunityChannel {
-  _FakeCommunityChannel_34(
+class _FakeClip_34 extends _i1.SmartFake implements _i5.Clip {
+  _FakeClip_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -423,8 +421,9 @@ class _FakeCommunityChannel_34 extends _i1.SmartFake
         );
 }
 
-class _FakeClip_35 extends _i1.SmartFake implements _i6.Clip {
-  _FakeClip_35(
+class _FakeMisskeyDriveFiles_35 extends _i1.SmartFake
+    implements _i5.MisskeyDriveFiles {
+  _FakeMisskeyDriveFiles_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -433,9 +432,9 @@ class _FakeClip_35 extends _i1.SmartFake implements _i6.Clip {
         );
 }
 
-class _FakeMisskeyDriveFiles_36 extends _i1.SmartFake
-    implements _i6.MisskeyDriveFiles {
-  _FakeMisskeyDriveFiles_36(
+class _FakeMisskeyDriveFolders_36 extends _i1.SmartFake
+    implements _i5.MisskeyDriveFolders {
+  _FakeMisskeyDriveFolders_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -444,9 +443,8 @@ class _FakeMisskeyDriveFiles_36 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyDriveFolders_37 extends _i1.SmartFake
-    implements _i6.MisskeyDriveFolders {
-  _FakeMisskeyDriveFolders_37(
+class _FakeDriveFile_37 extends _i1.SmartFake implements _i5.DriveFile {
+  _FakeDriveFile_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -455,8 +453,9 @@ class _FakeMisskeyDriveFolders_37 extends _i1.SmartFake
         );
 }
 
-class _FakeDriveFile_38 extends _i1.SmartFake implements _i6.DriveFile {
-  _FakeDriveFile_38(
+class _FakeFederationShowInstanceResponse_38 extends _i1.SmartFake
+    implements _i5.FederationShowInstanceResponse {
+  _FakeFederationShowInstanceResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +464,9 @@ class _FakeDriveFile_38 extends _i1.SmartFake implements _i6.DriveFile {
         );
 }
 
-class _FakeFederationShowInstanceResponse_39 extends _i1.SmartFake
-    implements _i6.FederationShowInstanceResponse {
-  _FakeFederationShowInstanceResponse_39(
+class _FakeMisskeyFollowingRequests_39 extends _i1.SmartFake
+    implements _i5.MisskeyFollowingRequests {
+  _FakeMisskeyFollowingRequests_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +475,8 @@ class _FakeFederationShowInstanceResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyFollowingRequests_40 extends _i1.SmartFake
-    implements _i6.MisskeyFollowingRequests {
-  _FakeMisskeyFollowingRequests_40(
+class _FakeUser_40 extends _i1.SmartFake implements _i5.User {
+  _FakeUser_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,8 +485,8 @@ class _FakeMisskeyFollowingRequests_40 extends _i1.SmartFake
         );
 }
 
-class _FakeUser_41 extends _i1.SmartFake implements _i6.User {
-  _FakeUser_41(
+class _FakeHashtag_41 extends _i1.SmartFake implements _i5.Hashtag {
+  _FakeHashtag_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -497,8 +495,8 @@ class _FakeUser_41 extends _i1.SmartFake implements _i6.User {
         );
 }
 
-class _FakeHashtag_42 extends _i1.SmartFake implements _i6.Hashtag {
-  _FakeHashtag_42(
+class _FakeIResponse_42 extends _i1.SmartFake implements _i5.IResponse {
+  _FakeIResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -507,8 +505,9 @@ class _FakeHashtag_42 extends _i1.SmartFake implements _i6.Hashtag {
         );
 }
 
-class _FakeIResponse_43 extends _i1.SmartFake implements _i6.IResponse {
-  _FakeIResponse_43(
+class _FakeMisskeyNotesReactions_43 extends _i1.SmartFake
+    implements _i5.MisskeyNotesReactions {
+  _FakeMisskeyNotesReactions_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -517,9 +516,9 @@ class _FakeIResponse_43 extends _i1.SmartFake implements _i6.IResponse {
         );
 }
 
-class _FakeMisskeyNotesReactions_44 extends _i1.SmartFake
-    implements _i6.MisskeyNotesReactions {
-  _FakeMisskeyNotesReactions_44(
+class _FakeMisskeyNotesFavorites_44 extends _i1.SmartFake
+    implements _i5.MisskeyNotesFavorites {
+  _FakeMisskeyNotesFavorites_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -528,9 +527,9 @@ class _FakeMisskeyNotesReactions_44 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyNotesFavorites_45 extends _i1.SmartFake
-    implements _i6.MisskeyNotesFavorites {
-  _FakeMisskeyNotesFavorites_45(
+class _FakeMisskeyNotesPolls_45 extends _i1.SmartFake
+    implements _i5.MisskeyNotesPolls {
+  _FakeMisskeyNotesPolls_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -539,9 +538,9 @@ class _FakeMisskeyNotesFavorites_45 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyNotesPolls_46 extends _i1.SmartFake
-    implements _i6.MisskeyNotesPolls {
-  _FakeMisskeyNotesPolls_46(
+class _FakeMisskeyNotesThreadMuting_46 extends _i1.SmartFake
+    implements _i5.MisskeyNotesThreadMuting {
+  _FakeMisskeyNotesThreadMuting_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,9 +549,8 @@ class _FakeMisskeyNotesPolls_46 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyNotesThreadMuting_47 extends _i1.SmartFake
-    implements _i6.MisskeyNotesThreadMuting {
-  _FakeMisskeyNotesThreadMuting_47(
+class _FakeNote_47 extends _i1.SmartFake implements _i5.Note {
+  _FakeNote_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,8 +559,9 @@ class _FakeMisskeyNotesThreadMuting_47 extends _i1.SmartFake
         );
 }
 
-class _FakeNote_48 extends _i1.SmartFake implements _i6.Note {
-  _FakeNote_48(
+class _FakeNotesStateResponse_48 extends _i1.SmartFake
+    implements _i5.NotesStateResponse {
+  _FakeNotesStateResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -571,9 +570,9 @@ class _FakeNote_48 extends _i1.SmartFake implements _i6.Note {
         );
 }
 
-class _FakeNotesStateResponse_49 extends _i1.SmartFake
-    implements _i6.NotesStateResponse {
-  _FakeNotesStateResponse_49(
+class _FakeRolesListResponse_49 extends _i1.SmartFake
+    implements _i5.RolesListResponse {
+  _FakeRolesListResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,9 +581,9 @@ class _FakeNotesStateResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeRolesListResponse_50 extends _i1.SmartFake
-    implements _i6.RolesListResponse {
-  _FakeRolesListResponse_50(
+class _FakeMisskeyUsersLists_50 extends _i1.SmartFake
+    implements _i5.MisskeyUsersLists {
+  _FakeMisskeyUsersLists_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -593,9 +592,9 @@ class _FakeRolesListResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeMisskeyUsersLists_51 extends _i1.SmartFake
-    implements _i6.MisskeyUsersLists {
-  _FakeMisskeyUsersLists_51(
+class _FakeUsersShowResponse_51 extends _i1.SmartFake
+    implements _i5.UsersShowResponse {
+  _FakeUsersShowResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -604,9 +603,8 @@ class _FakeMisskeyUsersLists_51 extends _i1.SmartFake
         );
 }
 
-class _FakeUsersShowResponse_52 extends _i1.SmartFake
-    implements _i6.UsersShowResponse {
-  _FakeUsersShowResponse_52(
+class _FakeBaseOptions_52 extends _i1.SmartFake implements _i10.BaseOptions {
+  _FakeBaseOptions_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -615,8 +613,9 @@ class _FakeUsersShowResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeBaseOptions_53 extends _i1.SmartFake implements _i11.BaseOptions {
-  _FakeBaseOptions_53(
+class _FakeHttpClientAdapter_53 extends _i1.SmartFake
+    implements _i10.HttpClientAdapter {
+  _FakeHttpClientAdapter_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -625,9 +624,8 @@ class _FakeBaseOptions_53 extends _i1.SmartFake implements _i11.BaseOptions {
         );
 }
 
-class _FakeHttpClientAdapter_54 extends _i1.SmartFake
-    implements _i11.HttpClientAdapter {
-  _FakeHttpClientAdapter_54(
+class _FakeTransformer_54 extends _i1.SmartFake implements _i10.Transformer {
+  _FakeTransformer_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -636,8 +634,8 @@ class _FakeHttpClientAdapter_54 extends _i1.SmartFake
         );
 }
 
-class _FakeTransformer_55 extends _i1.SmartFake implements _i11.Transformer {
-  _FakeTransformer_55(
+class _FakeInterceptors_55 extends _i1.SmartFake implements _i10.Interceptors {
+  _FakeInterceptors_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -646,8 +644,8 @@ class _FakeTransformer_55 extends _i1.SmartFake implements _i11.Transformer {
         );
 }
 
-class _FakeInterceptors_56 extends _i1.SmartFake implements _i11.Interceptors {
-  _FakeInterceptors_56(
+class _FakeResponse_56<T1> extends _i1.SmartFake implements _i10.Response<T1> {
+  _FakeResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -656,8 +654,8 @@ class _FakeInterceptors_56 extends _i1.SmartFake implements _i11.Interceptors {
         );
 }
 
-class _FakeResponse_57<T1> extends _i1.SmartFake implements _i11.Response<T1> {
-  _FakeResponse_57(
+class _FakeDuration_57 extends _i1.SmartFake implements Duration {
+  _FakeDuration_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -666,8 +664,9 @@ class _FakeResponse_57<T1> extends _i1.SmartFake implements _i11.Response<T1> {
         );
 }
 
-class _FakeDuration_58 extends _i1.SmartFake implements Duration {
-  _FakeDuration_58(
+class _FakeHttpClientRequest_58 extends _i1.SmartFake
+    implements _i11.HttpClientRequest {
+  _FakeHttpClientRequest_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -676,9 +675,8 @@ class _FakeDuration_58 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakeHttpClientRequest_59 extends _i1.SmartFake
-    implements _i12.HttpClientRequest {
-  _FakeHttpClientRequest_59(
+class _FakeFile_59 extends _i1.SmartFake implements _i12.File {
+  _FakeFile_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -687,29 +685,8 @@ class _FakeHttpClientRequest_59 extends _i1.SmartFake
         );
 }
 
-class _FakeWebSocketChannel_60 extends _i1.SmartFake
-    implements _i13.WebSocketChannel {
-  _FakeWebSocketChannel_60(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeFile_61 extends _i1.SmartFake implements _i14.File {
-  _FakeFile_61(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeFileInfo_62 extends _i1.SmartFake implements _i15.FileInfo {
-  _FakeFileInfo_62(
+class _FakeFileInfo_60 extends _i1.SmartFake implements _i13.FileInfo {
+  _FakeFileInfo_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -722,13 +699,13 @@ class _FakeFileInfo_62 extends _i1.SmartFake implements _i15.FileInfo {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTabSettingsRepository extends _i1.Mock
-    implements _i4.TabSettingsRepository {
+    implements _i14.TabSettingsRepository {
   @override
-  Iterable<_i16.TabSetting> get tabSettings => (super.noSuchMethod(
+  Iterable<_i15.TabSetting> get tabSettings => (super.noSuchMethod(
         Invocation.getter(#tabSettings),
-        returnValue: <_i16.TabSetting>[],
-        returnValueForMissingStub: <_i16.TabSetting>[],
-      ) as Iterable<_i16.TabSetting>);
+        returnValue: <_i15.TabSetting>[],
+        returnValueForMissingStub: <_i15.TabSetting>[],
+      ) as Iterable<_i15.TabSetting>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -738,35 +715,46 @@ class MockTabSettingsRepository extends _i1.Mock
       ) as bool);
 
   @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i16.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> save(List<_i16.TabSetting>? tabSettings) =>
+  _i16.Future<void> save(List<_i15.TabSetting>? tabSettings) =>
       (super.noSuchMethod(
         Invocation.method(
           #save,
           [tabSettings],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> removeAccount(_i18.Account? account) => (super.noSuchMethod(
+  _i16.Future<void> removeAccount(_i17.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #removeAccount,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
+
+  @override
+  _i16.Future<void> initializeTabSettings(_i18.Acct? acct) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #initializeTabSettings,
+          [acct],
+        ),
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
@@ -809,7 +797,7 @@ class MockTabSettingsRepository extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockAccountSettingsRepository extends _i1.Mock
-    implements _i5.AccountSettingsRepository {
+    implements _i20.AccountSettingsRepository {
   @override
   Iterable<_i2.AccountSettings> get accountSettings => (super.noSuchMethod(
         Invocation.getter(#accountSettings),
@@ -825,37 +813,37 @@ class MockAccountSettingsRepository extends _i1.Mock
       ) as bool);
 
   @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i16.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> save(_i2.AccountSettings? settings) => (super.noSuchMethod(
+  _i16.Future<void> save(_i2.AccountSettings? settings) => (super.noSuchMethod(
         Invocation.method(
           #save,
           [settings],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> removeAccount(_i18.Account? account) => (super.noSuchMethod(
+  _i16.Future<void> removeAccount(_i17.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #removeAccount,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i2.AccountSettings fromAcct(_i20.Acct? acct) => (super.noSuchMethod(
+  _i2.AccountSettings fromAcct(_i18.Acct? acct) => (super.noSuchMethod(
         Invocation.method(
           #fromAcct,
           [acct],
@@ -877,7 +865,7 @@ class MockAccountSettingsRepository extends _i1.Mock
       ) as _i2.AccountSettings);
 
   @override
-  _i2.AccountSettings fromAccount(_i18.Account? account) => (super.noSuchMethod(
+  _i2.AccountSettings fromAccount(_i17.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #fromAccount,
           [account],
@@ -949,37 +937,37 @@ class MockEmojiRepository extends _i1.Mock implements _i21.EmojiRepository {
       );
 
   @override
-  _i17.Future<void> loadFromSourceIfNeed() => (super.noSuchMethod(
+  _i16.Future<void> loadFromSourceIfNeed() => (super.noSuchMethod(
         Invocation.method(
           #loadFromSourceIfNeed,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> loadFromSource() => (super.noSuchMethod(
+  _i16.Future<void> loadFromSource() => (super.noSuchMethod(
         Invocation.method(
           #loadFromSource,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> loadFromLocalCache() => (super.noSuchMethod(
+  _i16.Future<void> loadFromLocalCache() => (super.noSuchMethod(
         Invocation.method(
           #loadFromLocalCache,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<List<_i22.MisskeyEmojiData>> searchEmojis(
+  _i16.Future<List<_i22.MisskeyEmojiData>> searchEmojis(
     String? name, {
     int? limit = 30,
   }) =>
@@ -989,12 +977,12 @@ class MockEmojiRepository extends _i1.Mock implements _i21.EmojiRepository {
           [name],
           {#limit: limit},
         ),
-        returnValue: _i17.Future<List<_i22.MisskeyEmojiData>>.value(
+        returnValue: _i16.Future<List<_i22.MisskeyEmojiData>>.value(
             <_i22.MisskeyEmojiData>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i22.MisskeyEmojiData>>.value(
+            _i16.Future<List<_i22.MisskeyEmojiData>>.value(
                 <_i22.MisskeyEmojiData>[]),
-      ) as _i17.Future<List<_i22.MisskeyEmojiData>>);
+      ) as _i16.Future<List<_i22.MisskeyEmojiData>>);
 
   @override
   List<_i22.MisskeyEmojiData> defaultEmojis({int? limit}) =>
@@ -1035,25 +1023,25 @@ class MockGeneralSettingsRepository extends _i1.Mock
       ) as bool);
 
   @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i16.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> update(_i3.GeneralSettings? settings) =>
+  _i16.Future<void> update(_i3.GeneralSettings? settings) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [settings],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
@@ -1097,109 +1085,70 @@ class MockGeneralSettingsRepository extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
   @override
-  List<bool> get accountDataValidated => (super.noSuchMethod(
-        Invocation.getter(#accountDataValidated),
-        returnValue: <bool>[],
-        returnValueForMissingStub: <bool>[],
-      ) as List<bool>);
+  _i4.NotifierProviderRef<List<_i17.Account>> get ref => (super.noSuchMethod(
+        Invocation.getter(#ref),
+        returnValue: _FakeNotifierProviderRef_2<List<_i17.Account>>(
+          this,
+          Invocation.getter(#ref),
+        ),
+        returnValueForMissingStub:
+            _FakeNotifierProviderRef_2<List<_i17.Account>>(
+          this,
+          Invocation.getter(#ref),
+        ),
+      ) as _i4.NotifierProviderRef<List<_i17.Account>>);
 
   @override
-  _i4.TabSettingsRepository get tabSettingsRepository => (super.noSuchMethod(
-        Invocation.getter(#tabSettingsRepository),
-        returnValue: _FakeTabSettingsRepository_2(
-          this,
-          Invocation.getter(#tabSettingsRepository),
-        ),
-        returnValueForMissingStub: _FakeTabSettingsRepository_2(
-          this,
-          Invocation.getter(#tabSettingsRepository),
-        ),
-      ) as _i4.TabSettingsRepository);
+  List<_i17.Account> get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: <_i17.Account>[],
+        returnValueForMissingStub: <_i17.Account>[],
+      ) as List<_i17.Account>);
 
   @override
-  _i5.AccountSettingsRepository get accountSettingsRepository =>
-      (super.noSuchMethod(
-        Invocation.getter(#accountSettingsRepository),
-        returnValue: _FakeAccountSettingsRepository_3(
-          this,
-          Invocation.getter(#accountSettingsRepository),
-        ),
-        returnValueForMissingStub: _FakeAccountSettingsRepository_3(
-          this,
-          Invocation.getter(#accountSettingsRepository),
-        ),
-      ) as _i5.AccountSettingsRepository);
-
-  @override
-  T Function<T>(_i25.ProviderListenable<T>) get reader => (super.noSuchMethod(
-        Invocation.getter(#reader),
-        returnValue: <T>(_i25.ProviderListenable<T> provider) =>
-            _i26.dummyValue<T>(
-          this,
-          Invocation.getter(#reader),
-        ),
-        returnValueForMissingStub: <T>(_i25.ProviderListenable<T> provider) =>
-            _i26.dummyValue<T>(
-          this,
-          Invocation.getter(#reader),
-        ),
-      ) as T Function<T>(_i25.ProviderListenable<T>));
-
-  @override
-  String get sessionId => (super.noSuchMethod(
-        Invocation.getter(#sessionId),
-        returnValue: '',
-        returnValueForMissingStub: '',
-      ) as String);
-
-  @override
-  set sessionId(String? _sessionId) => super.noSuchMethod(
+  set state(List<_i17.Account>? value) => super.noSuchMethod(
         Invocation.setter(
-          #sessionId,
-          _sessionId,
+          #state,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  Iterable<_i18.Account> get account => (super.noSuchMethod(
-        Invocation.getter(#account),
-        returnValue: <_i18.Account>[],
-        returnValueForMissingStub: <_i18.Account>[],
-      ) as Iterable<_i18.Account>);
+  List<_i17.Account> build() => (super.noSuchMethod(
+        Invocation.method(
+          #build,
+          [],
+        ),
+        returnValue: <_i17.Account>[],
+        returnValueForMissingStub: <_i17.Account>[],
+      ) as List<_i17.Account>);
 
   @override
-  bool get hasListeners => (super.noSuchMethod(
-        Invocation.getter(#hasListeners),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i16.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> loadFromSourceIfNeed(_i20.Acct? acct) =>
+  _i16.Future<void> loadFromSourceIfNeed(_i18.Acct? acct) =>
       (super.noSuchMethod(
         Invocation.method(
           #loadFromSourceIfNeed,
           [acct],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> createUnreadAnnouncement(
-    _i18.Account? account,
-    _i6.AnnouncementsResponse? announcement,
+  _i16.Future<void> createUnreadAnnouncement(
+    _i17.Account? account,
+    _i5.AnnouncementsResponse? announcement,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1209,43 +1158,33 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
             announcement,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> removeUnreadAnnouncement(_i18.Account? account) =>
+  _i16.Future<void> removeUnreadAnnouncement(_i17.Account? account) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeUnreadAnnouncement,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> remove(_i18.Account? account) => (super.noSuchMethod(
+  _i16.Future<void> remove(_i17.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> validateMisskey(String? server) => (super.noSuchMethod(
-        Invocation.method(
-          #validateMisskey,
-          [server],
-        ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
-
-  @override
-  _i17.Future<void> loginAsPassword(
+  _i16.Future<void> loginAsPassword(
     String? server,
     String? userId,
     String? password,
@@ -1259,12 +1198,12 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
             password,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> loginAsToken(
+  _i16.Future<void> loginAsToken(
     String? server,
     String? token,
   ) =>
@@ -1276,103 +1215,64 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
             token,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> openMiAuth(String? server) => (super.noSuchMethod(
+  _i16.Future<void> openMiAuth(String? server) => (super.noSuchMethod(
         Invocation.method(
           #openMiAuth,
           [server],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> validateMiAuth(String? server) => (super.noSuchMethod(
+  _i16.Future<void> validateMiAuth(String? server) => (super.noSuchMethod(
         Invocation.method(
           #validateMiAuth,
           [server],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> addAccount(_i18.Account? account) => (super.noSuchMethod(
+  bool updateShouldNotify(
+    List<_i17.Account>? previous,
+    List<_i17.Account>? next,
+  ) =>
+      (super.noSuchMethod(
         Invocation.method(
-          #addAccount,
-          [account],
+          #updateShouldNotify,
+          [
+            previous,
+            next,
+          ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
-
-  @override
-  _i17.Future<void> save() => (super.noSuchMethod(
-        Invocation.method(
-          #save,
-          [],
-        ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
-
-  @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
 }
 
 /// A class which mocks [NoteRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
+class MockNoteRepository extends _i1.Mock implements _i25.NoteRepository {
   @override
-  _i6.Misskey get misskey => (super.noSuchMethod(
+  _i5.Misskey get misskey => (super.noSuchMethod(
         Invocation.getter(#misskey),
-        returnValue: _FakeMisskey_4(
+        returnValue: _FakeMisskey_3(
           this,
           Invocation.getter(#misskey),
         ),
-        returnValueForMissingStub: _FakeMisskey_4(
+        returnValueForMissingStub: _FakeMisskey_3(
           this,
           Invocation.getter(#misskey),
         ),
-      ) as _i6.Misskey);
+      ) as _i5.Misskey);
 
   @override
   List<List<String>> get muteWordContents => (super.noSuchMethod(
@@ -1389,18 +1289,18 @@ class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
       ) as List<RegExp>);
 
   @override
-  Map<String, _i6.Note> get notes => (super.noSuchMethod(
+  Map<String, _i5.Note> get notes => (super.noSuchMethod(
         Invocation.getter(#notes),
-        returnValue: <String, _i6.Note>{},
-        returnValueForMissingStub: <String, _i6.Note>{},
-      ) as Map<String, _i6.Note>);
+        returnValue: <String, _i5.Note>{},
+        returnValueForMissingStub: <String, _i5.Note>{},
+      ) as Map<String, _i5.Note>);
 
   @override
-  Map<String, _i27.NoteStatus> get noteStatuses => (super.noSuchMethod(
+  Map<String, _i25.NoteStatus> get noteStatuses => (super.noSuchMethod(
         Invocation.getter(#noteStatuses),
-        returnValue: <String, _i27.NoteStatus>{},
-        returnValueForMissingStub: <String, _i27.NoteStatus>{},
-      ) as Map<String, _i27.NoteStatus>);
+        returnValue: <String, _i25.NoteStatus>{},
+        returnValueForMissingStub: <String, _i25.NoteStatus>{},
+      ) as Map<String, _i25.NoteStatus>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -1410,7 +1310,7 @@ class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
       ) as bool);
 
   @override
-  void updateMute(List<_i6.MuteWord>? mutedWords) => super.noSuchMethod(
+  void updateMute(List<_i5.MuteWord>? mutedWords) => super.noSuchMethod(
         Invocation.method(
           #updateMute,
           [mutedWords],
@@ -1421,7 +1321,7 @@ class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
   @override
   void updateNoteStatus(
     String? id,
-    _i27.NoteStatus Function(_i27.NoteStatus)? statusPredicate, {
+    _i25.NoteStatus Function(_i25.NoteStatus)? statusPredicate, {
     bool? isNotify = true,
   }) =>
       super.noSuchMethod(
@@ -1437,7 +1337,7 @@ class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
       );
 
   @override
-  void registerNote(_i6.Note? note) => super.noSuchMethod(
+  void registerNote(_i5.Note? note) => super.noSuchMethod(
         Invocation.method(
           #registerNote,
           [note],
@@ -1446,7 +1346,7 @@ class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
       );
 
   @override
-  void registerAll(Iterable<_i6.Note>? notes) => super.noSuchMethod(
+  void registerAll(Iterable<_i5.Note>? notes) => super.noSuchMethod(
         Invocation.method(
           #registerAll,
           [notes],
@@ -1455,14 +1355,14 @@ class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
       );
 
   @override
-  _i17.Future<void> refresh(String? noteId) => (super.noSuchMethod(
+  _i16.Future<void> refresh(String? noteId) => (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [noteId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void delete(String? noteId) => super.noSuchMethod(
@@ -1513,7 +1413,7 @@ class MockNoteRepository extends _i1.Mock implements _i27.NoteRepository {
 /// A class which mocks [Misskey].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskey extends _i1.Mock implements _i6.Misskey {
+class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   String get host => (super.noSuchMethod(
         Invocation.getter(#host),
@@ -1522,20 +1422,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       ) as String);
 
   @override
-  _i7.ApiService get apiService => (super.noSuchMethod(
+  _i6.ApiService get apiService => (super.noSuchMethod(
         Invocation.getter(#apiService),
-        returnValue: _FakeApiService_5(
+        returnValue: _FakeApiService_4(
           this,
           Invocation.getter(#apiService),
         ),
-        returnValueForMissingStub: _FakeApiService_5(
+        returnValueForMissingStub: _FakeApiService_4(
           this,
           Invocation.getter(#apiService),
         ),
-      ) as _i7.ApiService);
+      ) as _i6.ApiService);
 
   @override
-  set apiService(_i7.ApiService? _apiService) => super.noSuchMethod(
+  set apiService(_i6.ApiService? _apiService) => super.noSuchMethod(
         Invocation.setter(
           #apiService,
           _apiService,
@@ -1544,20 +1444,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.StreamingService get streamingService => (super.noSuchMethod(
+  _i5.StreamingService get streamingService => (super.noSuchMethod(
         Invocation.getter(#streamingService),
-        returnValue: _FakeStreamingService_6(
+        returnValue: _FakeStreamingService_5(
           this,
           Invocation.getter(#streamingService),
         ),
-        returnValueForMissingStub: _FakeStreamingService_6(
+        returnValueForMissingStub: _FakeStreamingService_5(
           this,
           Invocation.getter(#streamingService),
         ),
-      ) as _i6.StreamingService);
+      ) as _i5.StreamingService);
 
   @override
-  set streamingService(_i6.StreamingService? _streamingService) =>
+  set streamingService(_i5.StreamingService? _streamingService) =>
       super.noSuchMethod(
         Invocation.setter(
           #streamingService,
@@ -1567,20 +1467,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyNotes get notes => (super.noSuchMethod(
+  _i5.MisskeyNotes get notes => (super.noSuchMethod(
         Invocation.getter(#notes),
-        returnValue: _FakeMisskeyNotes_7(
+        returnValue: _FakeMisskeyNotes_6(
           this,
           Invocation.getter(#notes),
         ),
-        returnValueForMissingStub: _FakeMisskeyNotes_7(
+        returnValueForMissingStub: _FakeMisskeyNotes_6(
           this,
           Invocation.getter(#notes),
         ),
-      ) as _i6.MisskeyNotes);
+      ) as _i5.MisskeyNotes);
 
   @override
-  set notes(_i6.MisskeyNotes? _notes) => super.noSuchMethod(
+  set notes(_i5.MisskeyNotes? _notes) => super.noSuchMethod(
         Invocation.setter(
           #notes,
           _notes,
@@ -1589,20 +1489,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyChannels get channels => (super.noSuchMethod(
+  _i5.MisskeyChannels get channels => (super.noSuchMethod(
         Invocation.getter(#channels),
-        returnValue: _FakeMisskeyChannels_8(
+        returnValue: _FakeMisskeyChannels_7(
           this,
           Invocation.getter(#channels),
         ),
-        returnValueForMissingStub: _FakeMisskeyChannels_8(
+        returnValueForMissingStub: _FakeMisskeyChannels_7(
           this,
           Invocation.getter(#channels),
         ),
-      ) as _i6.MisskeyChannels);
+      ) as _i5.MisskeyChannels);
 
   @override
-  set channels(_i6.MisskeyChannels? _channels) => super.noSuchMethod(
+  set channels(_i5.MisskeyChannels? _channels) => super.noSuchMethod(
         Invocation.setter(
           #channels,
           _channels,
@@ -1611,20 +1511,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyUsers get users => (super.noSuchMethod(
+  _i5.MisskeyUsers get users => (super.noSuchMethod(
         Invocation.getter(#users),
-        returnValue: _FakeMisskeyUsers_9(
+        returnValue: _FakeMisskeyUsers_8(
           this,
           Invocation.getter(#users),
         ),
-        returnValueForMissingStub: _FakeMisskeyUsers_9(
+        returnValueForMissingStub: _FakeMisskeyUsers_8(
           this,
           Invocation.getter(#users),
         ),
-      ) as _i6.MisskeyUsers);
+      ) as _i5.MisskeyUsers);
 
   @override
-  set users(_i6.MisskeyUsers? _users) => super.noSuchMethod(
+  set users(_i5.MisskeyUsers? _users) => super.noSuchMethod(
         Invocation.setter(
           #users,
           _users,
@@ -1633,20 +1533,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyI get i => (super.noSuchMethod(
+  _i5.MisskeyI get i => (super.noSuchMethod(
         Invocation.getter(#i),
-        returnValue: _FakeMisskeyI_10(
+        returnValue: _FakeMisskeyI_9(
           this,
           Invocation.getter(#i),
         ),
-        returnValueForMissingStub: _FakeMisskeyI_10(
+        returnValueForMissingStub: _FakeMisskeyI_9(
           this,
           Invocation.getter(#i),
         ),
-      ) as _i6.MisskeyI);
+      ) as _i5.MisskeyI);
 
   @override
-  set i(_i6.MisskeyI? _i) => super.noSuchMethod(
+  set i(_i5.MisskeyI? _i) => super.noSuchMethod(
         Invocation.setter(
           #i,
           _i,
@@ -1655,20 +1555,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyClips get clips => (super.noSuchMethod(
+  _i5.MisskeyClips get clips => (super.noSuchMethod(
         Invocation.getter(#clips),
-        returnValue: _FakeMisskeyClips_11(
+        returnValue: _FakeMisskeyClips_10(
           this,
           Invocation.getter(#clips),
         ),
-        returnValueForMissingStub: _FakeMisskeyClips_11(
+        returnValueForMissingStub: _FakeMisskeyClips_10(
           this,
           Invocation.getter(#clips),
         ),
-      ) as _i6.MisskeyClips);
+      ) as _i5.MisskeyClips);
 
   @override
-  set clips(_i6.MisskeyClips? _clips) => super.noSuchMethod(
+  set clips(_i5.MisskeyClips? _clips) => super.noSuchMethod(
         Invocation.setter(
           #clips,
           _clips,
@@ -1677,20 +1577,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyAntenna get antennas => (super.noSuchMethod(
+  _i5.MisskeyAntenna get antennas => (super.noSuchMethod(
         Invocation.getter(#antennas),
-        returnValue: _FakeMisskeyAntenna_12(
+        returnValue: _FakeMisskeyAntenna_11(
           this,
           Invocation.getter(#antennas),
         ),
-        returnValueForMissingStub: _FakeMisskeyAntenna_12(
+        returnValueForMissingStub: _FakeMisskeyAntenna_11(
           this,
           Invocation.getter(#antennas),
         ),
-      ) as _i6.MisskeyAntenna);
+      ) as _i5.MisskeyAntenna);
 
   @override
-  set antennas(_i6.MisskeyAntenna? _antennas) => super.noSuchMethod(
+  set antennas(_i5.MisskeyAntenna? _antennas) => super.noSuchMethod(
         Invocation.setter(
           #antennas,
           _antennas,
@@ -1699,20 +1599,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyDrive get drive => (super.noSuchMethod(
+  _i5.MisskeyDrive get drive => (super.noSuchMethod(
         Invocation.getter(#drive),
-        returnValue: _FakeMisskeyDrive_13(
+        returnValue: _FakeMisskeyDrive_12(
           this,
           Invocation.getter(#drive),
         ),
-        returnValueForMissingStub: _FakeMisskeyDrive_13(
+        returnValueForMissingStub: _FakeMisskeyDrive_12(
           this,
           Invocation.getter(#drive),
         ),
-      ) as _i6.MisskeyDrive);
+      ) as _i5.MisskeyDrive);
 
   @override
-  set drive(_i6.MisskeyDrive? _drive) => super.noSuchMethod(
+  set drive(_i5.MisskeyDrive? _drive) => super.noSuchMethod(
         Invocation.setter(
           #drive,
           _drive,
@@ -1721,20 +1621,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyFollowing get following => (super.noSuchMethod(
+  _i5.MisskeyFollowing get following => (super.noSuchMethod(
         Invocation.getter(#following),
-        returnValue: _FakeMisskeyFollowing_14(
+        returnValue: _FakeMisskeyFollowing_13(
           this,
           Invocation.getter(#following),
         ),
-        returnValueForMissingStub: _FakeMisskeyFollowing_14(
+        returnValueForMissingStub: _FakeMisskeyFollowing_13(
           this,
           Invocation.getter(#following),
         ),
-      ) as _i6.MisskeyFollowing);
+      ) as _i5.MisskeyFollowing);
 
   @override
-  set following(_i6.MisskeyFollowing? _following) => super.noSuchMethod(
+  set following(_i5.MisskeyFollowing? _following) => super.noSuchMethod(
         Invocation.setter(
           #following,
           _following,
@@ -1743,20 +1643,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyBlocking get blocking => (super.noSuchMethod(
+  _i5.MisskeyBlocking get blocking => (super.noSuchMethod(
         Invocation.getter(#blocking),
-        returnValue: _FakeMisskeyBlocking_15(
+        returnValue: _FakeMisskeyBlocking_14(
           this,
           Invocation.getter(#blocking),
         ),
-        returnValueForMissingStub: _FakeMisskeyBlocking_15(
+        returnValueForMissingStub: _FakeMisskeyBlocking_14(
           this,
           Invocation.getter(#blocking),
         ),
-      ) as _i6.MisskeyBlocking);
+      ) as _i5.MisskeyBlocking);
 
   @override
-  set blocking(_i6.MisskeyBlocking? _blocking) => super.noSuchMethod(
+  set blocking(_i5.MisskeyBlocking? _blocking) => super.noSuchMethod(
         Invocation.setter(
           #blocking,
           _blocking,
@@ -1765,20 +1665,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyMute get mute => (super.noSuchMethod(
+  _i5.MisskeyMute get mute => (super.noSuchMethod(
         Invocation.getter(#mute),
-        returnValue: _FakeMisskeyMute_16(
+        returnValue: _FakeMisskeyMute_15(
           this,
           Invocation.getter(#mute),
         ),
-        returnValueForMissingStub: _FakeMisskeyMute_16(
+        returnValueForMissingStub: _FakeMisskeyMute_15(
           this,
           Invocation.getter(#mute),
         ),
-      ) as _i6.MisskeyMute);
+      ) as _i5.MisskeyMute);
 
   @override
-  set mute(_i6.MisskeyMute? _mute) => super.noSuchMethod(
+  set mute(_i5.MisskeyMute? _mute) => super.noSuchMethod(
         Invocation.setter(
           #mute,
           _mute,
@@ -1787,20 +1687,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyRenoteMute get renoteMute => (super.noSuchMethod(
+  _i5.MisskeyRenoteMute get renoteMute => (super.noSuchMethod(
         Invocation.getter(#renoteMute),
-        returnValue: _FakeMisskeyRenoteMute_17(
+        returnValue: _FakeMisskeyRenoteMute_16(
           this,
           Invocation.getter(#renoteMute),
         ),
-        returnValueForMissingStub: _FakeMisskeyRenoteMute_17(
+        returnValueForMissingStub: _FakeMisskeyRenoteMute_16(
           this,
           Invocation.getter(#renoteMute),
         ),
-      ) as _i6.MisskeyRenoteMute);
+      ) as _i5.MisskeyRenoteMute);
 
   @override
-  set renoteMute(_i6.MisskeyRenoteMute? _renoteMute) => super.noSuchMethod(
+  set renoteMute(_i5.MisskeyRenoteMute? _renoteMute) => super.noSuchMethod(
         Invocation.setter(
           #renoteMute,
           _renoteMute,
@@ -1809,20 +1709,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyFederation get federation => (super.noSuchMethod(
+  _i5.MisskeyFederation get federation => (super.noSuchMethod(
         Invocation.getter(#federation),
-        returnValue: _FakeMisskeyFederation_18(
+        returnValue: _FakeMisskeyFederation_17(
           this,
           Invocation.getter(#federation),
         ),
-        returnValueForMissingStub: _FakeMisskeyFederation_18(
+        returnValueForMissingStub: _FakeMisskeyFederation_17(
           this,
           Invocation.getter(#federation),
         ),
-      ) as _i6.MisskeyFederation);
+      ) as _i5.MisskeyFederation);
 
   @override
-  set federation(_i6.MisskeyFederation? _federation) => super.noSuchMethod(
+  set federation(_i5.MisskeyFederation? _federation) => super.noSuchMethod(
         Invocation.setter(
           #federation,
           _federation,
@@ -1831,20 +1731,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyRoles get roles => (super.noSuchMethod(
+  _i5.MisskeyRoles get roles => (super.noSuchMethod(
         Invocation.getter(#roles),
-        returnValue: _FakeMisskeyRoles_19(
+        returnValue: _FakeMisskeyRoles_18(
           this,
           Invocation.getter(#roles),
         ),
-        returnValueForMissingStub: _FakeMisskeyRoles_19(
+        returnValueForMissingStub: _FakeMisskeyRoles_18(
           this,
           Invocation.getter(#roles),
         ),
-      ) as _i6.MisskeyRoles);
+      ) as _i5.MisskeyRoles);
 
   @override
-  set roles(_i6.MisskeyRoles? _roles) => super.noSuchMethod(
+  set roles(_i5.MisskeyRoles? _roles) => super.noSuchMethod(
         Invocation.setter(
           #roles,
           _roles,
@@ -1853,20 +1753,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyHashtags get hashtags => (super.noSuchMethod(
+  _i5.MisskeyHashtags get hashtags => (super.noSuchMethod(
         Invocation.getter(#hashtags),
-        returnValue: _FakeMisskeyHashtags_20(
+        returnValue: _FakeMisskeyHashtags_19(
           this,
           Invocation.getter(#hashtags),
         ),
-        returnValueForMissingStub: _FakeMisskeyHashtags_20(
+        returnValueForMissingStub: _FakeMisskeyHashtags_19(
           this,
           Invocation.getter(#hashtags),
         ),
-      ) as _i6.MisskeyHashtags);
+      ) as _i5.MisskeyHashtags);
 
   @override
-  set hashtags(_i6.MisskeyHashtags? _hashtags) => super.noSuchMethod(
+  set hashtags(_i5.MisskeyHashtags? _hashtags) => super.noSuchMethod(
         Invocation.setter(
           #hashtags,
           _hashtags,
@@ -1875,20 +1775,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyAp get ap => (super.noSuchMethod(
+  _i5.MisskeyAp get ap => (super.noSuchMethod(
         Invocation.getter(#ap),
-        returnValue: _FakeMisskeyAp_21(
+        returnValue: _FakeMisskeyAp_20(
           this,
           Invocation.getter(#ap),
         ),
-        returnValueForMissingStub: _FakeMisskeyAp_21(
+        returnValueForMissingStub: _FakeMisskeyAp_20(
           this,
           Invocation.getter(#ap),
         ),
-      ) as _i6.MisskeyAp);
+      ) as _i5.MisskeyAp);
 
   @override
-  set ap(_i6.MisskeyAp? _ap) => super.noSuchMethod(
+  set ap(_i5.MisskeyAp? _ap) => super.noSuchMethod(
         Invocation.setter(
           #ap,
           _ap,
@@ -1897,20 +1797,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i6.MisskeyPages get pages => (super.noSuchMethod(
+  _i5.MisskeyPages get pages => (super.noSuchMethod(
         Invocation.getter(#pages),
-        returnValue: _FakeMisskeyPages_22(
+        returnValue: _FakeMisskeyPages_21(
           this,
           Invocation.getter(#pages),
         ),
-        returnValueForMissingStub: _FakeMisskeyPages_22(
+        returnValueForMissingStub: _FakeMisskeyPages_21(
           this,
           Invocation.getter(#pages),
         ),
-      ) as _i6.MisskeyPages);
+      ) as _i5.MisskeyPages);
 
   @override
-  set pages(_i6.MisskeyPages? _pages) => super.noSuchMethod(
+  set pages(_i5.MisskeyPages? _pages) => super.noSuchMethod(
         Invocation.setter(
           #pages,
           _pages,
@@ -1919,20 +1819,20 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i8.MisskeyFlash get flash => (super.noSuchMethod(
+  _i7.MisskeyFlash get flash => (super.noSuchMethod(
         Invocation.getter(#flash),
-        returnValue: _FakeMisskeyFlash_23(
+        returnValue: _FakeMisskeyFlash_22(
           this,
           Invocation.getter(#flash),
         ),
-        returnValueForMissingStub: _FakeMisskeyFlash_23(
+        returnValueForMissingStub: _FakeMisskeyFlash_22(
           this,
           Invocation.getter(#flash),
         ),
-      ) as _i8.MisskeyFlash);
+      ) as _i7.MisskeyFlash);
 
   @override
-  set flash(_i8.MisskeyFlash? _flash) => super.noSuchMethod(
+  set flash(_i7.MisskeyFlash? _flash) => super.noSuchMethod(
         Invocation.setter(
           #flash,
           _flash,
@@ -1941,38 +1841,38 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
       );
 
   @override
-  _i17.Future<Iterable<_i6.AnnouncementsResponse>> announcements(
-          _i6.AnnouncementsRequest? request) =>
+  _i16.Future<Iterable<_i5.AnnouncementsResponse>> announcements(
+          _i5.AnnouncementsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #announcements,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.AnnouncementsResponse>>.value(
-            <_i6.AnnouncementsResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.AnnouncementsResponse>>.value(
+            <_i5.AnnouncementsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.AnnouncementsResponse>>.value(
-                <_i6.AnnouncementsResponse>[]),
-      ) as _i17.Future<Iterable<_i6.AnnouncementsResponse>>);
+            _i16.Future<Iterable<_i5.AnnouncementsResponse>>.value(
+                <_i5.AnnouncementsResponse>[]),
+      ) as _i16.Future<Iterable<_i5.AnnouncementsResponse>>);
 
   @override
-  _i17.Future<List<String>> endpoints() => (super.noSuchMethod(
+  _i16.Future<List<String>> endpoints() => (super.noSuchMethod(
         Invocation.method(
           #endpoints,
           [],
         ),
-        returnValue: _i17.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
-      ) as _i17.Future<List<String>>);
+        returnValue: _i16.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
+      ) as _i16.Future<List<String>>);
 
   @override
-  _i17.Future<_i6.EmojisResponse> emojis() => (super.noSuchMethod(
+  _i16.Future<_i5.EmojisResponse> emojis() => (super.noSuchMethod(
         Invocation.method(
           #emojis,
           [],
         ),
         returnValue:
-            _i17.Future<_i6.EmojisResponse>.value(_FakeEmojisResponse_24(
+            _i16.Future<_i5.EmojisResponse>.value(_FakeEmojisResponse_23(
           this,
           Invocation.method(
             #emojis,
@@ -1980,23 +1880,23 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.EmojisResponse>.value(_FakeEmojisResponse_24(
+            _i16.Future<_i5.EmojisResponse>.value(_FakeEmojisResponse_23(
           this,
           Invocation.method(
             #emojis,
             [],
           ),
         )),
-      ) as _i17.Future<_i6.EmojisResponse>);
+      ) as _i16.Future<_i5.EmojisResponse>);
 
   @override
-  _i17.Future<_i6.EmojiResponse> emoji(_i6.EmojiRequest? request) =>
+  _i16.Future<_i5.EmojiResponse> emoji(_i5.EmojiRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #emoji,
           [request],
         ),
-        returnValue: _i17.Future<_i6.EmojiResponse>.value(_FakeEmojiResponse_25(
+        returnValue: _i16.Future<_i5.EmojiResponse>.value(_FakeEmojiResponse_24(
           this,
           Invocation.method(
             #emoji,
@@ -2004,22 +1904,22 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.EmojiResponse>.value(_FakeEmojiResponse_25(
+            _i16.Future<_i5.EmojiResponse>.value(_FakeEmojiResponse_24(
           this,
           Invocation.method(
             #emoji,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.EmojiResponse>);
+      ) as _i16.Future<_i5.EmojiResponse>);
 
   @override
-  _i17.Future<_i6.MetaResponse> meta() => (super.noSuchMethod(
+  _i16.Future<_i5.MetaResponse> meta() => (super.noSuchMethod(
         Invocation.method(
           #meta,
           [],
         ),
-        returnValue: _i17.Future<_i6.MetaResponse>.value(_FakeMetaResponse_26(
+        returnValue: _i16.Future<_i5.MetaResponse>.value(_FakeMetaResponse_25(
           this,
           Invocation.method(
             #meta,
@@ -2027,22 +1927,22 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.MetaResponse>.value(_FakeMetaResponse_26(
+            _i16.Future<_i5.MetaResponse>.value(_FakeMetaResponse_25(
           this,
           Invocation.method(
             #meta,
             [],
           ),
         )),
-      ) as _i17.Future<_i6.MetaResponse>);
+      ) as _i16.Future<_i5.MetaResponse>);
 
   @override
-  _i17.Future<_i9.StatsResponse> stats() => (super.noSuchMethod(
+  _i16.Future<_i8.StatsResponse> stats() => (super.noSuchMethod(
         Invocation.method(
           #stats,
           [],
         ),
-        returnValue: _i17.Future<_i9.StatsResponse>.value(_FakeStatsResponse_27(
+        returnValue: _i16.Future<_i8.StatsResponse>.value(_FakeStatsResponse_26(
           this,
           Invocation.method(
             #stats,
@@ -2050,22 +1950,22 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i9.StatsResponse>.value(_FakeStatsResponse_27(
+            _i16.Future<_i8.StatsResponse>.value(_FakeStatsResponse_26(
           this,
           Invocation.method(
             #stats,
             [],
           ),
         )),
-      ) as _i17.Future<_i9.StatsResponse>);
+      ) as _i16.Future<_i8.StatsResponse>);
 
   @override
-  _i17.Future<_i10.PingResponse> ping() => (super.noSuchMethod(
+  _i16.Future<_i9.PingResponse> ping() => (super.noSuchMethod(
         Invocation.method(
           #ping,
           [],
         ),
-        returnValue: _i17.Future<_i10.PingResponse>.value(_FakePingResponse_28(
+        returnValue: _i16.Future<_i9.PingResponse>.value(_FakePingResponse_27(
           this,
           Invocation.method(
             #ping,
@@ -2073,48 +1973,48 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i10.PingResponse>.value(_FakePingResponse_28(
+            _i16.Future<_i9.PingResponse>.value(_FakePingResponse_27(
           this,
           Invocation.method(
             #ping,
             [],
           ),
         )),
-      ) as _i17.Future<_i10.PingResponse>);
+      ) as _i16.Future<_i9.PingResponse>);
 
   @override
-  _i17.Future<_i6.ServerInfoResponse> serverInfo() => (super.noSuchMethod(
+  _i16.Future<_i5.ServerInfoResponse> serverInfo() => (super.noSuchMethod(
         Invocation.method(
           #serverInfo,
           [],
         ),
-        returnValue: _i17.Future<_i6.ServerInfoResponse>.value(
-            _FakeServerInfoResponse_29(
+        returnValue: _i16.Future<_i5.ServerInfoResponse>.value(
+            _FakeServerInfoResponse_28(
           this,
           Invocation.method(
             #serverInfo,
             [],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.ServerInfoResponse>.value(
-            _FakeServerInfoResponse_29(
+        returnValueForMissingStub: _i16.Future<_i5.ServerInfoResponse>.value(
+            _FakeServerInfoResponse_28(
           this,
           Invocation.method(
             #serverInfo,
             [],
           ),
         )),
-      ) as _i17.Future<_i6.ServerInfoResponse>);
+      ) as _i16.Future<_i5.ServerInfoResponse>);
 
   @override
-  _i17.Future<_i6.GetOnlineUsersCountResponse> getOnlineUsersCount() =>
+  _i16.Future<_i5.GetOnlineUsersCountResponse> getOnlineUsersCount() =>
       (super.noSuchMethod(
         Invocation.method(
           #getOnlineUsersCount,
           [],
         ),
-        returnValue: _i17.Future<_i6.GetOnlineUsersCountResponse>.value(
-            _FakeGetOnlineUsersCountResponse_30(
+        returnValue: _i16.Future<_i5.GetOnlineUsersCountResponse>.value(
+            _FakeGetOnlineUsersCountResponse_29(
           this,
           Invocation.method(
             #getOnlineUsersCount,
@@ -2122,65 +2022,65 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.GetOnlineUsersCountResponse>.value(
-                _FakeGetOnlineUsersCountResponse_30(
+            _i16.Future<_i5.GetOnlineUsersCountResponse>.value(
+                _FakeGetOnlineUsersCountResponse_29(
           this,
           Invocation.method(
             #getOnlineUsersCount,
             [],
           ),
         )),
-      ) as _i17.Future<_i6.GetOnlineUsersCountResponse>);
+      ) as _i16.Future<_i5.GetOnlineUsersCountResponse>);
 
   @override
-  _i17.Future<Iterable<_i6.GetAvatarDecorationsResponse>>
+  _i16.Future<Iterable<_i5.GetAvatarDecorationsResponse>>
       getAvatarDecorations() => (super.noSuchMethod(
             Invocation.method(
               #getAvatarDecorations,
               [],
             ),
             returnValue:
-                _i17.Future<Iterable<_i6.GetAvatarDecorationsResponse>>.value(
-                    <_i6.GetAvatarDecorationsResponse>[]),
+                _i16.Future<Iterable<_i5.GetAvatarDecorationsResponse>>.value(
+                    <_i5.GetAvatarDecorationsResponse>[]),
             returnValueForMissingStub:
-                _i17.Future<Iterable<_i6.GetAvatarDecorationsResponse>>.value(
-                    <_i6.GetAvatarDecorationsResponse>[]),
-          ) as _i17.Future<Iterable<_i6.GetAvatarDecorationsResponse>>);
+                _i16.Future<Iterable<_i5.GetAvatarDecorationsResponse>>.value(
+                    <_i5.GetAvatarDecorationsResponse>[]),
+          ) as _i16.Future<Iterable<_i5.GetAvatarDecorationsResponse>>);
 
   @override
-  _i17.Future<Iterable<_i6.User>> pinnedUsers() => (super.noSuchMethod(
+  _i16.Future<Iterable<_i5.User>> pinnedUsers() => (super.noSuchMethod(
         Invocation.method(
           #pinnedUsers,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
+        returnValue: _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
-      ) as _i17.Future<Iterable<_i6.User>>);
+            _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i16.Future<Iterable<_i5.User>>);
 
   @override
-  _i6.SocketController homeTimelineStream({
-    required _i6.HomeTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+  _i5.SocketController homeTimelineStream({
+    required _i5.HomeTimelineParameter? parameter,
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.NoteEdited,
+      _i5.NoteEdited,
     )? onUpdated,
   }) =>
       (super.noSuchMethod(
@@ -2197,7 +2097,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onUpdated: onUpdated,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #homeTimelineStream,
@@ -2213,7 +2113,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #homeTimelineStream,
@@ -2229,31 +2129,31 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController localTimelineStream({
-    required _i6.LocalTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+  _i5.SocketController localTimelineStream({
+    required _i5.LocalTimelineParameter? parameter,
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.NoteEdited,
+      _i5.NoteEdited,
     )? onUpdated,
   }) =>
       (super.noSuchMethod(
@@ -2270,7 +2170,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onUpdated: onUpdated,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #localTimelineStream,
@@ -2286,7 +2186,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #localTimelineStream,
@@ -2302,31 +2202,31 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController globalTimelineStream({
-    required _i6.GlobalTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+  _i5.SocketController globalTimelineStream({
+    required _i5.GlobalTimelineParameter? parameter,
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.NoteEdited,
+      _i5.NoteEdited,
     )? onUpdated,
   }) =>
       (super.noSuchMethod(
@@ -2343,7 +2243,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onUpdated: onUpdated,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #globalTimelineStream,
@@ -2359,7 +2259,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #globalTimelineStream,
@@ -2375,31 +2275,31 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController hybridTimelineStream({
-    required _i6.HybridTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+  _i5.SocketController hybridTimelineStream({
+    required _i5.HybridTimelineParameter? parameter,
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.NoteEdited,
+      _i5.NoteEdited,
     )? onUpdated,
   }) =>
       (super.noSuchMethod(
@@ -2416,7 +2316,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onUpdated: onUpdated,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #hybridTimelineStream,
@@ -2432,7 +2332,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #hybridTimelineStream,
@@ -2448,27 +2348,27 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController roleTimelineStream({
+  _i5.SocketController roleTimelineStream({
     required String? roleId,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
   }) =>
       (super.noSuchMethod(
@@ -2484,7 +2384,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onVoted: onVoted,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #roleTimelineStream,
@@ -2499,7 +2399,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #roleTimelineStream,
@@ -2514,31 +2414,31 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController channelStream({
+  _i5.SocketController channelStream({
     required String? channelId,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.NoteEdited,
+      _i5.NoteEdited,
     )? onUpdated,
   }) =>
       (super.noSuchMethod(
@@ -2555,7 +2455,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onUpdated: onUpdated,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #channelStream,
@@ -2571,7 +2471,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #channelStream,
@@ -2587,30 +2487,30 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController userListStream({
+  _i5.SocketController userListStream({
     required String? listId,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(_i6.User)? onUserAdded,
-    _i17.FutureOr<void> Function(_i6.User)? onUserRemoved,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(_i5.User)? onUserAdded,
+    _i16.FutureOr<void> Function(_i5.User)? onUserRemoved,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.NoteEdited,
+      _i5.NoteEdited,
     )? onUpdated,
-    _i17.FutureOr<void> Function(DateTime)? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(DateTime)? onDeleted,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
   }) =>
       (super.noSuchMethod(
@@ -2629,7 +2529,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onVoted: onVoted,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #userListStream,
@@ -2647,7 +2547,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #userListStream,
@@ -2665,31 +2565,31 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController antennaStream({
+  _i5.SocketController antennaStream({
     required String? antennaId,
-    _i17.FutureOr<void> Function(_i6.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineReacted,
+      _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.TimelineVoted,
+      _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i16.FutureOr<void> Function(
       String,
-      _i6.NoteEdited,
+      _i5.NoteEdited,
     )? onUpdated,
   }) =>
       (super.noSuchMethod(
@@ -2706,7 +2606,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onUpdated: onUpdated,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #antennaStream,
@@ -2722,7 +2622,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #antennaStream,
@@ -2738,12 +2638,12 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController serverStatsLogStream(
-    _i17.FutureOr<void> Function(List<_i6.StatsLogResponse>)? onLogReceived,
-    _i17.FutureOr<void> Function(_i6.StatsLogResponse)? onEventReceived,
+  _i5.SocketController serverStatsLogStream(
+    _i16.FutureOr<void> Function(List<_i5.StatsLogResponse>)? onLogReceived,
+    _i16.FutureOr<void> Function(_i5.StatsLogResponse)? onEventReceived,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2753,7 +2653,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             onEventReceived,
           ],
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #serverStatsLogStream,
@@ -2763,7 +2663,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #serverStatsLogStream,
@@ -2773,13 +2673,13 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             ],
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController queueStatsLogStream(
-    _i17.FutureOr<void> Function(List<_i6.QueueStatsLogResponse>)?
+  _i5.SocketController queueStatsLogStream(
+    _i16.FutureOr<void> Function(List<_i5.QueueStatsLogResponse>)?
         onLogReceived,
-    _i17.FutureOr<void> Function(_i6.QueueStatsLogResponse)? onEventReceived,
+    _i16.FutureOr<void> Function(_i5.QueueStatsLogResponse)? onEventReceived,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2789,7 +2689,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             onEventReceived,
           ],
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #queueStatsLogStream,
@@ -2799,7 +2699,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #queueStatsLogStream,
@@ -2809,32 +2709,32 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             ],
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i6.SocketController mainStream({
-    _i17.FutureOr<void> Function(_i6.Emoji)? onEmojiAdded,
-    _i17.FutureOr<void> Function(Iterable<_i6.Emoji>)? onEmojiUpdated,
-    _i17.FutureOr<void> Function(Iterable<_i6.Emoji>)? onEmojiDeleted,
-    _i17.FutureOr<void> Function(_i6.AnnouncementsResponse)?
+  _i5.SocketController mainStream({
+    _i16.FutureOr<void> Function(_i5.Emoji)? onEmojiAdded,
+    _i16.FutureOr<void> Function(Iterable<_i5.Emoji>)? onEmojiUpdated,
+    _i16.FutureOr<void> Function(Iterable<_i5.Emoji>)? onEmojiDeleted,
+    _i16.FutureOr<void> Function(_i5.AnnouncementsResponse)?
         onAnnouncementCreated,
-    _i17.FutureOr<void> Function(_i6.INotificationsResponse)? onNotification,
-    _i17.FutureOr<void> Function(_i6.Note)? onMention,
-    _i17.FutureOr<void> Function(_i6.Note)? onReply,
-    _i17.FutureOr<void> Function(_i6.Note)? onRenote,
-    _i17.FutureOr<void> Function(_i6.User)? onFollow,
-    _i17.FutureOr<void> Function(_i6.User)? onFollowed,
-    _i17.FutureOr<void> Function(_i6.User)? onUnfollow,
-    _i17.FutureOr<void> Function(_i6.User)? onMeUpdated,
-    _i17.FutureOr<void> Function()? onReadAllNotifications,
-    _i17.FutureOr<void> Function(_i6.INotificationsResponse)?
+    _i16.FutureOr<void> Function(_i5.INotificationsResponse)? onNotification,
+    _i16.FutureOr<void> Function(_i5.Note)? onMention,
+    _i16.FutureOr<void> Function(_i5.Note)? onReply,
+    _i16.FutureOr<void> Function(_i5.Note)? onRenote,
+    _i16.FutureOr<void> Function(_i5.User)? onFollow,
+    _i16.FutureOr<void> Function(_i5.User)? onFollowed,
+    _i16.FutureOr<void> Function(_i5.User)? onUnfollow,
+    _i16.FutureOr<void> Function(_i5.User)? onMeUpdated,
+    _i16.FutureOr<void> Function()? onReadAllNotifications,
+    _i16.FutureOr<void> Function(_i5.INotificationsResponse)?
         onUnreadNotification,
-    _i17.FutureOr<void> Function(String)? onUnreadMention,
-    _i17.FutureOr<void> Function()? onReadAllUnreadMentions,
-    _i17.FutureOr<void> Function(String)? onUnreadSpecifiedNote,
-    _i17.FutureOr<void> Function()? onReadAllUnreadSpecifiedNotes,
-    _i17.FutureOr<void> Function(_i6.User)? onReceiveFollowRequest,
-    _i17.FutureOr<void> Function()? onReadAllAnnouncements,
+    _i16.FutureOr<void> Function(String)? onUnreadMention,
+    _i16.FutureOr<void> Function()? onReadAllUnreadMentions,
+    _i16.FutureOr<void> Function(String)? onUnreadSpecifiedNote,
+    _i16.FutureOr<void> Function()? onReadAllUnreadSpecifiedNotes,
+    _i16.FutureOr<void> Function(_i5.User)? onReceiveFollowRequest,
+    _i16.FutureOr<void> Function()? onReadAllAnnouncements,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2863,7 +2763,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             #onReadAllAnnouncements: onReadAllAnnouncements,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #mainStream,
@@ -2892,7 +2792,7 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #mainStream,
@@ -2921,31 +2821,31 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i17.Future<void> startStreaming() => (super.noSuchMethod(
+  _i16.Future<void> startStreaming() => (super.noSuchMethod(
         Invocation.method(
           #startStreaming,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyAntenna].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyAntenna extends _i1.Mock implements _i6.MisskeyAntenna {
+class MockMisskeyAntenna extends _i1.Mock implements _i5.MisskeyAntenna {
   @override
-  _i17.Future<_i6.Antenna> create(_i6.AntennasCreateRequest? request) =>
+  _i16.Future<_i5.Antenna> create(_i5.AntennasCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<_i6.Antenna>.value(_FakeAntenna_32(
+        returnValue: _i16.Future<_i5.Antenna>.value(_FakeAntenna_31(
           this,
           Invocation.method(
             #create,
@@ -2953,57 +2853,57 @@ class MockMisskeyAntenna extends _i1.Mock implements _i6.MisskeyAntenna {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.Antenna>.value(_FakeAntenna_32(
+            _i16.Future<_i5.Antenna>.value(_FakeAntenna_31(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.Antenna>);
+      ) as _i16.Future<_i5.Antenna>);
 
   @override
-  _i17.Future<void> delete(_i6.AntennasDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.AntennasDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.Antenna>> list() => (super.noSuchMethod(
+  _i16.Future<Iterable<_i5.Antenna>> list() => (super.noSuchMethod(
         Invocation.method(
           #list,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Antenna>>.value(<_i6.Antenna>[]),
+        returnValue: _i16.Future<Iterable<_i5.Antenna>>.value(<_i5.Antenna>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Antenna>>.value(<_i6.Antenna>[]),
-      ) as _i17.Future<Iterable<_i6.Antenna>>);
+            _i16.Future<Iterable<_i5.Antenna>>.value(<_i5.Antenna>[]),
+      ) as _i16.Future<Iterable<_i5.Antenna>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> notes(_i6.AntennasNotesRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> notes(_i5.AntennasNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i6.Antenna> show(_i6.AntennasShowRequest? request) =>
+  _i16.Future<_i5.Antenna> show(_i5.AntennasShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i6.Antenna>.value(_FakeAntenna_32(
+        returnValue: _i16.Future<_i5.Antenna>.value(_FakeAntenna_31(
           this,
           Invocation.method(
             #show,
@@ -3011,40 +2911,40 @@ class MockMisskeyAntenna extends _i1.Mock implements _i6.MisskeyAntenna {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.Antenna>.value(_FakeAntenna_32(
+            _i16.Future<_i5.Antenna>.value(_FakeAntenna_31(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.Antenna>);
+      ) as _i16.Future<_i5.Antenna>);
 
   @override
-  _i17.Future<void> update(_i6.AntennasUpdateRequest? request) =>
+  _i16.Future<void> update(_i5.AntennasUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyAp].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyAp extends _i1.Mock implements _i6.MisskeyAp {
+class MockMisskeyAp extends _i1.Mock implements _i5.MisskeyAp {
   @override
-  _i17.Future<_i6.ApShowResponse> show(_i6.ApShowRequest? request) =>
+  _i16.Future<_i5.ApShowResponse> show(_i5.ApShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i6.ApShowResponse>.value(_FakeApShowResponse_33(
+            _i16.Future<_i5.ApShowResponse>.value(_FakeApShowResponse_32(
           this,
           Invocation.method(
             #show,
@@ -3052,69 +2952,69 @@ class MockMisskeyAp extends _i1.Mock implements _i6.MisskeyAp {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.ApShowResponse>.value(_FakeApShowResponse_33(
+            _i16.Future<_i5.ApShowResponse>.value(_FakeApShowResponse_32(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.ApShowResponse>);
+      ) as _i16.Future<_i5.ApShowResponse>);
 }
 
 /// A class which mocks [MisskeyBlocking].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyBlocking extends _i1.Mock implements _i6.MisskeyBlocking {
+class MockMisskeyBlocking extends _i1.Mock implements _i5.MisskeyBlocking {
   @override
-  _i17.Future<void> create(_i6.BlockCreateRequest? request) =>
+  _i16.Future<void> create(_i5.BlockCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i6.BlockDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.BlockDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyChannels].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyChannels extends _i1.Mock implements _i6.MisskeyChannels {
+class MockMisskeyChannels extends _i1.Mock implements _i5.MisskeyChannels {
   @override
-  _i17.Future<Iterable<_i6.Note>> timeline(
-          _i6.ChannelsTimelineRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> timeline(
+          _i5.ChannelsTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #timeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i6.CommunityChannel> show(_i6.ChannelsShowRequest? request) =>
+  _i16.Future<_i5.CommunityChannel> show(_i5.ChannelsShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i6.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i16.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_33(
           this,
           Invocation.method(
             #show,
@@ -3122,98 +3022,98 @@ class MockMisskeyChannels extends _i1.Mock implements _i6.MisskeyChannels {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i16.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_33(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.CommunityChannel>);
+      ) as _i16.Future<_i5.CommunityChannel>);
 
   @override
-  _i17.Future<Iterable<_i6.CommunityChannel>> followed(
-          _i6.ChannelsFollowedRequest? request) =>
+  _i16.Future<Iterable<_i5.CommunityChannel>> followed(
+          _i5.ChannelsFollowedRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #followed,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-            <_i6.CommunityChannel>[]),
+        returnValue: _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+            <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-                <_i6.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i6.CommunityChannel>>);
+            _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+                <_i5.CommunityChannel>[]),
+      ) as _i16.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i6.CommunityChannel>> myFavorite(
-          _i6.ChannelsMyFavoriteRequest? request) =>
+  _i16.Future<Iterable<_i5.CommunityChannel>> myFavorite(
+          _i5.ChannelsMyFavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #myFavorite,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-            <_i6.CommunityChannel>[]),
+        returnValue: _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+            <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-                <_i6.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i6.CommunityChannel>>);
+            _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+                <_i5.CommunityChannel>[]),
+      ) as _i16.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i6.CommunityChannel>> featured() => (super.noSuchMethod(
+  _i16.Future<Iterable<_i5.CommunityChannel>> featured() => (super.noSuchMethod(
         Invocation.method(
           #featured,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-            <_i6.CommunityChannel>[]),
+        returnValue: _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+            <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-                <_i6.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i6.CommunityChannel>>);
+            _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+                <_i5.CommunityChannel>[]),
+      ) as _i16.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i6.CommunityChannel>> owned(
-          _i6.ChannelsOwnedRequest? request) =>
+  _i16.Future<Iterable<_i5.CommunityChannel>> owned(
+          _i5.ChannelsOwnedRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #owned,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-            <_i6.CommunityChannel>[]),
+        returnValue: _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+            <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-                <_i6.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i6.CommunityChannel>>);
+            _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+                <_i5.CommunityChannel>[]),
+      ) as _i16.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i6.CommunityChannel>> search(
-          _i6.ChannelsSearchRequest? request) =>
+  _i16.Future<Iterable<_i5.CommunityChannel>> search(
+          _i5.ChannelsSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-            <_i6.CommunityChannel>[]),
+        returnValue: _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+            <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.CommunityChannel>>.value(
-                <_i6.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i6.CommunityChannel>>);
+            _i16.Future<Iterable<_i5.CommunityChannel>>.value(
+                <_i5.CommunityChannel>[]),
+      ) as _i16.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<_i6.CommunityChannel> create(
-          _i6.ChannelsCreateRequest? request) =>
+  _i16.Future<_i5.CommunityChannel> create(
+          _i5.ChannelsCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
         returnValue:
-            _i17.Future<_i6.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i16.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_33(
           this,
           Invocation.method(
             #create,
@@ -3221,293 +3121,293 @@ class MockMisskeyChannels extends _i1.Mock implements _i6.MisskeyChannels {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i16.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_33(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.CommunityChannel>);
+      ) as _i16.Future<_i5.CommunityChannel>);
 
   @override
-  _i17.Future<void> update(_i6.ChannelsUpdateRequest? request) =>
+  _i16.Future<void> update(_i5.ChannelsUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> favorite(_i6.ChannelsFavoriteRequest? request) =>
+  _i16.Future<void> favorite(_i5.ChannelsFavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #favorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> unfavorite(_i6.ChannelsUnfavoriteRequest? request) =>
+  _i16.Future<void> unfavorite(_i5.ChannelsUnfavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unfavorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> follow(_i6.ChannelsFollowRequest? request) =>
+  _i16.Future<void> follow(_i5.ChannelsFollowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #follow,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> unfollow(_i6.ChannelsUnfollowRequest? request) =>
+  _i16.Future<void> unfollow(_i5.ChannelsUnfollowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unfollow,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyClips].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyClips extends _i1.Mock implements _i6.MisskeyClips {
+class MockMisskeyClips extends _i1.Mock implements _i5.MisskeyClips {
   @override
-  _i17.Future<Iterable<_i6.Clip>> list() => (super.noSuchMethod(
+  _i16.Future<Iterable<_i5.Clip>> list() => (super.noSuchMethod(
         Invocation.method(
           #list,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
+        returnValue: _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
-      ) as _i17.Future<Iterable<_i6.Clip>>);
+            _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i16.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<Iterable<_i6.Clip>> myFavorites() => (super.noSuchMethod(
+  _i16.Future<Iterable<_i5.Clip>> myFavorites() => (super.noSuchMethod(
         Invocation.method(
           #myFavorites,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
+        returnValue: _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
-      ) as _i17.Future<Iterable<_i6.Clip>>);
+            _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i16.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> notes(_i6.ClipsNotesRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> notes(_i5.ClipsNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<void> addNote(_i6.ClipsAddNoteRequest? request) =>
+  _i16.Future<void> addNote(_i5.ClipsAddNoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #addNote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> removeNote(_i6.ClipsRemoveNoteRequest? request) =>
+  _i16.Future<void> removeNote(_i5.ClipsRemoveNoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeNote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<_i6.Clip> create(_i6.ClipsCreateRequest? request) =>
+  _i16.Future<_i5.Clip> create(_i5.ClipsCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<_i6.Clip>.value(_FakeClip_35(
+        returnValue: _i16.Future<_i5.Clip>.value(_FakeClip_34(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.Clip>.value(_FakeClip_35(
+        returnValueForMissingStub: _i16.Future<_i5.Clip>.value(_FakeClip_34(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.Clip>);
+      ) as _i16.Future<_i5.Clip>);
 
   @override
-  _i17.Future<void> delete(_i6.ClipsDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.ClipsDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<_i6.Clip> update(_i6.ClipsUpdateRequest? request) =>
+  _i16.Future<_i5.Clip> update(_i5.ClipsUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<_i6.Clip>.value(_FakeClip_35(
+        returnValue: _i16.Future<_i5.Clip>.value(_FakeClip_34(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.Clip>.value(_FakeClip_35(
+        returnValueForMissingStub: _i16.Future<_i5.Clip>.value(_FakeClip_34(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.Clip>);
+      ) as _i16.Future<_i5.Clip>);
 
   @override
-  _i17.Future<_i6.Clip> show(_i6.ClipsShowRequest? request) =>
+  _i16.Future<_i5.Clip> show(_i5.ClipsShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i6.Clip>.value(_FakeClip_35(
+        returnValue: _i16.Future<_i5.Clip>.value(_FakeClip_34(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.Clip>.value(_FakeClip_35(
+        returnValueForMissingStub: _i16.Future<_i5.Clip>.value(_FakeClip_34(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.Clip>);
+      ) as _i16.Future<_i5.Clip>);
 
   @override
-  _i17.Future<void> favorite(_i6.ClipsFavoriteRequest? request) =>
+  _i16.Future<void> favorite(_i5.ClipsFavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #favorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> unfavorite(_i6.ClipsUnfavoriteRequest? request) =>
+  _i16.Future<void> unfavorite(_i5.ClipsUnfavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unfavorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyDrive].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyDrive extends _i1.Mock implements _i6.MisskeyDrive {
+class MockMisskeyDrive extends _i1.Mock implements _i5.MisskeyDrive {
   @override
-  _i6.MisskeyDriveFiles get files => (super.noSuchMethod(
+  _i5.MisskeyDriveFiles get files => (super.noSuchMethod(
         Invocation.getter(#files),
-        returnValue: _FakeMisskeyDriveFiles_36(
+        returnValue: _FakeMisskeyDriveFiles_35(
           this,
           Invocation.getter(#files),
         ),
-        returnValueForMissingStub: _FakeMisskeyDriveFiles_36(
+        returnValueForMissingStub: _FakeMisskeyDriveFiles_35(
           this,
           Invocation.getter(#files),
         ),
-      ) as _i6.MisskeyDriveFiles);
+      ) as _i5.MisskeyDriveFiles);
 
   @override
-  _i6.MisskeyDriveFolders get folders => (super.noSuchMethod(
+  _i5.MisskeyDriveFolders get folders => (super.noSuchMethod(
         Invocation.getter(#folders),
-        returnValue: _FakeMisskeyDriveFolders_37(
+        returnValue: _FakeMisskeyDriveFolders_36(
           this,
           Invocation.getter(#folders),
         ),
-        returnValueForMissingStub: _FakeMisskeyDriveFolders_37(
+        returnValueForMissingStub: _FakeMisskeyDriveFolders_36(
           this,
           Invocation.getter(#folders),
         ),
-      ) as _i6.MisskeyDriveFolders);
+      ) as _i5.MisskeyDriveFolders);
 }
 
 /// A class which mocks [MisskeyDriveFolders].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyDriveFolders extends _i1.Mock
-    implements _i6.MisskeyDriveFolders {
+    implements _i5.MisskeyDriveFolders {
   @override
-  _i17.Future<Iterable<_i6.DriveFolder>> folders(
-          _i6.DriveFoldersRequest? request) =>
+  _i16.Future<Iterable<_i5.DriveFolder>> folders(
+          _i5.DriveFoldersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #folders,
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i6.DriveFolder>>.value(<_i6.DriveFolder>[]),
+            _i16.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.DriveFolder>>.value(<_i6.DriveFolder>[]),
-      ) as _i17.Future<Iterable<_i6.DriveFolder>>);
+            _i16.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
+      ) as _i16.Future<Iterable<_i5.DriveFolder>>);
 }
 
 /// A class which mocks [MisskeyDriveFiles].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
+class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
   @override
-  _i17.Future<_i6.DriveFile> create(
-    _i6.DriveFilesCreateRequest? request,
-    _i12.File? fileContent,
+  _i16.Future<_i5.DriveFile> create(
+    _i5.DriveFilesCreateRequest? request,
+    _i11.File? fileContent,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3517,7 +3417,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
             fileContent,
           ],
         ),
-        returnValue: _i17.Future<_i6.DriveFile>.value(_FakeDriveFile_38(
+        returnValue: _i16.Future<_i5.DriveFile>.value(_FakeDriveFile_37(
           this,
           Invocation.method(
             #create,
@@ -3528,7 +3428,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.DriveFile>.value(_FakeDriveFile_38(
+            _i16.Future<_i5.DriveFile>.value(_FakeDriveFile_37(
           this,
           Invocation.method(
             #create,
@@ -3538,12 +3438,12 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
             ],
           ),
         )),
-      ) as _i17.Future<_i6.DriveFile>);
+      ) as _i16.Future<_i5.DriveFile>);
 
   @override
-  _i17.Future<_i6.DriveFile> createAsBinary(
-    _i6.DriveFilesCreateRequest? request,
-    _i28.Uint8List? fileContent,
+  _i16.Future<_i5.DriveFile> createAsBinary(
+    _i5.DriveFilesCreateRequest? request,
+    _i26.Uint8List? fileContent,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3553,7 +3453,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
             fileContent,
           ],
         ),
-        returnValue: _i17.Future<_i6.DriveFile>.value(_FakeDriveFile_38(
+        returnValue: _i16.Future<_i5.DriveFile>.value(_FakeDriveFile_37(
           this,
           Invocation.method(
             #createAsBinary,
@@ -3564,7 +3464,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.DriveFile>.value(_FakeDriveFile_38(
+            _i16.Future<_i5.DriveFile>.value(_FakeDriveFile_37(
           this,
           Invocation.method(
             #createAsBinary,
@@ -3574,16 +3474,16 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
             ],
           ),
         )),
-      ) as _i17.Future<_i6.DriveFile>);
+      ) as _i16.Future<_i5.DriveFile>);
 
   @override
-  _i17.Future<_i6.DriveFile> update(_i6.DriveFilesUpdateRequest? request) =>
+  _i16.Future<_i5.DriveFile> update(_i5.DriveFilesUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<_i6.DriveFile>.value(_FakeDriveFile_38(
+        returnValue: _i16.Future<_i5.DriveFile>.value(_FakeDriveFile_37(
           this,
           Invocation.method(
             #update,
@@ -3591,68 +3491,68 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.DriveFile>.value(_FakeDriveFile_38(
+            _i16.Future<_i5.DriveFile>.value(_FakeDriveFile_37(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.DriveFile>);
+      ) as _i16.Future<_i5.DriveFile>);
 
   @override
-  _i17.Future<void> delete(_i6.DriveFilesDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.DriveFilesDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.DriveFile>> files(_i6.DriveFilesRequest? request) =>
+  _i16.Future<Iterable<_i5.DriveFile>> files(_i5.DriveFilesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #files,
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i6.DriveFile>>.value(<_i6.DriveFile>[]),
+            _i16.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.DriveFile>>.value(<_i6.DriveFile>[]),
-      ) as _i17.Future<Iterable<_i6.DriveFile>>);
+            _i16.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+      ) as _i16.Future<Iterable<_i5.DriveFile>>);
 
   @override
-  _i17.Future<Iterable<_i6.DriveFile>> find(
-          _i6.DriveFilesFindRequest? request) =>
+  _i16.Future<Iterable<_i5.DriveFile>> find(
+          _i5.DriveFilesFindRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #find,
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i6.DriveFile>>.value(<_i6.DriveFile>[]),
+            _i16.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.DriveFile>>.value(<_i6.DriveFile>[]),
-      ) as _i17.Future<Iterable<_i6.DriveFile>>);
+            _i16.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+      ) as _i16.Future<Iterable<_i5.DriveFile>>);
 }
 
 /// A class which mocks [MisskeyFederation].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyFederation extends _i1.Mock implements _i6.MisskeyFederation {
+class MockMisskeyFederation extends _i1.Mock implements _i5.MisskeyFederation {
   @override
-  _i17.Future<_i6.FederationShowInstanceResponse> showInstance(
-          _i6.FederationShowInstanceRequest? request) =>
+  _i16.Future<_i5.FederationShowInstanceResponse> showInstance(
+          _i5.FederationShowInstanceRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #showInstance,
           [request],
         ),
-        returnValue: _i17.Future<_i6.FederationShowInstanceResponse>.value(
-            _FakeFederationShowInstanceResponse_39(
+        returnValue: _i16.Future<_i5.FederationShowInstanceResponse>.value(
+            _FakeFederationShowInstanceResponse_38(
           this,
           Invocation.method(
             #showInstance,
@@ -3660,163 +3560,163 @@ class MockMisskeyFederation extends _i1.Mock implements _i6.MisskeyFederation {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.FederationShowInstanceResponse>.value(
-                _FakeFederationShowInstanceResponse_39(
+            _i16.Future<_i5.FederationShowInstanceResponse>.value(
+                _FakeFederationShowInstanceResponse_38(
           this,
           Invocation.method(
             #showInstance,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.FederationShowInstanceResponse>);
+      ) as _i16.Future<_i5.FederationShowInstanceResponse>);
 
   @override
-  _i17.Future<Iterable<_i6.User>> users(_i6.FederationUsersRequest? request) =>
+  _i16.Future<Iterable<_i5.User>> users(_i5.FederationUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
+        returnValue: _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
-      ) as _i17.Future<Iterable<_i6.User>>);
+            _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i16.Future<Iterable<_i5.User>>);
 }
 
 /// A class which mocks [MisskeyFollowing].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyFollowing extends _i1.Mock implements _i6.MisskeyFollowing {
+class MockMisskeyFollowing extends _i1.Mock implements _i5.MisskeyFollowing {
   @override
-  _i6.MisskeyFollowingRequests get requests => (super.noSuchMethod(
+  _i5.MisskeyFollowingRequests get requests => (super.noSuchMethod(
         Invocation.getter(#requests),
-        returnValue: _FakeMisskeyFollowingRequests_40(
+        returnValue: _FakeMisskeyFollowingRequests_39(
           this,
           Invocation.getter(#requests),
         ),
-        returnValueForMissingStub: _FakeMisskeyFollowingRequests_40(
+        returnValueForMissingStub: _FakeMisskeyFollowingRequests_39(
           this,
           Invocation.getter(#requests),
         ),
-      ) as _i6.MisskeyFollowingRequests);
+      ) as _i5.MisskeyFollowingRequests);
 
   @override
-  _i17.Future<_i6.User> create(_i6.FollowingCreateRequest? request) =>
+  _i16.Future<_i5.User> create(_i5.FollowingCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<_i6.User>.value(_FakeUser_41(
+        returnValue: _i16.Future<_i5.User>.value(_FakeUser_40(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.User>.value(_FakeUser_41(
+        returnValueForMissingStub: _i16.Future<_i5.User>.value(_FakeUser_40(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.User>);
+      ) as _i16.Future<_i5.User>);
 
   @override
-  _i17.Future<_i6.User> delete(_i6.FollowingDeleteRequest? request) =>
+  _i16.Future<_i5.User> delete(_i5.FollowingDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<_i6.User>.value(_FakeUser_41(
+        returnValue: _i16.Future<_i5.User>.value(_FakeUser_40(
           this,
           Invocation.method(
             #delete,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.User>.value(_FakeUser_41(
+        returnValueForMissingStub: _i16.Future<_i5.User>.value(_FakeUser_40(
           this,
           Invocation.method(
             #delete,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.User>);
+      ) as _i16.Future<_i5.User>);
 
   @override
-  _i17.Future<_i6.User> invalidate(_i6.FollowingInvalidateRequest? request) =>
+  _i16.Future<_i5.User> invalidate(_i5.FollowingInvalidateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #invalidate,
           [request],
         ),
-        returnValue: _i17.Future<_i6.User>.value(_FakeUser_41(
+        returnValue: _i16.Future<_i5.User>.value(_FakeUser_40(
           this,
           Invocation.method(
             #invalidate,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.User>.value(_FakeUser_41(
+        returnValueForMissingStub: _i16.Future<_i5.User>.value(_FakeUser_40(
           this,
           Invocation.method(
             #invalidate,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.User>);
+      ) as _i16.Future<_i5.User>);
 
   @override
-  _i17.Future<void> updateAll(_i6.FollowingUpdateAllRequest? request) =>
+  _i16.Future<void> updateAll(_i5.FollowingUpdateAllRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateAll,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyHashtags].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyHashtags extends _i1.Mock implements _i6.MisskeyHashtags {
+class MockMisskeyHashtags extends _i1.Mock implements _i5.MisskeyHashtags {
   @override
-  _i17.Future<Iterable<_i6.Hashtag>> list(_i6.HashtagsListRequest? request) =>
+  _i16.Future<Iterable<_i5.Hashtag>> list(_i5.HashtagsListRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #list,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Hashtag>>.value(<_i6.Hashtag>[]),
+        returnValue: _i16.Future<Iterable<_i5.Hashtag>>.value(<_i5.Hashtag>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Hashtag>>.value(<_i6.Hashtag>[]),
-      ) as _i17.Future<Iterable<_i6.Hashtag>>);
+            _i16.Future<Iterable<_i5.Hashtag>>.value(<_i5.Hashtag>[]),
+      ) as _i16.Future<Iterable<_i5.Hashtag>>);
 
   @override
-  _i17.Future<Iterable<String>> search(_i6.HashtagsSearchRequest? request) =>
+  _i16.Future<Iterable<String>> search(_i5.HashtagsSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<String>>.value(<String>[]),
+        returnValue: _i16.Future<Iterable<String>>.value(<String>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<String>>.value(<String>[]),
-      ) as _i17.Future<Iterable<String>>);
+            _i16.Future<Iterable<String>>.value(<String>[]),
+      ) as _i16.Future<Iterable<String>>);
 
   @override
-  _i17.Future<_i6.Hashtag> show(_i6.HashtagsShowRequest? request) =>
+  _i16.Future<_i5.Hashtag> show(_i5.HashtagsShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i6.Hashtag>.value(_FakeHashtag_42(
+        returnValue: _i16.Future<_i5.Hashtag>.value(_FakeHashtag_41(
           this,
           Invocation.method(
             #show,
@@ -3824,53 +3724,53 @@ class MockMisskeyHashtags extends _i1.Mock implements _i6.MisskeyHashtags {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.Hashtag>.value(_FakeHashtag_42(
+            _i16.Future<_i5.Hashtag>.value(_FakeHashtag_41(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.Hashtag>);
+      ) as _i16.Future<_i5.Hashtag>);
 
   @override
-  _i17.Future<Iterable<_i6.HashtagsTrendResponse>> trend() =>
+  _i16.Future<Iterable<_i5.HashtagsTrendResponse>> trend() =>
       (super.noSuchMethod(
         Invocation.method(
           #trend,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i6.HashtagsTrendResponse>>.value(
-            <_i6.HashtagsTrendResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.HashtagsTrendResponse>>.value(
+            <_i5.HashtagsTrendResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.HashtagsTrendResponse>>.value(
-                <_i6.HashtagsTrendResponse>[]),
-      ) as _i17.Future<Iterable<_i6.HashtagsTrendResponse>>);
+            _i16.Future<Iterable<_i5.HashtagsTrendResponse>>.value(
+                <_i5.HashtagsTrendResponse>[]),
+      ) as _i16.Future<Iterable<_i5.HashtagsTrendResponse>>);
 
   @override
-  _i17.Future<Iterable<_i6.User>> users(_i6.HashtagsUsersRequest? request) =>
+  _i16.Future<Iterable<_i5.User>> users(_i5.HashtagsUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
+        returnValue: _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
-      ) as _i17.Future<Iterable<_i6.User>>);
+            _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i16.Future<Iterable<_i5.User>>);
 }
 
 /// A class which mocks [MisskeyI].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyI extends _i1.Mock implements _i6.MisskeyI {
+class MockMisskeyI extends _i1.Mock implements _i5.MisskeyI {
   @override
-  _i17.Future<_i6.IResponse> i() => (super.noSuchMethod(
+  _i16.Future<_i5.IResponse> i() => (super.noSuchMethod(
         Invocation.method(
           #i,
           [],
         ),
-        returnValue: _i17.Future<_i6.IResponse>.value(_FakeIResponse_43(
+        returnValue: _i16.Future<_i5.IResponse>.value(_FakeIResponse_42(
           this,
           Invocation.method(
             #i,
@@ -3878,64 +3778,64 @@ class MockMisskeyI extends _i1.Mock implements _i6.MisskeyI {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.IResponse>.value(_FakeIResponse_43(
+            _i16.Future<_i5.IResponse>.value(_FakeIResponse_42(
           this,
           Invocation.method(
             #i,
             [],
           ),
         )),
-      ) as _i17.Future<_i6.IResponse>);
+      ) as _i16.Future<_i5.IResponse>);
 
   @override
-  _i17.Future<Iterable<_i6.INotificationsResponse>> notifications(
-          _i6.INotificationsRequest? request) =>
+  _i16.Future<Iterable<_i5.INotificationsResponse>> notifications(
+          _i5.INotificationsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notifications,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.INotificationsResponse>>.value(
-            <_i6.INotificationsResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.INotificationsResponse>>.value(
+            <_i5.INotificationsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.INotificationsResponse>>.value(
-                <_i6.INotificationsResponse>[]),
-      ) as _i17.Future<Iterable<_i6.INotificationsResponse>>);
+            _i16.Future<Iterable<_i5.INotificationsResponse>>.value(
+                <_i5.INotificationsResponse>[]),
+      ) as _i16.Future<Iterable<_i5.INotificationsResponse>>);
 
   @override
-  _i17.Future<void> readAnnouncement(_i6.IReadAnnouncementRequest? request) =>
+  _i16.Future<void> readAnnouncement(_i5.IReadAnnouncementRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #readAnnouncement,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.IFavoritesResponse>> favorites(
-          _i6.IFavoritesRequest? request) =>
+  _i16.Future<Iterable<_i5.IFavoritesResponse>> favorites(
+          _i5.IFavoritesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #favorites,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.IFavoritesResponse>>.value(
-            <_i6.IFavoritesResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.IFavoritesResponse>>.value(
+            <_i5.IFavoritesResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.IFavoritesResponse>>.value(
-                <_i6.IFavoritesResponse>[]),
-      ) as _i17.Future<Iterable<_i6.IFavoritesResponse>>);
+            _i16.Future<Iterable<_i5.IFavoritesResponse>>.value(
+                <_i5.IFavoritesResponse>[]),
+      ) as _i16.Future<Iterable<_i5.IFavoritesResponse>>);
 
   @override
-  _i17.Future<_i6.IResponse> update(_i6.IUpdateRequest? request) =>
+  _i16.Future<_i5.IResponse> update(_i5.IUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<_i6.IResponse>.value(_FakeIResponse_43(
+        returnValue: _i16.Future<_i5.IResponse>.value(_FakeIResponse_42(
           this,
           Invocation.method(
             #update,
@@ -3943,520 +3843,520 @@ class MockMisskeyI extends _i1.Mock implements _i6.MisskeyI {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.IResponse>.value(_FakeIResponse_43(
+            _i16.Future<_i5.IResponse>.value(_FakeIResponse_42(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.IResponse>);
+      ) as _i16.Future<_i5.IResponse>);
 }
 
 /// A class which mocks [MisskeyNotes].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyNotes extends _i1.Mock implements _i6.MisskeyNotes {
+class MockMisskeyNotes extends _i1.Mock implements _i5.MisskeyNotes {
   @override
-  _i6.MisskeyNotesReactions get reactions => (super.noSuchMethod(
+  _i5.MisskeyNotesReactions get reactions => (super.noSuchMethod(
         Invocation.getter(#reactions),
-        returnValue: _FakeMisskeyNotesReactions_44(
+        returnValue: _FakeMisskeyNotesReactions_43(
           this,
           Invocation.getter(#reactions),
         ),
-        returnValueForMissingStub: _FakeMisskeyNotesReactions_44(
+        returnValueForMissingStub: _FakeMisskeyNotesReactions_43(
           this,
           Invocation.getter(#reactions),
         ),
-      ) as _i6.MisskeyNotesReactions);
+      ) as _i5.MisskeyNotesReactions);
 
   @override
-  _i6.MisskeyNotesFavorites get favorites => (super.noSuchMethod(
+  _i5.MisskeyNotesFavorites get favorites => (super.noSuchMethod(
         Invocation.getter(#favorites),
-        returnValue: _FakeMisskeyNotesFavorites_45(
+        returnValue: _FakeMisskeyNotesFavorites_44(
           this,
           Invocation.getter(#favorites),
         ),
-        returnValueForMissingStub: _FakeMisskeyNotesFavorites_45(
+        returnValueForMissingStub: _FakeMisskeyNotesFavorites_44(
           this,
           Invocation.getter(#favorites),
         ),
-      ) as _i6.MisskeyNotesFavorites);
+      ) as _i5.MisskeyNotesFavorites);
 
   @override
-  _i6.MisskeyNotesPolls get polls => (super.noSuchMethod(
+  _i5.MisskeyNotesPolls get polls => (super.noSuchMethod(
         Invocation.getter(#polls),
-        returnValue: _FakeMisskeyNotesPolls_46(
+        returnValue: _FakeMisskeyNotesPolls_45(
           this,
           Invocation.getter(#polls),
         ),
-        returnValueForMissingStub: _FakeMisskeyNotesPolls_46(
+        returnValueForMissingStub: _FakeMisskeyNotesPolls_45(
           this,
           Invocation.getter(#polls),
         ),
-      ) as _i6.MisskeyNotesPolls);
+      ) as _i5.MisskeyNotesPolls);
 
   @override
-  _i6.MisskeyNotesThreadMuting get threadMuting => (super.noSuchMethod(
+  _i5.MisskeyNotesThreadMuting get threadMuting => (super.noSuchMethod(
         Invocation.getter(#threadMuting),
-        returnValue: _FakeMisskeyNotesThreadMuting_47(
+        returnValue: _FakeMisskeyNotesThreadMuting_46(
           this,
           Invocation.getter(#threadMuting),
         ),
-        returnValueForMissingStub: _FakeMisskeyNotesThreadMuting_47(
+        returnValueForMissingStub: _FakeMisskeyNotesThreadMuting_46(
           this,
           Invocation.getter(#threadMuting),
         ),
-      ) as _i6.MisskeyNotesThreadMuting);
+      ) as _i5.MisskeyNotesThreadMuting);
 
   @override
-  _i17.Future<void> create(_i6.NotesCreateRequest? request) =>
+  _i16.Future<void> create(_i5.NotesCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> update(_i6.NotesUpdateRequest? request) =>
+  _i16.Future<void> update(_i5.NotesUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i6.NotesDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.NotesDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> notes(_i6.NotesRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> notes(_i5.NotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i6.Note> show(_i6.NotesShowRequest? request) =>
+  _i16.Future<_i5.Note> show(_i5.NotesShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i6.Note>.value(_FakeNote_48(
+        returnValue: _i16.Future<_i5.Note>.value(_FakeNote_47(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.Note>.value(_FakeNote_48(
+        returnValueForMissingStub: _i16.Future<_i5.Note>.value(_FakeNote_47(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.Note>);
+      ) as _i16.Future<_i5.Note>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> homeTimeline(
-          _i6.NotesTimelineRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> homeTimeline(
+          _i5.NotesTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #homeTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> localTimeline(
-          _i6.NotesLocalTimelineRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> localTimeline(
+          _i5.NotesLocalTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #localTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> hybridTimeline(
-          _i6.NotesHybridTimelineRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> hybridTimeline(
+          _i5.NotesHybridTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #hybridTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> globalTimeline(
-          _i6.NotesGlobalTimelineRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> globalTimeline(
+          _i5.NotesGlobalTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #globalTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> userListTimeline(
-          _i6.UserListTimelineRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> userListTimeline(
+          _i5.UserListTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #userListTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i6.NotesStateResponse> state(_i6.NotesStateRequest? request) =>
+  _i16.Future<_i5.NotesStateResponse> state(_i5.NotesStateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #state,
           [request],
         ),
-        returnValue: _i17.Future<_i6.NotesStateResponse>.value(
-            _FakeNotesStateResponse_49(
+        returnValue: _i16.Future<_i5.NotesStateResponse>.value(
+            _FakeNotesStateResponse_48(
           this,
           Invocation.method(
             #state,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i6.NotesStateResponse>.value(
-            _FakeNotesStateResponse_49(
+        returnValueForMissingStub: _i16.Future<_i5.NotesStateResponse>.value(
+            _FakeNotesStateResponse_48(
           this,
           Invocation.method(
             #state,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.NotesStateResponse>);
+      ) as _i16.Future<_i5.NotesStateResponse>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> search(_i6.NotesSearchRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> search(_i5.NotesSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> searchByTag(
-          _i6.NotesSearchByTagRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> searchByTag(
+          _i5.NotesSearchByTagRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchByTag,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> renotes(_i6.NotesRenoteRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> renotes(_i5.NotesRenoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #renotes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> replies(_i6.NotesRepliesRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> replies(_i5.NotesRepliesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #replies,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> children(_i6.NotesChildrenRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> children(_i5.NotesChildrenRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #children,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> conversation(
-          _i6.NotesConversationRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> conversation(
+          _i5.NotesConversationRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #conversation,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> featured(_i6.NotesFeaturedRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> featured(_i5.NotesFeaturedRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #featured,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> mentions(_i6.NotesMentionsRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> mentions(_i5.NotesMentionsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #mentions,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Clip>> clips(_i6.NotesClipsRequest? request) =>
+  _i16.Future<Iterable<_i5.Clip>> clips(_i5.NotesClipsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #clips,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
+        returnValue: _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
-      ) as _i17.Future<Iterable<_i6.Clip>>);
+            _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i16.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<void> unrenote(_i6.NotesUnrenoteRequest? request) =>
+  _i16.Future<void> unrenote(_i5.NotesUnrenoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unrenote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyNotesFavorites].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyNotesFavorites extends _i1.Mock
-    implements _i6.MisskeyNotesFavorites {
+    implements _i5.MisskeyNotesFavorites {
   @override
-  _i17.Future<void> create(_i6.NotesFavoritesCreateRequest? request) =>
+  _i16.Future<void> create(_i5.NotesFavoritesCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i6.NotesFavoritesDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.NotesFavoritesDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyNotesReactions].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyNotesReactions extends _i1.Mock
-    implements _i6.MisskeyNotesReactions {
+    implements _i5.MisskeyNotesReactions {
   @override
-  _i17.Future<void> create(_i6.NotesReactionsCreateRequest? request) =>
+  _i16.Future<void> create(_i5.NotesReactionsCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i6.NotesReactionsDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.NotesReactionsDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.NotesReactionsResponse>> reactions(
-          _i6.NotesReactionsRequest? request) =>
+  _i16.Future<Iterable<_i5.NotesReactionsResponse>> reactions(
+          _i5.NotesReactionsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #reactions,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.NotesReactionsResponse>>.value(
-            <_i6.NotesReactionsResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.NotesReactionsResponse>>.value(
+            <_i5.NotesReactionsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.NotesReactionsResponse>>.value(
-                <_i6.NotesReactionsResponse>[]),
-      ) as _i17.Future<Iterable<_i6.NotesReactionsResponse>>);
+            _i16.Future<Iterable<_i5.NotesReactionsResponse>>.value(
+                <_i5.NotesReactionsResponse>[]),
+      ) as _i16.Future<Iterable<_i5.NotesReactionsResponse>>);
 }
 
 /// A class which mocks [MisskeyNotesPolls].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyNotesPolls extends _i1.Mock implements _i6.MisskeyNotesPolls {
+class MockMisskeyNotesPolls extends _i1.Mock implements _i5.MisskeyNotesPolls {
   @override
-  _i17.Future<void> vote(_i6.NotesPollsVoteRequest? request) =>
+  _i16.Future<void> vote(_i5.NotesPollsVoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #vote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> recommendation(
-          _i6.NotesPollsRecommendationRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> recommendation(
+          _i5.NotesPollsRecommendationRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #recommendation,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 }
 
 /// A class which mocks [MisskeyRenoteMute].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyRenoteMute extends _i1.Mock implements _i6.MisskeyRenoteMute {
+class MockMisskeyRenoteMute extends _i1.Mock implements _i5.MisskeyRenoteMute {
   @override
-  _i17.Future<void> create(_i6.RenoteMuteCreateRequest? request) =>
+  _i16.Future<void> create(_i5.RenoteMuteCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i6.RenoteMuteDeleteRequest? request) =>
+  _i16.Future<void> delete(_i5.RenoteMuteDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [MisskeyRoles].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyRoles extends _i1.Mock implements _i6.MisskeyRoles {
+class MockMisskeyRoles extends _i1.Mock implements _i5.MisskeyRoles {
   @override
-  _i17.Future<Iterable<_i6.RolesListResponse>> list() => (super.noSuchMethod(
+  _i16.Future<Iterable<_i5.RolesListResponse>> list() => (super.noSuchMethod(
         Invocation.method(
           #list,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i6.RolesListResponse>>.value(
-            <_i6.RolesListResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.RolesListResponse>>.value(
+            <_i5.RolesListResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.RolesListResponse>>.value(
-                <_i6.RolesListResponse>[]),
-      ) as _i17.Future<Iterable<_i6.RolesListResponse>>);
+            _i16.Future<Iterable<_i5.RolesListResponse>>.value(
+                <_i5.RolesListResponse>[]),
+      ) as _i16.Future<Iterable<_i5.RolesListResponse>>);
 
   @override
-  _i17.Future<Iterable<_i6.RolesUsersResponse>> users(
-          _i6.RolesUsersRequest? request) =>
+  _i16.Future<Iterable<_i5.RolesUsersResponse>> users(
+          _i5.RolesUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.RolesUsersResponse>>.value(
-            <_i6.RolesUsersResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.RolesUsersResponse>>.value(
+            <_i5.RolesUsersResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.RolesUsersResponse>>.value(
-                <_i6.RolesUsersResponse>[]),
-      ) as _i17.Future<Iterable<_i6.RolesUsersResponse>>);
+            _i16.Future<Iterable<_i5.RolesUsersResponse>>.value(
+                <_i5.RolesUsersResponse>[]),
+      ) as _i16.Future<Iterable<_i5.RolesUsersResponse>>);
 
   @override
-  _i17.Future<_i6.RolesListResponse> show(_i6.RolesShowRequest? request) =>
+  _i16.Future<_i5.RolesListResponse> show(_i5.RolesShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i6.RolesListResponse>.value(_FakeRolesListResponse_50(
+            _i16.Future<_i5.RolesListResponse>.value(_FakeRolesListResponse_49(
           this,
           Invocation.method(
             #show,
@@ -4464,54 +4364,54 @@ class MockMisskeyRoles extends _i1.Mock implements _i6.MisskeyRoles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.RolesListResponse>.value(_FakeRolesListResponse_50(
+            _i16.Future<_i5.RolesListResponse>.value(_FakeRolesListResponse_49(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.RolesListResponse>);
+      ) as _i16.Future<_i5.RolesListResponse>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> notes(_i6.RolesNotesRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> notes(_i5.RolesNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 }
 
 /// A class which mocks [MisskeyUsers].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMisskeyUsers extends _i1.Mock implements _i6.MisskeyUsers {
+class MockMisskeyUsers extends _i1.Mock implements _i5.MisskeyUsers {
   @override
-  _i6.MisskeyUsersLists get list => (super.noSuchMethod(
+  _i5.MisskeyUsersLists get list => (super.noSuchMethod(
         Invocation.getter(#list),
-        returnValue: _FakeMisskeyUsersLists_51(
+        returnValue: _FakeMisskeyUsersLists_50(
           this,
           Invocation.getter(#list),
         ),
-        returnValueForMissingStub: _FakeMisskeyUsersLists_51(
+        returnValueForMissingStub: _FakeMisskeyUsersLists_50(
           this,
           Invocation.getter(#list),
         ),
-      ) as _i6.MisskeyUsersLists);
+      ) as _i5.MisskeyUsersLists);
 
   @override
-  _i17.Future<_i6.UsersShowResponse> show(_i6.UsersShowRequest? request) =>
+  _i16.Future<_i5.UsersShowResponse> show(_i5.UsersShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i6.UsersShowResponse>.value(_FakeUsersShowResponse_52(
+            _i16.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_51(
           this,
           Invocation.method(
             #show,
@@ -4519,40 +4419,40 @@ class MockMisskeyUsers extends _i1.Mock implements _i6.MisskeyUsers {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.UsersShowResponse>.value(_FakeUsersShowResponse_52(
+            _i16.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_51(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.UsersShowResponse>);
+      ) as _i16.Future<_i5.UsersShowResponse>);
 
   @override
-  _i17.Future<Iterable<_i6.UsersShowResponse>> showByIds(
-          _i6.UsersShowByIdsRequest? request) =>
+  _i16.Future<Iterable<_i5.UsersShowResponse>> showByIds(
+          _i5.UsersShowByIdsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #showByIds,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.UsersShowResponse>>.value(
-            <_i6.UsersShowResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.UsersShowResponse>>.value(
+            <_i5.UsersShowResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.UsersShowResponse>>.value(
-                <_i6.UsersShowResponse>[]),
-      ) as _i17.Future<Iterable<_i6.UsersShowResponse>>);
+            _i16.Future<Iterable<_i5.UsersShowResponse>>.value(
+                <_i5.UsersShowResponse>[]),
+      ) as _i16.Future<Iterable<_i5.UsersShowResponse>>);
 
   @override
-  _i17.Future<_i6.UsersShowResponse> showByName(
-          _i6.UsersShowByUserNameRequest? request) =>
+  _i16.Future<_i5.UsersShowResponse> showByName(
+          _i5.UsersShowByUserNameRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #showByName,
           [request],
         ),
         returnValue:
-            _i17.Future<_i6.UsersShowResponse>.value(_FakeUsersShowResponse_52(
+            _i16.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_51(
           this,
           Invocation.method(
             #showByName,
@@ -4560,198 +4460,198 @@ class MockMisskeyUsers extends _i1.Mock implements _i6.MisskeyUsers {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i6.UsersShowResponse>.value(_FakeUsersShowResponse_52(
+            _i16.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_51(
           this,
           Invocation.method(
             #showByName,
             [request],
           ),
         )),
-      ) as _i17.Future<_i6.UsersShowResponse>);
+      ) as _i16.Future<_i5.UsersShowResponse>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> notes(_i6.UsersNotesRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> notes(_i5.UsersNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Clip>> clips(_i6.UsersClipsRequest? request) =>
+  _i16.Future<Iterable<_i5.Clip>> clips(_i5.UsersClipsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #clips,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
+        returnValue: _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Clip>>.value(<_i6.Clip>[]),
-      ) as _i17.Future<Iterable<_i6.Clip>>);
+            _i16.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i16.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<Iterable<_i6.Following>> followers(
-          _i6.UsersFollowersRequest? request) =>
+  _i16.Future<Iterable<_i5.Following>> followers(
+          _i5.UsersFollowersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #followers,
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i6.Following>>.value(<_i6.Following>[]),
+            _i16.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Following>>.value(<_i6.Following>[]),
-      ) as _i17.Future<Iterable<_i6.Following>>);
+            _i16.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
+      ) as _i16.Future<Iterable<_i5.Following>>);
 
   @override
-  _i17.Future<Iterable<_i6.Following>> following(
-          _i6.UsersFollowingRequest? request) =>
+  _i16.Future<Iterable<_i5.Following>> following(
+          _i5.UsersFollowingRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #following,
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i6.Following>>.value(<_i6.Following>[]),
+            _i16.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Following>>.value(<_i6.Following>[]),
-      ) as _i17.Future<Iterable<_i6.Following>>);
+            _i16.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
+      ) as _i16.Future<Iterable<_i5.Following>>);
 
   @override
-  _i17.Future<void> reportAbuse(_i6.UsersReportAbuseRequest? request) =>
+  _i16.Future<void> reportAbuse(_i5.UsersReportAbuseRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #reportAbuse,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.UsersReactionsResponse>> reactions(
-          _i6.UsersReactionsRequest? request) =>
+  _i16.Future<Iterable<_i5.UsersReactionsResponse>> reactions(
+          _i5.UsersReactionsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #reactions,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.UsersReactionsResponse>>.value(
-            <_i6.UsersReactionsResponse>[]),
+        returnValue: _i16.Future<Iterable<_i5.UsersReactionsResponse>>.value(
+            <_i5.UsersReactionsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.UsersReactionsResponse>>.value(
-                <_i6.UsersReactionsResponse>[]),
-      ) as _i17.Future<Iterable<_i6.UsersReactionsResponse>>);
+            _i16.Future<Iterable<_i5.UsersReactionsResponse>>.value(
+                <_i5.UsersReactionsResponse>[]),
+      ) as _i16.Future<Iterable<_i5.UsersReactionsResponse>>);
 
   @override
-  _i17.Future<Iterable<_i6.User>> search(_i6.UsersSearchRequest? request) =>
+  _i16.Future<Iterable<_i5.User>> search(_i5.UsersSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
+        returnValue: _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
-      ) as _i17.Future<Iterable<_i6.User>>);
+            _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i16.Future<Iterable<_i5.User>>);
 
   @override
-  _i17.Future<Iterable<_i6.User>> recommendation(
-          _i6.UsersRecommendationRequest? request) =>
+  _i16.Future<Iterable<_i5.User>> recommendation(
+          _i5.UsersRecommendationRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #recommendation,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
+        returnValue: _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
-      ) as _i17.Future<Iterable<_i6.User>>);
+            _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i16.Future<Iterable<_i5.User>>);
 
   @override
-  _i17.Future<Iterable<_i6.User>> users(_i6.UsersUsersRequest? request) =>
+  _i16.Future<Iterable<_i5.User>> users(_i5.UsersUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
+        returnValue: _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.User>>.value(<_i6.User>[]),
-      ) as _i17.Future<Iterable<_i6.User>>);
+            _i16.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i16.Future<Iterable<_i5.User>>);
 
   @override
-  _i17.Future<void> updateMemo(_i6.UsersUpdateMemoRequest? request) =>
+  _i16.Future<void> updateMemo(_i5.UsersUpdateMemoRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateMemo,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i6.Flash>> flashs(_i6.UsersFlashsRequest? request) =>
+  _i16.Future<Iterable<_i5.Flash>> flashs(_i5.UsersFlashsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #flashs,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Flash>>.value(<_i6.Flash>[]),
+        returnValue: _i16.Future<Iterable<_i5.Flash>>.value(<_i5.Flash>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Flash>>.value(<_i6.Flash>[]),
-      ) as _i17.Future<Iterable<_i6.Flash>>);
+            _i16.Future<Iterable<_i5.Flash>>.value(<_i5.Flash>[]),
+      ) as _i16.Future<Iterable<_i5.Flash>>);
 
   @override
-  _i17.Future<Iterable<_i6.Note>> featuredNotes(
-          _i6.UsersFeaturedNotesRequest? request) =>
+  _i16.Future<Iterable<_i5.Note>> featuredNotes(
+          _i5.UsersFeaturedNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #featuredNotes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
+        returnValue: _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Note>>.value(<_i6.Note>[]),
-      ) as _i17.Future<Iterable<_i6.Note>>);
+            _i16.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i16.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i6.Page>> pages(_i6.UsersPagesRequest? request) =>
+  _i16.Future<Iterable<_i5.Page>> pages(_i5.UsersPagesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #pages,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i6.Page>>.value(<_i6.Page>[]),
+        returnValue: _i16.Future<Iterable<_i5.Page>>.value(<_i5.Page>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i6.Page>>.value(<_i6.Page>[]),
-      ) as _i17.Future<Iterable<_i6.Page>>);
+            _i16.Future<Iterable<_i5.Page>>.value(<_i5.Page>[]),
+      ) as _i16.Future<Iterable<_i5.Page>>);
 }
 
 /// A class which mocks [Dio].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDio extends _i1.Mock implements _i11.Dio {
+class MockDio extends _i1.Mock implements _i10.Dio {
   @override
-  _i11.BaseOptions get options => (super.noSuchMethod(
+  _i10.BaseOptions get options => (super.noSuchMethod(
         Invocation.getter(#options),
-        returnValue: _FakeBaseOptions_53(
+        returnValue: _FakeBaseOptions_52(
           this,
           Invocation.getter(#options),
         ),
-        returnValueForMissingStub: _FakeBaseOptions_53(
+        returnValueForMissingStub: _FakeBaseOptions_52(
           this,
           Invocation.getter(#options),
         ),
-      ) as _i11.BaseOptions);
+      ) as _i10.BaseOptions);
 
   @override
-  set options(_i11.BaseOptions? _options) => super.noSuchMethod(
+  set options(_i10.BaseOptions? _options) => super.noSuchMethod(
         Invocation.setter(
           #options,
           _options,
@@ -4760,20 +4660,20 @@ class MockDio extends _i1.Mock implements _i11.Dio {
       );
 
   @override
-  _i11.HttpClientAdapter get httpClientAdapter => (super.noSuchMethod(
+  _i10.HttpClientAdapter get httpClientAdapter => (super.noSuchMethod(
         Invocation.getter(#httpClientAdapter),
-        returnValue: _FakeHttpClientAdapter_54(
+        returnValue: _FakeHttpClientAdapter_53(
           this,
           Invocation.getter(#httpClientAdapter),
         ),
-        returnValueForMissingStub: _FakeHttpClientAdapter_54(
+        returnValueForMissingStub: _FakeHttpClientAdapter_53(
           this,
           Invocation.getter(#httpClientAdapter),
         ),
-      ) as _i11.HttpClientAdapter);
+      ) as _i10.HttpClientAdapter);
 
   @override
-  set httpClientAdapter(_i11.HttpClientAdapter? _httpClientAdapter) =>
+  set httpClientAdapter(_i10.HttpClientAdapter? _httpClientAdapter) =>
       super.noSuchMethod(
         Invocation.setter(
           #httpClientAdapter,
@@ -4783,20 +4683,20 @@ class MockDio extends _i1.Mock implements _i11.Dio {
       );
 
   @override
-  _i11.Transformer get transformer => (super.noSuchMethod(
+  _i10.Transformer get transformer => (super.noSuchMethod(
         Invocation.getter(#transformer),
-        returnValue: _FakeTransformer_55(
+        returnValue: _FakeTransformer_54(
           this,
           Invocation.getter(#transformer),
         ),
-        returnValueForMissingStub: _FakeTransformer_55(
+        returnValueForMissingStub: _FakeTransformer_54(
           this,
           Invocation.getter(#transformer),
         ),
-      ) as _i11.Transformer);
+      ) as _i10.Transformer);
 
   @override
-  set transformer(_i11.Transformer? _transformer) => super.noSuchMethod(
+  set transformer(_i10.Transformer? _transformer) => super.noSuchMethod(
         Invocation.setter(
           #transformer,
           _transformer,
@@ -4805,17 +4705,17 @@ class MockDio extends _i1.Mock implements _i11.Dio {
       );
 
   @override
-  _i11.Interceptors get interceptors => (super.noSuchMethod(
+  _i10.Interceptors get interceptors => (super.noSuchMethod(
         Invocation.getter(#interceptors),
-        returnValue: _FakeInterceptors_56(
+        returnValue: _FakeInterceptors_55(
           this,
           Invocation.getter(#interceptors),
         ),
-        returnValueForMissingStub: _FakeInterceptors_56(
+        returnValueForMissingStub: _FakeInterceptors_55(
           this,
           Invocation.getter(#interceptors),
         ),
-      ) as _i11.Interceptors);
+      ) as _i10.Interceptors);
 
   @override
   void close({bool? force = false}) => super.noSuchMethod(
@@ -4828,12 +4728,12 @@ class MockDio extends _i1.Mock implements _i11.Dio {
       );
 
   @override
-  _i17.Future<_i11.Response<T>> head<T>(
+  _i16.Future<_i10.Response<T>> head<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4846,7 +4746,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #head,
@@ -4860,7 +4760,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #head,
@@ -4873,14 +4773,14 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> headUri<T>(
+  _i16.Future<_i10.Response<T>> headUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4892,7 +4792,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #headUri,
@@ -4905,7 +4805,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #headUri,
@@ -4917,16 +4817,16 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> get<T>(
+  _i16.Future<_i10.Response<T>> get<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4940,7 +4840,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #get,
@@ -4955,7 +4855,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #get,
@@ -4969,15 +4869,15 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> getUri<T>(
+  _i16.Future<_i10.Response<T>> getUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4990,7 +4890,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #getUri,
@@ -5004,7 +4904,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #getUri,
@@ -5017,17 +4917,17 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> post<T>(
+  _i16.Future<_i10.Response<T>> post<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5042,7 +4942,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #post,
@@ -5058,7 +4958,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #post,
@@ -5073,16 +4973,16 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> postUri<T>(
+  _i16.Future<_i10.Response<T>> postUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5096,7 +4996,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #postUri,
@@ -5111,7 +5011,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #postUri,
@@ -5125,17 +5025,17 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> put<T>(
+  _i16.Future<_i10.Response<T>> put<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5150,7 +5050,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #put,
@@ -5166,7 +5066,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #put,
@@ -5181,16 +5081,16 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> putUri<T>(
+  _i16.Future<_i10.Response<T>> putUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5204,7 +5104,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #putUri,
@@ -5219,7 +5119,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #putUri,
@@ -5233,17 +5133,17 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> patch<T>(
+  _i16.Future<_i10.Response<T>> patch<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5258,7 +5158,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #patch,
@@ -5274,7 +5174,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #patch,
@@ -5289,16 +5189,16 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> patchUri<T>(
+  _i16.Future<_i10.Response<T>> patchUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5312,7 +5212,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #patchUri,
@@ -5327,7 +5227,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #patchUri,
@@ -5341,15 +5241,15 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> delete<T>(
+  _i16.Future<_i10.Response<T>> delete<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5362,7 +5262,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #delete,
@@ -5376,7 +5276,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #delete,
@@ -5389,14 +5289,14 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> deleteUri<T>(
+  _i16.Future<_i10.Response<T>> deleteUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i10.Options? options,
+    _i10.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5408,7 +5308,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #deleteUri,
@@ -5421,7 +5321,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #deleteUri,
@@ -5433,19 +5333,19 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<dynamic>> download(
+  _i16.Future<_i10.Response<dynamic>> download(
     String? urlPath,
     dynamic savePath, {
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.ProgressCallback? onReceiveProgress,
     Map<String, dynamic>? queryParameters,
-    _i11.CancelToken? cancelToken,
+    _i10.CancelToken? cancelToken,
     bool? deleteOnError = true,
     String? lengthHeader = r'content-length',
     Object? data,
-    _i11.Options? options,
+    _i10.Options? options,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5465,7 +5365,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           },
         ),
         returnValue:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_57<dynamic>(
+            _i16.Future<_i10.Response<dynamic>>.value(_FakeResponse_56<dynamic>(
           this,
           Invocation.method(
             #download,
@@ -5485,7 +5385,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_57<dynamic>(
+            _i16.Future<_i10.Response<dynamic>>.value(_FakeResponse_56<dynamic>(
           this,
           Invocation.method(
             #download,
@@ -5504,18 +5404,18 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<dynamic>>);
+      ) as _i16.Future<_i10.Response<dynamic>>);
 
   @override
-  _i17.Future<_i11.Response<dynamic>> downloadUri(
+  _i16.Future<_i10.Response<dynamic>> downloadUri(
     Uri? uri,
     dynamic savePath, {
-    _i11.ProgressCallback? onReceiveProgress,
-    _i11.CancelToken? cancelToken,
+    _i10.ProgressCallback? onReceiveProgress,
+    _i10.CancelToken? cancelToken,
     bool? deleteOnError = true,
     String? lengthHeader = r'content-length',
     Object? data,
-    _i11.Options? options,
+    _i10.Options? options,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5534,7 +5434,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           },
         ),
         returnValue:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_57<dynamic>(
+            _i16.Future<_i10.Response<dynamic>>.value(_FakeResponse_56<dynamic>(
           this,
           Invocation.method(
             #downloadUri,
@@ -5553,7 +5453,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_57<dynamic>(
+            _i16.Future<_i10.Response<dynamic>>.value(_FakeResponse_56<dynamic>(
           this,
           Invocation.method(
             #downloadUri,
@@ -5571,17 +5471,17 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<dynamic>>);
+      ) as _i16.Future<_i10.Response<dynamic>>);
 
   @override
-  _i17.Future<_i11.Response<T>> request<T>(
+  _i16.Future<_i10.Response<T>> request<T>(
     String? url, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.CancelToken? cancelToken,
-    _i11.Options? options,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.CancelToken? cancelToken,
+    _i10.Options? options,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5596,7 +5496,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #request,
@@ -5612,7 +5512,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #request,
@@ -5627,16 +5527,16 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> requestUri<T>(
+  _i16.Future<_i10.Response<T>> requestUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.CancelToken? cancelToken,
-    _i11.Options? options,
-    _i11.ProgressCallback? onSendProgress,
-    _i11.ProgressCallback? onReceiveProgress,
+    _i10.CancelToken? cancelToken,
+    _i10.Options? options,
+    _i10.ProgressCallback? onSendProgress,
+    _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5650,7 +5550,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #requestUri,
@@ -5665,7 +5565,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #requestUri,
@@ -5679,16 +5579,16 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> fetch<T>(_i11.RequestOptions? requestOptions) =>
+  _i16.Future<_i10.Response<T>> fetch<T>(_i10.RequestOptions? requestOptions) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetch,
           [requestOptions],
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+        returnValue: _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #fetch,
@@ -5696,28 +5596,28 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_57<T>(
+            _i16.Future<_i10.Response<T>>.value(_FakeResponse_56<T>(
           this,
           Invocation.method(
             #fetch,
             [requestOptions],
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i16.Future<_i10.Response<T>>);
 }
 
 /// A class which mocks [HttpClient].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
+class MockHttpClient extends _i1.Mock implements _i11.HttpClient {
   @override
   Duration get idleTimeout => (super.noSuchMethod(
         Invocation.getter(#idleTimeout),
-        returnValue: _FakeDuration_58(
+        returnValue: _FakeDuration_57(
           this,
           Invocation.getter(#idleTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_58(
+        returnValueForMissingStub: _FakeDuration_57(
           this,
           Invocation.getter(#idleTimeout),
         ),
@@ -5777,7 +5677,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
 
   @override
   set authenticate(
-          _i17.Future<bool> Function(
+          _i16.Future<bool> Function(
             Uri,
             String,
             String?,
@@ -5792,7 +5692,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
 
   @override
   set connectionFactory(
-          _i17.Future<_i12.ConnectionTask<_i12.Socket>> Function(
+          _i16.Future<_i11.ConnectionTask<_i11.Socket>> Function(
             Uri,
             String?,
             int?,
@@ -5816,7 +5716,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
 
   @override
   set authenticateProxy(
-          _i17.Future<bool> Function(
+          _i16.Future<bool> Function(
             String,
             int,
             String,
@@ -5833,7 +5733,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
   @override
   set badCertificateCallback(
           bool Function(
-            _i12.X509Certificate,
+            _i11.X509Certificate,
             String,
             int,
           )? callback) =>
@@ -5855,7 +5755,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
       );
 
   @override
-  _i17.Future<_i12.HttpClientRequest> open(
+  _i16.Future<_i11.HttpClientRequest> open(
     String? method,
     String? host,
     int? port,
@@ -5872,7 +5772,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #open,
@@ -5885,7 +5785,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #open,
@@ -5897,10 +5797,10 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> openUrl(
+  _i16.Future<_i11.HttpClientRequest> openUrl(
     String? method,
     Uri? url,
   ) =>
@@ -5913,7 +5813,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #openUrl,
@@ -5924,7 +5824,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #openUrl,
@@ -5934,10 +5834,10 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> get(
+  _i16.Future<_i11.HttpClientRequest> get(
     String? host,
     int? port,
     String? path,
@@ -5952,7 +5852,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #get,
@@ -5964,7 +5864,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #get,
@@ -5975,16 +5875,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
+  _i16.Future<_i11.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #getUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #getUrl,
@@ -5992,17 +5892,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #getUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> post(
+  _i16.Future<_i11.HttpClientRequest> post(
     String? host,
     int? port,
     String? path,
@@ -6017,7 +5917,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #post,
@@ -6029,7 +5929,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #post,
@@ -6040,16 +5940,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
+  _i16.Future<_i11.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #postUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #postUrl,
@@ -6057,17 +5957,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #postUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> put(
+  _i16.Future<_i11.HttpClientRequest> put(
     String? host,
     int? port,
     String? path,
@@ -6082,7 +5982,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #put,
@@ -6094,7 +5994,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #put,
@@ -6105,16 +6005,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
+  _i16.Future<_i11.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #putUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #putUrl,
@@ -6122,17 +6022,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #putUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> delete(
+  _i16.Future<_i11.HttpClientRequest> delete(
     String? host,
     int? port,
     String? path,
@@ -6147,7 +6047,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #delete,
@@ -6159,7 +6059,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #delete,
@@ -6170,17 +6070,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> deleteUrl(Uri? url) =>
+  _i16.Future<_i11.HttpClientRequest> deleteUrl(Uri? url) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #deleteUrl,
@@ -6188,17 +6088,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #deleteUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> patch(
+  _i16.Future<_i11.HttpClientRequest> patch(
     String? host,
     int? port,
     String? path,
@@ -6213,7 +6113,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #patch,
@@ -6225,7 +6125,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #patch,
@@ -6236,16 +6136,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
+  _i16.Future<_i11.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #patchUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #patchUrl,
@@ -6253,17 +6153,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #patchUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> head(
+  _i16.Future<_i11.HttpClientRequest> head(
     String? host,
     int? port,
     String? path,
@@ -6278,7 +6178,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #head,
@@ -6290,7 +6190,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #head,
@@ -6301,16 +6201,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
+  _i16.Future<_i11.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #headUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #headUrl,
@@ -6318,20 +6218,20 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_59(
+            _i16.Future<_i11.HttpClientRequest>.value(_FakeHttpClientRequest_58(
           this,
           Invocation.method(
             #headUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i16.Future<_i11.HttpClientRequest>);
 
   @override
   void addCredentials(
     Uri? url,
     String? realm,
-    _i12.HttpClientCredentials? credentials,
+    _i11.HttpClientCredentials? credentials,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -6350,7 +6250,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
     String? host,
     int? port,
     String? realm,
-    _i12.HttpClientCredentials? credentials,
+    _i11.HttpClientCredentials? credentials,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -6379,19 +6279,19 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
 /// A class which mocks [SocketController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSocketController extends _i1.Mock implements _i6.SocketController {
+class MockSocketController extends _i1.Mock implements _i5.SocketController {
   @override
-  _i6.StreamingService get service => (super.noSuchMethod(
+  _i5.StreamingService get service => (super.noSuchMethod(
         Invocation.getter(#service),
-        returnValue: _FakeStreamingService_6(
+        returnValue: _FakeStreamingService_5(
           this,
           Invocation.getter(#service),
         ),
-        returnValueForMissingStub: _FakeStreamingService_6(
+        returnValueForMissingStub: _FakeStreamingService_5(
           this,
           Invocation.getter(#service),
         ),
-      ) as _i6.StreamingService);
+      ) as _i5.StreamingService);
 
   @override
   String get id => (super.noSuchMethod(
@@ -6401,11 +6301,11 @@ class MockSocketController extends _i1.Mock implements _i6.SocketController {
       ) as String);
 
   @override
-  _i29.Channel get channel => (super.noSuchMethod(
+  _i27.Channel get channel => (super.noSuchMethod(
         Invocation.getter(#channel),
-        returnValue: _i29.Channel.homeTimeline,
-        returnValueForMissingStub: _i29.Channel.homeTimeline,
-      ) as _i29.Channel);
+        returnValue: _i27.Channel.homeTimeline,
+        returnValueForMissingStub: _i27.Channel.homeTimeline,
+      ) as _i27.Channel);
 
   @override
   bool get isDisconnected => (super.noSuchMethod(
@@ -6422,19 +6322,6 @@ class MockSocketController extends _i1.Mock implements _i6.SocketController {
         ),
         returnValueForMissingStub: null,
       );
-
-  @override
-  _i13.WebSocketChannel get webSocketChannel => (super.noSuchMethod(
-        Invocation.getter(#webSocketChannel),
-        returnValue: _FakeWebSocketChannel_60(
-          this,
-          Invocation.getter(#webSocketChannel),
-        ),
-        returnValueForMissingStub: _FakeWebSocketChannel_60(
-          this,
-          Invocation.getter(#webSocketChannel),
-        ),
-      ) as _i13.WebSocketChannel);
 
   @override
   void connect() => super.noSuchMethod(
@@ -6464,27 +6351,27 @@ class MockSocketController extends _i1.Mock implements _i6.SocketController {
       );
 
   @override
-  _i17.Future<void> subNote(String? noteId) => (super.noSuchMethod(
+  _i16.Future<void> subNote(String? noteId) => (super.noSuchMethod(
         Invocation.method(
           #subNote,
           [noteId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> unsubNote(String? noteId) => (super.noSuchMethod(
+  _i16.Future<void> unsubNote(String? noteId) => (super.noSuchMethod(
         Invocation.method(
           #unsubNote,
           [noteId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> requestLog({
+  _i16.Future<void> requestLog({
     String? id,
     int? length,
   }) =>
@@ -6497,14 +6384,14 @@ class MockSocketController extends _i1.Mock implements _i6.SocketController {
             #length: length,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> send(
-    _i6.StreamingRequestType? requestType,
-    _i30.StreamingRequestBody? body,
+  _i16.Future<void> send(
+    _i5.StreamingRequestType? requestType,
+    _i28.StreamingRequestBody? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6514,15 +6401,15 @@ class MockSocketController extends _i1.Mock implements _i6.SocketController {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [StreamingService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
+class MockStreamingService extends _i1.Mock implements _i5.StreamingService {
   @override
   String get host => (super.noSuchMethod(
         Invocation.getter(#host),
@@ -6531,23 +6418,23 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
       ) as String);
 
   @override
-  _i31.HashMap<String, _i6.SocketController> get streamingChannelControllers =>
+  _i29.HashMap<String, _i5.SocketController> get streamingChannelControllers =>
       (super.noSuchMethod(
         Invocation.getter(#streamingChannelControllers),
         returnValue:
-            _i26.dummyValue<_i31.HashMap<String, _i6.SocketController>>(
+            _i30.dummyValue<_i29.HashMap<String, _i5.SocketController>>(
           this,
           Invocation.getter(#streamingChannelControllers),
         ),
         returnValueForMissingStub:
-            _i26.dummyValue<_i31.HashMap<String, _i6.SocketController>>(
+            _i30.dummyValue<_i29.HashMap<String, _i5.SocketController>>(
           this,
           Invocation.getter(#streamingChannelControllers),
         ),
-      ) as _i31.HashMap<String, _i6.SocketController>);
+      ) as _i29.HashMap<String, _i5.SocketController>);
 
   @override
-  set subscription(_i17.StreamSubscription<dynamic>? _subscription) =>
+  set subscription(_i16.StreamSubscription<dynamic>? _subscription) =>
       super.noSuchMethod(
         Invocation.setter(
           #subscription,
@@ -6557,22 +6444,9 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
       );
 
   @override
-  _i13.WebSocketChannel get webSocketChannel => (super.noSuchMethod(
-        Invocation.getter(#webSocketChannel),
-        returnValue: _FakeWebSocketChannel_60(
-          this,
-          Invocation.getter(#webSocketChannel),
-        ),
-        returnValueForMissingStub: _FakeWebSocketChannel_60(
-          this,
-          Invocation.getter(#webSocketChannel),
-        ),
-      ) as _i13.WebSocketChannel);
-
-  @override
-  _i17.Future<void> onChannelEventReceived(
+  _i16.Future<void> onChannelEventReceived(
     String? id,
-    _i32.ChannelEventType? type,
+    _i31.ChannelEventType? type,
     dynamic body,
   ) =>
       (super.noSuchMethod(
@@ -6584,14 +6458,14 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> onNoteUpdatedEventReceived(
+  _i16.Future<void> onNoteUpdatedEventReceived(
     String? id,
-    _i33.NoteUpdatedEventType? type,
+    _i32.NoteUpdatedEventType? type,
     Map<String, dynamic>? body,
   ) =>
       (super.noSuchMethod(
@@ -6603,13 +6477,13 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> onBroadcastEventReceived(
-    _i34.BroadcastEventType? type,
+  _i16.Future<void> onBroadcastEventReceived(
+    _i33.BroadcastEventType? type,
     Map<String, dynamic>? body,
   ) =>
       (super.noSuchMethod(
@@ -6620,35 +6494,35 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> startStreaming() => (super.noSuchMethod(
+  _i16.Future<void> startStreaming() => (super.noSuchMethod(
         Invocation.method(
           #startStreaming,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i6.SocketController connect({
+  _i5.SocketController connect({
     String? id,
-    required _i29.Channel? channel,
-    _i17.Future<void> Function(
-      _i32.ChannelEventType,
+    required _i27.Channel? channel,
+    _i16.Future<void> Function(
+      _i31.ChannelEventType,
       dynamic,
     )? onChannelEventReceived,
-    _i17.Future<void> Function(
+    _i16.Future<void> Function(
       String,
-      _i33.NoteUpdatedEventType,
+      _i32.NoteUpdatedEventType,
       Map<String, dynamic>,
     )? onNoteUpdatedEventReceived,
-    _i17.Future<void> Function(
-      _i34.BroadcastEventType,
+    _i16.Future<void> Function(
+      _i33.BroadcastEventType,
       Map<String, dynamic>,
     )? onBroadcastEventReceived,
     Map<String, dynamic>? parameters,
@@ -6666,7 +6540,7 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
             #parameters: parameters,
           },
         ),
-        returnValue: _FakeSocketController_31(
+        returnValue: _FakeSocketController_30(
           this,
           Invocation.method(
             #connect,
@@ -6681,7 +6555,7 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSocketController_31(
+        returnValueForMissingStub: _FakeSocketController_30(
           this,
           Invocation.method(
             #connect,
@@ -6696,41 +6570,41 @@ class MockStreamingService extends _i1.Mock implements _i6.StreamingService {
             },
           ),
         ),
-      ) as _i6.SocketController);
+      ) as _i5.SocketController);
 
   @override
-  _i17.Future<void> close() => (super.noSuchMethod(
+  _i16.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> restart() => (super.noSuchMethod(
+  _i16.Future<void> restart() => (super.noSuchMethod(
         Invocation.method(
           #restart,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [FakeFilePickerPlatform].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFilePickerPlatform extends _i1.Mock
-    implements _i35.FakeFilePickerPlatform {
+    implements _i34.FakeFilePickerPlatform {
   @override
-  _i17.Future<_i36.FilePickerResult?> pickFiles({
+  _i16.Future<_i35.FilePickerResult?> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
-    _i36.FileType? type = _i36.FileType.any,
+    _i35.FileType? type = _i35.FileType.any,
     List<String>? allowedExtensions,
-    dynamic Function(_i36.FilePickerStatus)? onFileLoading,
+    dynamic Function(_i35.FilePickerStatus)? onFileLoading,
     bool? allowCompression = true,
     bool? allowMultiple = false,
     bool? withData = false,
@@ -6754,22 +6628,22 @@ class MockFilePickerPlatform extends _i1.Mock
             #lockParentWindow: lockParentWindow,
           },
         ),
-        returnValue: _i17.Future<_i36.FilePickerResult?>.value(),
-        returnValueForMissingStub: _i17.Future<_i36.FilePickerResult?>.value(),
-      ) as _i17.Future<_i36.FilePickerResult?>);
+        returnValue: _i16.Future<_i35.FilePickerResult?>.value(),
+        returnValueForMissingStub: _i16.Future<_i35.FilePickerResult?>.value(),
+      ) as _i16.Future<_i35.FilePickerResult?>);
 
   @override
-  _i17.Future<bool?> clearTemporaryFiles() => (super.noSuchMethod(
+  _i16.Future<bool?> clearTemporaryFiles() => (super.noSuchMethod(
         Invocation.method(
           #clearTemporaryFiles,
           [],
         ),
-        returnValue: _i17.Future<bool?>.value(),
-        returnValueForMissingStub: _i17.Future<bool?>.value(),
-      ) as _i17.Future<bool?>);
+        returnValue: _i16.Future<bool?>.value(),
+        returnValueForMissingStub: _i16.Future<bool?>.value(),
+      ) as _i16.Future<bool?>);
 
   @override
-  _i17.Future<String?> getDirectoryPath({
+  _i16.Future<String?> getDirectoryPath({
     String? dialogTitle,
     bool? lockParentWindow = false,
     String? initialDirectory,
@@ -6784,16 +6658,16 @@ class MockFilePickerPlatform extends _i1.Mock
             #initialDirectory: initialDirectory,
           },
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
-  _i17.Future<String?> saveFile({
+  _i16.Future<String?> saveFile({
     String? dialogTitle,
     String? fileName,
     String? initialDirectory,
-    _i36.FileType? type = _i36.FileType.any,
+    _i35.FileType? type = _i35.FileType.any,
     List<String>? allowedExtensions,
     bool? lockParentWindow = false,
   }) =>
@@ -6810,18 +6684,18 @@ class MockFilePickerPlatform extends _i1.Mock
             #lockParentWindow: lockParentWindow,
           },
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 }
 
 /// A class which mocks [$MockBaseCacheManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockBaseCacheManager extends _i1.Mock
-    implements _i35.$MockBaseCacheManager {
+    implements _i34.$MockBaseCacheManager {
   @override
-  _i17.Future<_i14.File> getSingleFile(
+  _i16.Future<_i12.File> getSingleFile(
     String? url, {
     String? key,
     Map<String, String>? headers,
@@ -6835,7 +6709,7 @@ class MockBaseCacheManager extends _i1.Mock
             #headers: headers,
           },
         ),
-        returnValue: _i17.Future<_i14.File>.value(_FakeFile_61(
+        returnValue: _i16.Future<_i12.File>.value(_FakeFile_59(
           this,
           Invocation.method(
             #getSingleFile,
@@ -6846,7 +6720,7 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i14.File>.value(_FakeFile_61(
+        returnValueForMissingStub: _i16.Future<_i12.File>.value(_FakeFile_59(
           this,
           Invocation.method(
             #getSingleFile,
@@ -6857,10 +6731,10 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i14.File>);
+      ) as _i16.Future<_i12.File>);
 
   @override
-  _i17.Stream<_i15.FileInfo> getFile(
+  _i16.Stream<_i13.FileInfo> getFile(
     String? url, {
     String? key,
     Map<String, String>? headers,
@@ -6874,12 +6748,12 @@ class MockBaseCacheManager extends _i1.Mock
             #headers: headers,
           },
         ),
-        returnValue: _i17.Stream<_i15.FileInfo>.empty(),
-        returnValueForMissingStub: _i17.Stream<_i15.FileInfo>.empty(),
-      ) as _i17.Stream<_i15.FileInfo>);
+        returnValue: _i16.Stream<_i13.FileInfo>.empty(),
+        returnValueForMissingStub: _i16.Stream<_i13.FileInfo>.empty(),
+      ) as _i16.Stream<_i13.FileInfo>);
 
   @override
-  _i17.Stream<_i15.FileResponse> getFileStream(
+  _i16.Stream<_i13.FileResponse> getFileStream(
     String? url, {
     String? key,
     Map<String, String>? headers,
@@ -6895,12 +6769,12 @@ class MockBaseCacheManager extends _i1.Mock
             #withProgress: withProgress,
           },
         ),
-        returnValue: _i17.Stream<_i15.FileResponse>.empty(),
-        returnValueForMissingStub: _i17.Stream<_i15.FileResponse>.empty(),
-      ) as _i17.Stream<_i15.FileResponse>);
+        returnValue: _i16.Stream<_i13.FileResponse>.empty(),
+        returnValueForMissingStub: _i16.Stream<_i13.FileResponse>.empty(),
+      ) as _i16.Stream<_i13.FileResponse>);
 
   @override
-  _i17.Future<_i15.FileInfo> downloadFile(
+  _i16.Future<_i13.FileInfo> downloadFile(
     String? url, {
     String? key,
     Map<String, String>? authHeaders,
@@ -6916,7 +6790,7 @@ class MockBaseCacheManager extends _i1.Mock
             #force: force,
           },
         ),
-        returnValue: _i17.Future<_i15.FileInfo>.value(_FakeFileInfo_62(
+        returnValue: _i16.Future<_i13.FileInfo>.value(_FakeFileInfo_60(
           this,
           Invocation.method(
             #downloadFile,
@@ -6929,7 +6803,7 @@ class MockBaseCacheManager extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i15.FileInfo>.value(_FakeFileInfo_62(
+            _i16.Future<_i13.FileInfo>.value(_FakeFileInfo_60(
           this,
           Invocation.method(
             #downloadFile,
@@ -6941,10 +6815,10 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i15.FileInfo>);
+      ) as _i16.Future<_i13.FileInfo>);
 
   @override
-  _i17.Future<_i15.FileInfo?> getFileFromCache(
+  _i16.Future<_i13.FileInfo?> getFileFromCache(
     String? key, {
     bool? ignoreMemCache = false,
   }) =>
@@ -6954,25 +6828,25 @@ class MockBaseCacheManager extends _i1.Mock
           [key],
           {#ignoreMemCache: ignoreMemCache},
         ),
-        returnValue: _i17.Future<_i15.FileInfo?>.value(),
-        returnValueForMissingStub: _i17.Future<_i15.FileInfo?>.value(),
-      ) as _i17.Future<_i15.FileInfo?>);
+        returnValue: _i16.Future<_i13.FileInfo?>.value(),
+        returnValueForMissingStub: _i16.Future<_i13.FileInfo?>.value(),
+      ) as _i16.Future<_i13.FileInfo?>);
 
   @override
-  _i17.Future<_i15.FileInfo?> getFileFromMemory(String? key) =>
+  _i16.Future<_i13.FileInfo?> getFileFromMemory(String? key) =>
       (super.noSuchMethod(
         Invocation.method(
           #getFileFromMemory,
           [key],
         ),
-        returnValue: _i17.Future<_i15.FileInfo?>.value(),
-        returnValueForMissingStub: _i17.Future<_i15.FileInfo?>.value(),
-      ) as _i17.Future<_i15.FileInfo?>);
+        returnValue: _i16.Future<_i13.FileInfo?>.value(),
+        returnValueForMissingStub: _i16.Future<_i13.FileInfo?>.value(),
+      ) as _i16.Future<_i13.FileInfo?>);
 
   @override
-  _i17.Future<_i14.File> putFile(
+  _i16.Future<_i12.File> putFile(
     String? url,
-    _i28.Uint8List? fileBytes, {
+    _i26.Uint8List? fileBytes, {
     String? key,
     String? eTag,
     Duration? maxAge = const Duration(days: 30),
@@ -6992,7 +6866,7 @@ class MockBaseCacheManager extends _i1.Mock
             #fileExtension: fileExtension,
           },
         ),
-        returnValue: _i17.Future<_i14.File>.value(_FakeFile_61(
+        returnValue: _i16.Future<_i12.File>.value(_FakeFile_59(
           this,
           Invocation.method(
             #putFile,
@@ -7008,7 +6882,7 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i14.File>.value(_FakeFile_61(
+        returnValueForMissingStub: _i16.Future<_i12.File>.value(_FakeFile_59(
           this,
           Invocation.method(
             #putFile,
@@ -7024,12 +6898,12 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i14.File>);
+      ) as _i16.Future<_i12.File>);
 
   @override
-  _i17.Future<_i14.File> putFileStream(
+  _i16.Future<_i12.File> putFileStream(
     String? url,
-    _i17.Stream<List<int>>? source, {
+    _i16.Stream<List<int>>? source, {
     String? key,
     String? eTag,
     Duration? maxAge = const Duration(days: 30),
@@ -7049,7 +6923,7 @@ class MockBaseCacheManager extends _i1.Mock
             #fileExtension: fileExtension,
           },
         ),
-        returnValue: _i17.Future<_i14.File>.value(_FakeFile_61(
+        returnValue: _i16.Future<_i12.File>.value(_FakeFile_59(
           this,
           Invocation.method(
             #putFileStream,
@@ -7065,7 +6939,7 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i14.File>.value(_FakeFile_61(
+        returnValueForMissingStub: _i16.Future<_i12.File>.value(_FakeFile_59(
           this,
           Invocation.method(
             #putFileStream,
@@ -7081,56 +6955,56 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i14.File>);
+      ) as _i16.Future<_i12.File>);
 
   @override
-  _i17.Future<void> removeFile(String? key) => (super.noSuchMethod(
+  _i16.Future<void> removeFile(String? key) => (super.noSuchMethod(
         Invocation.method(
           #removeFile,
           [key],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> emptyCache() => (super.noSuchMethod(
+  _i16.Future<void> emptyCache() => (super.noSuchMethod(
         Invocation.method(
           #emptyCache,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<void> dispose() => (super.noSuchMethod(
+  _i16.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [$MockUrlLauncherPlatform].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockUrlLauncherPlatform extends _i1.Mock
-    implements _i35.$MockUrlLauncherPlatform {
+    implements _i34.$MockUrlLauncherPlatform {
   @override
-  _i17.Future<bool> canLaunch(String? url) => (super.noSuchMethod(
+  _i16.Future<bool> canLaunch(String? url) => (super.noSuchMethod(
         Invocation.method(
           #canLaunch,
           [url],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i17.Future<bool> launch(
+  _i16.Future<bool> launch(
     String? url, {
     required bool? useSafariVC,
     required bool? useWebView,
@@ -7154,14 +7028,14 @@ class MockUrlLauncherPlatform extends _i1.Mock
             #webOnlyWindowName: webOnlyWindowName,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i17.Future<bool> launchUrl(
+  _i16.Future<bool> launchUrl(
     String? url,
-    _i37.LaunchOptions? options,
+    _i36.LaunchOptions? options,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7171,39 +7045,39 @@ class MockUrlLauncherPlatform extends _i1.Mock
             options,
           ],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i17.Future<void> closeWebView() => (super.noSuchMethod(
+  _i16.Future<void> closeWebView() => (super.noSuchMethod(
         Invocation.method(
           #closeWebView,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i17.Future<bool> supportsMode(_i37.PreferredLaunchMode? mode) =>
+  _i16.Future<bool> supportsMode(_i36.PreferredLaunchMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #supportsMode,
           [mode],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i17.Future<bool> supportsCloseForMode(_i37.PreferredLaunchMode? mode) =>
+  _i16.Future<bool> supportsCloseForMode(_i36.PreferredLaunchMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #supportsCloseForMode,
           [mode],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 }

--- a/test/view/timeline_page/timeline_page_test_util.dart
+++ b/test/view/timeline_page/timeline_page_test_util.dart
@@ -53,8 +53,6 @@ class TimelinePageTest {
     when(mockMisskeyI.i()).thenAnswer((_) async => TestData.account.i);
 
     when(mockTabSettingsRepository.tabSettings).thenReturn([tabSetting]);
-
-    when(mockAccountRepository.account).thenReturn([TestData.account]);
   }
 
   Widget buildWidget({
@@ -65,7 +63,7 @@ class TimelinePageTest {
         misskeyProvider.overrideWith((ref, arg) => mockMisskey),
         tabSettingsRepositoryProvider
             .overrideWith((ref) => mockTabSettingsRepository),
-        accountRepository.overrideWith((ref) => mockAccountRepository),
+        accountsProvider.overrideWith((ref) => [TestData.account]),
         emojiRepositoryProvider
             .overrideWith((ref, arg) => MockEmojiRepository())
       ],


### PR DESCRIPTION
アカウント設定画面でアカウントを並べ替えられるようにしました

- ドラッグすることで順番を変えられます
- iOSやAndroidでもハンドルが表示されるようにしました
  - ドラッグできることを示すための飾りとして
  - タブ設定画面も同様に変更しました
- 削除はボタンをタップするとダイアログが出るようにしました
  - #48
    - アカウントをタップしたときに見せたい情報が特に思いつかなかったので統一はできていませんが、長押ししたときの挙動は統一できています

これに伴ってAccountRepositoryを書き換えました

- iを更新したアカウントをSetで保持するようにしました
- アカウントを追加する際に既に追加されているアカウントを追加できないようにしました
  - #238
- 1つ目のアカウントが追加されたときに追加するタブ設定をTabSettingsRepositoryに移しました

Fix #238
Fix #239
Fix #48