### PR TITLE
detailedではないノートのregisterを修正

### DIFF
--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -33,9 +33,12 @@ class NoteRepository extends ChangeNotifier {
   }
 
   void _registerNote(Note note) {
+    final registeredNote = _notes[note.id];
     _notes[note.id] = note.copyWith(
       renote: note.renote ?? _notes[note.renoteId],
       reply: note.reply ?? _notes[note.replyId],
+      poll: note.poll ?? registeredNote?.poll,
+      myReaction: note.myReaction ?? registeredNote?.myReaction,
     );
     _noteStatuses[note.id] ??= const NoteStatus(
         isCwOpened: false,


### PR DESCRIPTION
Fix #228

detailedではないノートでは `reply`, `renote`, `poll`, `myReaction` がnullになります

https://github.com/misskey-dev/misskey/blob/23102a2c082d583e9746f4af6e5015e43f038232/packages/backend/src/core/entities/NoteEntityService.ts#L342-L358

`reply`, `renote` についてはnullの場合の処理が書かれていましたが、 `poll`, `myReaction` についてはなかったので、過去に登録されたノートを見るようにしました