### PR TITLE
Linuxのフォントコールバックの改善

### DIFF
--- a/lib/view/themes/app_theme_scope.dart
+++ b/lib/view/themes/app_theme_scope.dart
@@ -60,6 +60,9 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
         defaultTargetPlatform == TargetPlatform.macOS) {
       return "SF Pro Text";
     }
+    if (defaultTargetPlatform == TargetPlatform.linux) {
+      return "Noto Sans CJK JP";
+    }
 
     return "KosugiMaru";
   }

--- a/lib/view/themes/app_theme_scope.dart
+++ b/lib/view/themes/app_theme_scope.dart
@@ -65,7 +65,8 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
   }
 
   List<String> resolveFontFamilyCallback() {
-    if (defaultTargetPlatform == TargetPlatform.windows) {
+    if (defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.linux) {
       return ["Noto Sans CJK JP", "KosugiMaru", "BIZ UDPGothic"];
     }
     if (defaultTargetPlatform == TargetPlatform.iOS ||
@@ -101,7 +102,8 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
           fontFamily: "Segoe UI Emoji",
           fontFamilyFallback: ["Segoe UI Emoji", "Noto Color Emoji", "Meiryo"]);
     }
-    if (defaultTargetPlatform == TargetPlatform.android) {
+    if (defaultTargetPlatform == TargetPlatform.android ||
+       defaultTargetPlatform == TargetPlatform.linux) {
       return const TextStyle(
           fontFamily: "Noto Color Emoji",
           fontFamilyFallback: ["Noto Color Emoji", "Noto Sans JP"]);


### PR DESCRIPTION
Linux環境でコールバックするフォントが指定されていなかったため追加しました（Windowsと同じ指定にしました）。
また、標準のUnicode絵文字が"Noto Color Emoji"を使用するように指定しました（Androidと同じ指定にしました）。