### PR TITLE
[Linux]AppImageビルドのサポート

### DIFF
--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -43,6 +43,24 @@ jobs:
       - name: Flutter Build
         run:  flutter build linux --release
 
+      - name: Setup Packaging AppImage
+        run:  |
+          sudo apt install -y locate libfuse2
+          wget -O appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x appimagetool
+          sudo mv appimagetool /usr/local/bin/
+          flutter pub global activate flutter_distributor
+
+      - name: Packaging AppImage
+        run:  |
+          flutter_distributor package --platform linux --targets appimage --skip-clean
+          mv ./dist/$BUMP_VERSION/miria-$BUMP_VERSION-linux.AppImage ./dist/$BUMP_VERSION/miria-$BUMP_VERSION-amd64.AppImage
+
+      - name: Upload artifact to release (AppImage)
+        env:  
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:  gh release upload v$VERSION ./dist/$BUMP_VERSION/miria-$BUMP_VERSION-amd64.AppImage
+  
       - name: Compress App
         run:  |
           cd build/linux/x64/release/bundle

--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -17,9 +17,22 @@ jobs:
         uses: subosito/flutter-action@v2
         with: 
           channel:  'stable'
+          cache:  true
+
+      - name: Cache pubspec dependencies
+        uses: actions/cache@v3
+        with: 
+          path: |
+            ${{ env.FLUTTER_HOME }}/.pub-cache
+            **/.packages
+            **/.flutter-plugins
+            **/.flutter-plugin-dependencies
+            **/.dart_tool/package_config.json
+          key:  build-pubspec-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: build-pubspec-
 
       - name: Install Flutter Build Tools for Linux
-        run:  sudo apt install -y libsecret-1-dev imagemagick
+        run:  sudo apt install -y libsecret-1-dev
 
       - name: Flutter pub get
         run:  flutter pub get
@@ -35,8 +48,13 @@ jobs:
           cd build/linux/x64/release/bundle
           tar -czaf miria-$VERSION-x86_64.tar.gz
 
-      - name: Upload artifact
-        uses: actions/upload-artifacts@v3
-        with: 
-          name: linux-x86_64
-          path: build/linux/x64/release/bundle/miria-$VERSION-x86_64.tar.gz
+      # - name: Upload artifact
+      #   uses: actions/upload-artifacts@v3
+      #   with: 
+      #     name: linux-x86_64
+      #     path: build/linux/x64/release/bundle/miria-$VERSION-x86_64.tar.gz
+
+      - name: Upload artifact to release
+        env:  
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:  gh release upload v$VERSION ./build/linux/x64/release/bundle/miria-$VERSION-x86_64.tar.gz

--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -1,0 +1,42 @@
+name: デプロイ(Linux)
+on: [workflow_dispatch]
+permissions:  
+  contents: write
+jobs: 
+  build_for_linux:  
+    name: Linux用ビルド
+    runs-on:  ubuntu-latest
+    steps:  
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Flutter Develop dependencies
+        run:  sudo apt install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
+          
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with: 
+          channel:  'stable'
+
+      - name: Install Flutter Build Tools for Linux
+        run:  sudo apt install -y libsecret-1-dev imagemagick
+
+      - name: Flutter pub get
+        run:  flutter pub get
+
+      - name: Get Version
+        run:  echo "VERSION=$(flutter pub run cider version)" >> $GITHUB_ENV
+
+      - name: Flutter Build
+        run:  flutter build linux --release
+
+      - name: Compress App
+        run:  |
+          cd build/linux/x64/release/bundle
+          tar -czaf miria-$VERSION-x86_64.tar.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifacts@v3
+        with: 
+          name: linux-x86_64
+          path: build/linux/x64/release/bundle/miria-$VERSION-x86_64.tar.gz

--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Compress App
         run:  |
           cd build/linux/x64/release/bundle
-          tar -czaf miria-$VERSION-x86_64.tar.gz
+          tar -czaf miria-$VERSION-x86_64.tar.gz *
 
       # - name: Upload artifact
       #   uses: actions/upload-artifacts@v3
@@ -58,3 +58,6 @@ jobs:
         env:  
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:  gh release upload v$VERSION ./build/linux/x64/release/bundle/miria-$VERSION-x86_64.tar.gz
+
+      - name: Remove artifact.tar.gz
+        run:  rm build/linux/x64/release/bundle/miria-$VERSION-x86_64.tar.gz

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -1,0 +1,12 @@
+display_name: Miria
+icon: assets/images/icon.png
+keywords:
+  - Misskey
+  - みすきー
+  - Miria
+  - みりあ
+categories:
+  - Network
+include: []
+startup_notify: true
+generic_name: Misskey Client Application

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -452,13 +452,13 @@ packages:
     source: hosted
     version: "8.0.0"
   flutter_secure_storage_linux:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_secure_storage_linux
-      sha256: "0912ae29a572230ad52d8a4697e5518d7f0f429052fd51df7e5a7952c7efe2a3"
+      sha256: "3d5032e314774ee0e1a7d0a9f5e2793486f0dff2dd9ef5a23f4e3fb2a0ae6a9e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   flutter_secure_storage_macos:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   colorfilter_generator: ^0.0.8
   matrix2d: ^1.0.4
   twemoji_v2: ^0.5.3
+  flutter_secure_storage_linux: ^1.2.0
 
 dependency_overrides:
   image_editor:


### PR DESCRIPTION
#254 に関連
Linuxパッケージのひとつである`AppImage`（amd64）のビルドができるようにしました。

このPRにはGitHub Actionsへの変更を含みます。Android apkのビルドが不完全の可能性があります。

既知の問題: 実行時にアプリアイコンが表示されません。
→ https://github.com/leanflutter/flutter_distributor/issues/141