### PR TITLE
#211 対応

### DIFF
--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -38,7 +38,8 @@ class NoteRepository extends ChangeNotifier {
       renote: note.renote ?? _notes[note.renoteId],
       reply: note.reply ?? _notes[note.replyId],
       poll: note.poll ?? registeredNote?.poll,
-      myReaction: note.myReaction ?? registeredNote?.myReaction,
+      myReaction: note.myReaction ??
+          (note.reactions.isNotEmpty ? registeredNote?.myReaction : null),
     );
     _noteStatuses[note.id] ??= const NoteStatus(
         isCwOpened: false,

--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -24,6 +24,7 @@ import 'package:miria/view/common/misskey_notes/note_vote.dart';
 import 'package:miria/view/common/misskey_notes/reaction_button.dart';
 import 'package:miria/view/common/misskey_notes/renote_modal_sheet.dart';
 import 'package:miria/view/common/misskey_notes/renote_user_dialog.dart';
+import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
 import 'package:miria/view/reaction_picker_dialog/reaction_picker_dialog.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/view/themes/app_theme.dart';
@@ -736,6 +737,15 @@ class MisskeyNoteState extends ConsumerState<MisskeyNote> {
       return;
     }
     if (displayNote.myReaction != null && requestEmoji == null) {
+      if (await SimpleConfirmDialog.show(
+              context: context,
+              message: "リアクション取り消してもええか？",
+              primary: "取り消す",
+              secondary: "やっぱりやめる") !=
+          true) {
+        return;
+      }
+
       await ref
           .read(misskeyProvider(account))
           .notes

--- a/lib/view/common/misskey_notes/reaction_button.dart
+++ b/lib/view/common/misskey_notes/reaction_button.dart
@@ -5,6 +5,7 @@ import 'package:miria/model/account.dart';
 import 'package:miria/model/misskey_emoji_data.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/view/common/account_scope.dart';
+import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
 import 'package:miria/view/themes/app_theme.dart';
 import 'package:miria/view/common/misskey_notes/custom_emoji.dart';
 import 'package:miria/view/common/misskey_notes/reaction_user_dialog.dart';
@@ -65,6 +66,15 @@ class ReactionButtonState extends ConsumerState<ReactionButton> {
           // リアクション取り消し
           final account = AccountScope.of(context);
           if (isMyReaction) {
+            if (await SimpleConfirmDialog.show(
+                    context: context,
+                    message: "リアクション取り消してもええか？",
+                    primary: "取り消す",
+                    secondary: "やっぱりやめる") !=
+                true) {
+              return;
+            }
+
             await ref
                 .read(misskeyProvider(account))
                 .notes

--- a/lib/view/user_page/user_control_dialog.dart
+++ b/lib/view/user_page/user_control_dialog.dart
@@ -6,6 +6,7 @@ import 'package:miria/model/account.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/view/common/error_notification.dart';
 import 'package:miria/view/common/futurable.dart';
+import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -95,6 +96,15 @@ class UserControlDialogState extends ConsumerState<UserControlDialog> {
   }
 
   Future<void> blockingCreate() async {
+    if (await SimpleConfirmDialog.show(
+            context: context,
+            message: "ブロックしてもええか？",
+            primary: "ブロックする",
+            secondary: "やっぱりやめる") !=
+        true) {
+      return;
+    }
+
     await ref
         .read(misskeyProvider(widget.account))
         .blocking

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -11,6 +11,7 @@ import 'package:miria/view/common/avatar_icon.dart';
 import 'package:miria/view/common/constants.dart';
 import 'package:miria/view/common/misskey_notes/mfm_text.dart';
 import 'package:miria/view/common/misskey_notes/misskey_note.dart';
+import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
 import 'package:miria/view/themes/app_theme.dart';
 import 'package:miria/view/user_page/update_memo_dialog.dart';
 import 'package:miria/view/user_page/user_control_dialog.dart';
@@ -58,11 +59,20 @@ class UserDetailState extends ConsumerState<UserDetail> {
 
   Future<void> followDelete() async {
     if (isFollowEditing) return;
+    final account = AccountScope.of(context);
+    if (await SimpleConfirmDialog.show(
+            context: context,
+            message: "フォロー解除してもええか？",
+            primary: "解除する",
+            secondary: "やっぱりやめる") !=
+        true) {
+      return;
+    }
     setState(() {
       isFollowEditing = true;
     });
     await ref
-        .read(misskeyProvider(AccountScope.of(context)))
+        .read(misskeyProvider(account))
         .following
         .delete(FollowingDeleteRequest(userId: response.id));
     if (!mounted) return;


### PR DESCRIPTION
#211 対応

- フォロー解除、ブロック、リアクション取り消し時に確認ダイアログを表示する
- リアクション取り消し後、再取得した際に再リアクションできなくなっていたのをあわせて修正