### PR TITLE
省略されたノートを一定の行まで表示する

### DIFF
--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -620,67 +620,50 @@ class MisskeyNote extends HookConsumerWidget {
                         ],
                         if (displayNote.cw == null ||
                             displayNote.cw != null && isCwOpened) ...[
-                          if (isReactionedRenote)
-                            SimpleMfmText(
-                              "${(displayNote.text ?? "").substring(0, min((displayNote.text ?? "").length, 50))}..."
-                                  .replaceAll("\n\n", "\n"),
-                              isNyaize: displayNote.user.isCat,
-                              emojis: displayNote.emojis,
-                              suffixSpan: [
-                                WidgetSpan(
-                                  child: InNoteButton(
-                                    onPressed: toggleReactionedRenote,
-                                    child: Text(
-                                      S.of(context).showReactionedNote,
-                                    ),
+                          MfmText(
+                            mfmNode: displayTextNodes,
+                            host: displayNote.user.host,
+                            emoji: displayNote.emojis,
+                            isNyaize: displayNote.user.isCat,
+                            isEnableAnimatedMFM: ref
+                                .read(generalSettingsRepositoryProvider)
+                                .settings
+                                .enableAnimatedMFM,
+                            onEmojiTap: (emojiData) async =>
+                                await reactionControl(requestEmoji: emojiData),
+                            suffixSpan: [
+                              if (!isEmptyRenote &&
+                                  displayNote.renoteId != null &&
+                                  (recursive == 2 || isForceUnvisibleRenote))
+                                TextSpan(
+                                  text: "  RN:...",
+                                  style: TextStyle(
+                                    color: Theme.of(context).primaryColor,
+                                    fontStyle: FontStyle.italic,
                                   ),
                                 ),
-                              ],
-                            )
-                          else ...[
-                            if (isLongVisible)
-                              MfmText(
-                                mfmNode: displayTextNodes,
-                                host: displayNote.user.host,
-                                emoji: displayNote.emojis,
-                                isNyaize: displayNote.user.isCat,
-                                isEnableAnimatedMFM: ref
-                                    .read(generalSettingsRepositoryProvider)
-                                    .settings
-                                    .enableAnimatedMFM,
-                                onEmojiTap: (emojiData) async =>
-                                    await reactionControl(
-                                      requestEmoji: emojiData,
-                                    ),
-                                suffixSpan: [
-                                  if (!isEmptyRenote &&
-                                      displayNote.renoteId != null &&
-                                      (recursive == 2 ||
-                                          isForceUnvisibleRenote))
-                                    TextSpan(
-                                      text: "  RN:...",
-                                      style: TextStyle(
-                                        color: Theme.of(context).primaryColor,
-                                        fontStyle: FontStyle.italic,
-                                      ),
-                                    ),
-                                ],
-                              )
-                            else
-                              SimpleMfmText(
-                                "${(displayNote.text ?? "").substring(0, min((displayNote.text ?? "").length, 150))}..."
-                                    .replaceAll("\n\n", "\n"),
-                                emojis: displayNote.emojis,
-                                isNyaize: displayNote.user.isCat,
-                                suffixSpan: [
-                                  WidgetSpan(
-                                    child: InNoteButton(
-                                      onPressed: toggleLongNote,
-                                      child: Text(S.of(context).showLongText),
-                                    ),
-                                  ),
-                                ],
+                            ],
+                            maxLines: isReactionedRenote
+                                ? 1
+                                : isLongVisible
+                                ? null
+                                : 10,
+                          ),
+                          if (isReactionedRenote)
+                            Center(
+                              child: InNoteButton(
+                                onPressed: toggleReactionedRenote,
+                                child: Text(S.of(context).showReactionedNote),
                               ),
+                            )
+                          else if (!isLongVisible)
+                            Center(
+                              child: InNoteButton(
+                                onPressed: toggleLongNote,
+                                child: Text(S.of(context).showLongText),
+                              ),
+                            ),
+                          if (!isReactionedRenote) ...[
                             MisskeyFileView(
                               files: displayNote.files,
                               height: 200 * pow(0.5, recursive - 1).toDouble(),

--- a/test/view/common/misskey_notes/misskey_notes_test.dart
+++ b/test/view/common/misskey_notes/misskey_notes_test.dart
@@ -228,9 +228,9 @@ System.out.println("@ai uneune");
           ),
         );
         await tester.pumpAndSettle();
-        expect(find.textContaining(longText), findsNothing);
         await tester.tap(find.text("続きを表示"));
         await tester.pumpAndSettle();
+        expect(find.text("続きを表示"), findsNothing);
         expect(find.textContaining(longText), findsOneWidget);
       });
     });


### PR DESCRIPTION
省略されたノートの表示にSimpleMfmTextの代わりにMfmTextを使い、リアクションをしたノートは1行、長いノートと判定されたノートは10行まで表示するようにしました

- 行数は根拠があって決めたものではありません
- 折りたたまれたノートはこの行数より短いことも長いこともあります
  - 短い場合、続きを表示のボタンを押してもボタンが消えるだけで内容に変化は起こりません
- この変更によってmfmのタグが表示されたりすることが無くなります

shiosyakeyakini-info/mfm_renderer#1 に依存します