### PR TITLE
MFMの関数とハッシュタグの入力補完を追加

### DIFF
--- a/lib/extensions/text_editing_controller_extension.dart
+++ b/lib/extensions/text_editing_controller_extension.dart
@@ -27,10 +27,31 @@ extension TextEditingControllerExtension on TextEditingController {
     }
   }
 
+  String? get mfmFnQuery {
+    final textBeforeSelection = this.textBeforeSelection;
+    if (textBeforeSelection == null) {
+      return null;
+    }
+    final lastOpenTagIndex = textBeforeSelection.lastIndexOf(r"$[");
+    if (lastOpenTagIndex < 0) {
+      return null;
+    }
+    final query = textBeforeSelection.substring(lastOpenTagIndex + 2);
+    if (RegExp(r"^[a-z234]*$").hasMatch(query)) {
+      return query;
+    } else {
+      return null;
+    }
+  }
+
   InputCompletionType get inputCompletionType {
     final emojiQuery = this.emojiQuery;
     if (emojiQuery != null) {
       return Emoji(emojiQuery);
+    }
+    final mfmFnQuery = this.mfmFnQuery;
+    if (mfmFnQuery != null) {
+      return MfmFn(mfmFnQuery);
     }
     return Basic();
   }

--- a/lib/extensions/text_editing_controller_extension.dart
+++ b/lib/extensions/text_editing_controller_extension.dart
@@ -1,25 +1,38 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:miria/model/input_completion_type.dart';
 
 extension TextEditingControllerExtension on TextEditingController {
-  bool get isIncludeBeforeColon {
-    if (selection.base.offset == -1) return false;
-    return text.substring(0, selection.base.offset).contains(":");
-  }
-
-  bool get isEmojiScope {
-    final position = selection.base.offset;
-    final startPosition = text.substring(0, position).lastIndexOf(":") + 1;
-    if (RegExp(r':[a-zA-z_0-9]+?:$')
-        .hasMatch(text.substring(0, startPosition))) {
-      return true;
+  String? get textBeforeSelection {
+    final baseOffset = selection.baseOffset;
+    if (baseOffset < 0) {
+      return null;
     }
-    return false;
+    return text.substring(0, baseOffset);
   }
 
-  String get emojiSearchValue {
-    final position = selection.base.offset;
-    final startPosition = text.substring(0, position).lastIndexOf(":") + 1;
-    return text.substring(startPosition, position);
+  String? get emojiQuery {
+    final textBeforeSelection = this.textBeforeSelection;
+    if (textBeforeSelection == null) {
+      return null;
+    }
+    final lastColonIndex = textBeforeSelection.lastIndexOf(":");
+    if (lastColonIndex < 0) {
+      return null;
+    }
+    if (RegExp(r':[a-zA-z_0-9]+?:$')
+        .hasMatch(text.substring(0, lastColonIndex + 1))) {
+      return null;
+    } else {
+      return textBeforeSelection.substring(lastColonIndex + 1);
+    }
+  }
+
+  InputCompletionType get inputCompletionType {
+    final emojiQuery = this.emojiQuery;
+    if (emojiQuery != null) {
+      return Emoji(emojiQuery);
+    }
+    return Basic();
   }
 
   void insert(String insertText, {String? afterText}) {

--- a/lib/extensions/text_editing_controller_extension.dart
+++ b/lib/extensions/text_editing_controller_extension.dart
@@ -44,6 +44,23 @@ extension TextEditingControllerExtension on TextEditingController {
     }
   }
 
+  String? get hashtagQuery {
+    final textBeforeSelection = this.textBeforeSelection;
+    if (textBeforeSelection == null) {
+      return null;
+    }
+    final lastHashIndex = textBeforeSelection.lastIndexOf("#");
+    if (lastHashIndex < 0) {
+      return null;
+    }
+    final query = textBeforeSelection.substring(lastHashIndex + 1);
+    if (query.contains(RegExp(r"""[ \u3000\t.,!?'"#:/[\]【】()「」（）<>]"""))) {
+      return null;
+    } else {
+      return query;
+    }
+  }
+
   InputCompletionType get inputCompletionType {
     final emojiQuery = this.emojiQuery;
     if (emojiQuery != null) {
@@ -52,6 +69,10 @@ extension TextEditingControllerExtension on TextEditingController {
     final mfmFnQuery = this.mfmFnQuery;
     if (mfmFnQuery != null) {
       return MfmFn(mfmFnQuery);
+    }
+    final hashtagQuery = this.hashtagQuery;
+    if (hashtagQuery != null) {
+      return Hashtag(hashtagQuery);
     }
     return Basic();
   }

--- a/lib/model/input_completion_type.dart
+++ b/lib/model/input_completion_type.dart
@@ -1,0 +1,11 @@
+sealed class InputCompletionType {
+  const InputCompletionType();
+}
+
+class Basic extends InputCompletionType {}
+
+class Emoji extends InputCompletionType {
+  const Emoji(this.query);
+
+  final String query;
+}

--- a/lib/model/input_completion_type.dart
+++ b/lib/model/input_completion_type.dart
@@ -15,3 +15,9 @@ class MfmFn extends InputCompletionType {
 
   final String query;
 }
+
+class Hashtag extends InputCompletionType {
+  const Hashtag(this.query);
+
+  final String query;
+}

--- a/lib/model/input_completion_type.dart
+++ b/lib/model/input_completion_type.dart
@@ -9,3 +9,9 @@ class Emoji extends InputCompletionType {
 
   final String query;
 }
+
+class MfmFn extends InputCompletionType {
+  const MfmFn(this.query);
+
+  final String query;
+}

--- a/lib/view/common/note_create/basic_keyboard.dart
+++ b/lib/view/common/note_create/basic_keyboard.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/cupertino.dart';
 
-import 'custom_keyboard.dart';
+import 'custom_keyboard_button.dart';
 
-class CustomKeyboardList extends StatelessWidget {
+class BasicKeyboard extends StatelessWidget {
   final TextEditingController controller;
   final FocusNode focusNode;
 
-  const CustomKeyboardList({
+  const BasicKeyboard({
     super.key,
     required this.controller,
     required this.focusNode,
@@ -14,69 +14,85 @@ class CustomKeyboardList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(children: [
-      CustomKeyboard(
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        CustomKeyboardButton(
           keyboard: ":",
           displayText: "：",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: r"$[",
           afterInsert: "]",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "**",
           afterInsert: "**",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "<small>",
           afterInsert: "</small>",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "<i>",
           afterInsert: "</i>",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "***",
           afterInsert: "***",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "~~",
           afterInsert: "~~",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
-        keyboard: "> ",
-        displayText: "＞",
-        controller: controller,
-        focusNode: focusNode,
-      ),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
+          keyboard: "> ",
+          displayText: "＞",
+          controller: controller,
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "<center>",
           afterInsert: "</center>",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "`",
           afterInsert: "`",
           displayText: "｀",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "```\n",
           afterInsert: "\n```",
           controller: controller,
-          focusNode: focusNode),
-      CustomKeyboard(
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: "<plain>",
           afterInsert: "</plain>",
           controller: controller,
-          focusNode: focusNode)
-    ]);
+          focusNode: focusNode,
+        ),
+      ],
+    );
   }
 }

--- a/lib/view/common/note_create/custom_keyboard_button.dart
+++ b/lib/view/common/note_create/custom_keyboard_button.dart
@@ -7,6 +7,7 @@ class CustomKeyboardButton extends StatelessWidget {
   final String? afterInsert;
   final TextEditingController controller;
   final FocusNode focusNode;
+  final void Function()? onTap;
 
   const CustomKeyboardButton({
     super.key,
@@ -15,6 +16,7 @@ class CustomKeyboardButton extends StatelessWidget {
     required this.focusNode,
     String? displayText,
     this.afterInsert,
+    this.onTap,
   }) : displayText = displayText ?? keyboard;
 
   void insert() {
@@ -25,7 +27,7 @@ class CustomKeyboardButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => insert(),
+      onTap: onTap ?? insert,
       child: Padding(
         padding: const EdgeInsets.all(5),
         child: ConstrainedBox(

--- a/lib/view/common/note_create/custom_keyboard_button.dart
+++ b/lib/view/common/note_create/custom_keyboard_button.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:miria/extensions/text_editing_controller_extension.dart';
 
-class CustomKeyboard extends StatelessWidget {
+class CustomKeyboardButton extends StatelessWidget {
   final String keyboard;
   final String displayText;
   final String? afterInsert;
   final TextEditingController controller;
   final FocusNode focusNode;
 
-  const CustomKeyboard({
+  const CustomKeyboardButton({
     super.key,
     required this.keyboard,
     required this.controller,
@@ -29,14 +29,15 @@ class CustomKeyboard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(5),
         child: ConstrainedBox(
-            constraints: BoxConstraints(
-              minWidth: 32 * MediaQuery.of(context).textScaleFactor,
-              maxHeight: 32 * MediaQuery.of(context).textScaleFactor,
-            ),
-            child: Text(
-              keyboard,
-              textAlign: TextAlign.center,
-            )),
+          constraints: BoxConstraints(
+            minWidth: 32 * MediaQuery.of(context).textScaleFactor,
+            maxHeight: 32 * MediaQuery.of(context).textScaleFactor,
+          ),
+          child: Text(
+            keyboard,
+            textAlign: TextAlign.center,
+          ),
+        ),
       ),
     );
   }

--- a/lib/view/common/note_create/emoji_keyboard.dart
+++ b/lib/view/common/note_create/emoji_keyboard.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/extensions/text_editing_controller_extension.dart';
+import 'package:miria/model/account.dart';
+import 'package:miria/model/misskey_emoji_data.dart';
+import 'package:miria/providers.dart';
+import 'package:miria/view/common/misskey_notes/custom_emoji.dart';
+import 'package:miria/view/reaction_picker_dialog/reaction_picker_dialog.dart';
+
+final _filteredEmojisProvider = NotifierProvider.autoDispose.family<
+    _FilteredEmojis, List<MisskeyEmojiData>, (Account, TextEditingController)>(
+  _FilteredEmojis.new,
+);
+
+class _FilteredEmojis extends AutoDisposeFamilyNotifier<List<MisskeyEmojiData>,
+    (Account, TextEditingController)> {
+  @override
+  List<MisskeyEmojiData> build((Account, TextEditingController) arg) {
+    _controller.addListener(_updateEmojis);
+    ref.onDispose(() {
+      _controller.removeListener(_updateEmojis);
+    });
+    return ref.read(emojiRepositoryProvider(_account)).defaultEmojis();
+  }
+
+  Account get _account {
+    return arg.$1;
+  }
+
+  TextEditingController get _controller {
+    return arg.$2;
+  }
+
+  void _updateEmojis() async {
+    state = await ref
+        .read(emojiRepositoryProvider(_account))
+        .searchEmojis(_controller.emojiSearchValue);
+  }
+}
+
+class EmojiKeyboard extends ConsumerWidget {
+  const EmojiKeyboard({
+    super.key,
+    required this.account,
+    required this.controller,
+    required this.focusNode,
+  });
+
+  final Account account;
+  final TextEditingController controller;
+  final FocusNode focusNode;
+
+  void insertEmoji(MisskeyEmojiData emoji, WidgetRef ref) {
+    final currentPosition = controller.selection.base.offset;
+    final text = controller.text;
+
+    final beforeSearchText =
+        text.substring(0, text.substring(0, currentPosition).lastIndexOf(":"));
+
+    final after = (currentPosition == text.length || currentPosition == -1)
+        ? ""
+        : text.substring(currentPosition, text.length);
+
+    switch (emoji) {
+      case CustomEmojiData():
+        controller.value = TextEditingValue(
+          text: "$beforeSearchText:${emoji.baseName}:$after",
+          selection: TextSelection.collapsed(
+            offset: beforeSearchText.length + emoji.baseName.length + 2,
+          ),
+        );
+        break;
+      case UnicodeEmojiData():
+        controller.value = TextEditingValue(
+          text: "$beforeSearchText${emoji.char}$after",
+          selection: TextSelection.collapsed(offset: emoji.char.length),
+        );
+        break;
+      default:
+        return;
+    }
+    focusNode.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filteredEmojis =
+        ref.watch(_filteredEmojisProvider((account, controller)));
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        for (final emoji in filteredEmojis)
+          GestureDetector(
+            onTap: () => insertEmoji(emoji, ref),
+            child: Padding(
+              padding: const EdgeInsets.all(5),
+              child: SizedBox(
+                height: 32 * MediaQuery.of(context).textScaleFactor,
+                child: CustomEmoji(emojiData: emoji),
+              ),
+            ),
+          ),
+        TextButton.icon(
+          onPressed: () async {
+            final selected = await showDialog(
+              context: context,
+              builder: (context2) => ReactionPickerDialog(
+                account: account,
+                isAcceptSensitive: true,
+              ),
+            );
+            if (selected != null) {
+              insertEmoji(selected, ref);
+            }
+          },
+          icon: const Icon(Icons.add_reaction_outlined),
+          label: const Text("他のん"),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/common/note_create/emoji_keyboard.dart
+++ b/lib/view/common/note_create/emoji_keyboard.dart
@@ -73,7 +73,9 @@ class EmojiKeyboard extends ConsumerWidget {
       case UnicodeEmojiData():
         controller.value = TextEditingValue(
           text: "$beforeSearchText${emoji.char}$after",
-          selection: TextSelection.collapsed(offset: emoji.char.length),
+          selection: TextSelection.collapsed(
+            offset: beforeSearchText.length + emoji.char.length,
+          ),
         );
         break;
       default:

--- a/lib/view/common/note_create/hashtag_keyboard.dart
+++ b/lib/view/common/note_create/hashtag_keyboard.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/extensions/text_editing_controller_extension.dart';
+import 'package:miria/model/account.dart';
+import 'package:miria/model/input_completion_type.dart';
+import 'package:miria/providers.dart';
+import 'package:miria/view/common/note_create/basic_keyboard.dart';
+import 'package:miria/view/common/note_create/custom_keyboard_button.dart';
+import 'package:miria/view/common/note_create/input_completation.dart';
+import 'package:misskey_dart/misskey_dart.dart' hide Hashtag;
+
+final _hashtagsSearchProvider = AsyncNotifierProviderFamily<_HashtagsSearch,
+    List<String>, (String, String)>(_HashtagsSearch.new);
+
+class _HashtagsSearch
+    extends FamilyAsyncNotifier<List<String>, (String, String)> {
+  @override
+  Future<List<String>> build((String, String) arg) async {
+    final (host, query) = arg;
+    if (query.isEmpty) {
+      return [];
+    } else {
+      final response = await ref
+          .read(misskeyProvider(Account.demoAccount(host)))
+          .hashtags
+          .search(
+            HashtagsSearchRequest(
+              query: query,
+              limit: 30,
+            ),
+          );
+      return response.toList();
+    }
+  }
+}
+
+final _filteredHashtagsProvider = NotifierProvider.autoDispose
+    .family<_FilteredHashtags, List<String>, Account>(_FilteredHashtags.new);
+
+class _FilteredHashtags
+    extends AutoDisposeFamilyNotifier<List<String>, Account> {
+  @override
+  List<String> build(Account arg) {
+    ref.listen(
+      inputCompletionTypeProvider,
+      (_, type) {
+        _updateHashtags(type);
+      },
+      fireImmediately: true,
+    );
+    return [];
+  }
+
+  void _updateHashtags(InputCompletionType type) async {
+    if (type is Hashtag) {
+      final query = type.query;
+      if (query.isEmpty) {
+        final response = await ref.read(misskeyProvider(arg)).hashtags.trend();
+        state = response.map((hashtag) => hashtag.tag).toList();
+      } else {
+        state = await ref.read(
+          _hashtagsSearchProvider((arg.host, query)).future,
+        );
+      }
+    }
+  }
+}
+
+class HashtagKeyboard extends ConsumerWidget {
+  const HashtagKeyboard({
+    super.key,
+    required this.account,
+    required this.controller,
+    required this.focusNode,
+  });
+
+  final Account account;
+  final TextEditingController controller;
+  final FocusNode focusNode;
+
+  void insertHashtag(String hashtag) {
+    final textBeforeSelection = controller.textBeforeSelection;
+    final lastHashIndex = textBeforeSelection!.lastIndexOf("#");
+    final queryLength = textBeforeSelection.length - lastHashIndex - 1;
+    controller.insert("${hashtag.substring(queryLength)} ");
+    focusNode.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filteredHashtags = ref.watch(_filteredHashtagsProvider(account));
+
+    if (filteredHashtags.isEmpty) {
+      return BasicKeyboard(
+        controller: controller,
+        focusNode: focusNode,
+      );
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        for (final hashtag in filteredHashtags)
+          CustomKeyboardButton(
+            keyboard: hashtag,
+            controller: controller,
+            focusNode: focusNode,
+            onTap: () => insertHashtag(hashtag),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/view/common/note_create/input_completation.dart
+++ b/lib/view/common/note_create/input_completation.dart
@@ -3,18 +3,14 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/extensions/text_editing_controller_extension.dart';
+import 'package:miria/model/input_completion_type.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/note_create/basic_keyboard.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/view/common/note_create/emoji_keyboard.dart';
 
-enum InputCompletionType {
-  basic,
-  emoji,
-}
-
 final inputCompletionTypeProvider =
-    StateProvider.autoDispose((ref) => InputCompletionType.basic);
+    StateProvider.autoDispose<InputCompletionType>((ref) => Basic());
 
 final inputComplementDelayedProvider = Provider((ref) => 300);
 
@@ -57,18 +53,8 @@ class InputComplementState extends ConsumerState<InputComplement> {
   }
 
   void updateType() {
-    if (widget.controller.isIncludeBeforeColon) {
-      if (widget.controller.isEmojiScope) {
-        ref.read(inputCompletionTypeProvider.notifier).state =
-            InputCompletionType.basic;
-      } else {
-        ref.read(inputCompletionTypeProvider.notifier).state =
-            InputCompletionType.emoji;
-      }
-    } else {
-      ref.read(inputCompletionTypeProvider.notifier).state =
-          InputCompletionType.basic;
-    }
+    ref.read(inputCompletionTypeProvider.notifier).state =
+        widget.controller.inputCompletionType;
   }
 
   @override
@@ -112,11 +98,11 @@ class InputComplementState extends ConsumerState<InputComplement> {
                 constraints:
                     BoxConstraints(minWidth: MediaQuery.of(context).size.width),
                 child: switch (inputCompletionType) {
-                  InputCompletionType.basic => BasicKeyboard(
+                  Basic() => BasicKeyboard(
                       controller: widget.controller,
                       focusNode: focusNode,
                     ),
-                  InputCompletionType.emoji => EmojiKeyboard(
+                  Emoji() => EmojiKeyboard(
                       account: account,
                       controller: widget.controller,
                       focusNode: focusNode,

--- a/lib/view/common/note_create/input_completation.dart
+++ b/lib/view/common/note_create/input_completation.dart
@@ -8,6 +8,7 @@ import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/note_create/basic_keyboard.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/view/common/note_create/emoji_keyboard.dart';
+import 'package:miria/view/common/note_create/hashtag_keyboard.dart';
 import 'package:miria/view/common/note_create/mfm_fn_keyboard.dart';
 
 final inputCompletionTypeProvider =
@@ -109,6 +110,11 @@ class InputComplementState extends ConsumerState<InputComplement> {
                       focusNode: focusNode,
                     ),
                   MfmFn() => MfmFnKeyboard(
+                      controller: widget.controller,
+                      focusNode: focusNode,
+                    ),
+                  Hashtag() => HashtagKeyboard(
+                      account: account,
                       controller: widget.controller,
                       focusNode: focusNode,
                     ),

--- a/lib/view/common/note_create/input_completation.dart
+++ b/lib/view/common/note_create/input_completation.dart
@@ -8,6 +8,7 @@ import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/note_create/basic_keyboard.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/view/common/note_create/emoji_keyboard.dart';
+import 'package:miria/view/common/note_create/mfm_fn_keyboard.dart';
 
 final inputCompletionTypeProvider =
     StateProvider.autoDispose<InputCompletionType>((ref) => Basic());
@@ -104,6 +105,10 @@ class InputComplementState extends ConsumerState<InputComplement> {
                     ),
                   Emoji() => EmojiKeyboard(
                       account: account,
+                      controller: widget.controller,
+                      focusNode: focusNode,
+                    ),
+                  MfmFn() => MfmFnKeyboard(
                       controller: widget.controller,
                       focusNode: focusNode,
                     ),

--- a/lib/view/common/note_create/input_completation.dart
+++ b/lib/view/common/note_create/input_completation.dart
@@ -3,16 +3,19 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/extensions/text_editing_controller_extension.dart';
-import 'package:miria/model/misskey_emoji_data.dart';
-import 'package:miria/providers.dart';
 import 'package:miria/view/common/account_scope.dart';
-import 'package:miria/view/common/misskey_notes/custom_emoji.dart';
-import 'package:miria/view/common/note_create/custom_keyboard_list.dart';
+import 'package:miria/view/common/note_create/basic_keyboard.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:miria/view/reaction_picker_dialog/reaction_picker_dialog.dart';
+import 'package:miria/view/common/note_create/emoji_keyboard.dart';
 
-final inputComplementEmojiProvider =
-    StateProvider.autoDispose((ref) => <MisskeyEmojiData>[]);
+enum InputCompletionType {
+  basic,
+  emoji,
+}
+
+final inputCompletionTypeProvider =
+    StateProvider.autoDispose((ref) => InputCompletionType.basic);
+
 final inputComplementDelayedProvider = Provider((ref) => 300);
 
 class InputComplement extends ConsumerStatefulWidget {
@@ -32,65 +35,11 @@ class InputComplement extends ConsumerStatefulWidget {
 class InputComplementState extends ConsumerState<InputComplement> {
   bool isClose = true;
 
-  void insertEmoji(MisskeyEmojiData emoji, WidgetRef ref) {
-    final currentPosition = widget.controller.selection.base.offset;
-    final text = widget.controller.text;
-
-    final beforeSearchText =
-        text.substring(0, text.substring(0, currentPosition).lastIndexOf(":"));
-
-    final after = (currentPosition == text.length || currentPosition == -1)
-        ? ""
-        : text.substring(currentPosition, text.length);
-
-    switch (emoji) {
-      case CustomEmojiData():
-        widget.controller.value = TextEditingValue(
-            text: "$beforeSearchText:${emoji.baseName}:$after",
-            selection: TextSelection.collapsed(
-                offset: beforeSearchText.length + emoji.baseName.length + 2));
-        break;
-      case UnicodeEmojiData():
-        widget.controller.value = TextEditingValue(
-            text: "$beforeSearchText${emoji.char}$after",
-            selection: TextSelection.collapsed(offset: emoji.char.length));
-
-        break;
-      default:
-        return;
-    }
-
-    ref.read(inputComplementEmojiProvider.notifier).state = [];
-    ref.read(widget.focusNode).requestFocus();
-  }
-
   @override
   void initState() {
     super.initState();
 
-    widget.controller.addListener(() {
-      if (widget.controller.isIncludeBeforeColon) {
-        if (widget.controller.isEmojiScope) {
-          if (ref.read(inputComplementEmojiProvider).isNotEmpty) {
-            ref.read(inputComplementEmojiProvider.notifier).state = [];
-          }
-          return;
-        }
-
-        Future(() async {
-          final initialAccount = AccountScope.of(context);
-          final searchedEmojis = await (ref
-              .read(emojiRepositoryProvider(initialAccount))
-              .searchEmojis(widget.controller.emojiSearchValue));
-          ref.read(inputComplementEmojiProvider.notifier).state =
-              searchedEmojis;
-        });
-      } else {
-        if (ref.read(inputComplementEmojiProvider).isNotEmpty) {
-          ref.read(inputComplementEmojiProvider.notifier).state = [];
-        }
-      }
-    });
+    widget.controller.addListener(updateType);
   }
 
   @override
@@ -101,21 +50,44 @@ class InputComplementState extends ConsumerState<InputComplement> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final filteredInputEmoji = ref.watch(inputComplementEmojiProvider);
+  void dispose() {
+    widget.controller.removeListener(updateType);
 
-    ref.listen(widget.focusNode, (previous, next) {
+    super.dispose();
+  }
+
+  void updateType() {
+    if (widget.controller.isIncludeBeforeColon) {
+      if (widget.controller.isEmojiScope) {
+        ref.read(inputCompletionTypeProvider.notifier).state =
+            InputCompletionType.basic;
+      } else {
+        ref.read(inputCompletionTypeProvider.notifier).state =
+            InputCompletionType.emoji;
+      }
+    } else {
+      ref.read(inputCompletionTypeProvider.notifier).state =
+          InputCompletionType.basic;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final inputCompletionType = ref.watch(inputCompletionTypeProvider);
+    final focusNode = ref.watch(widget.focusNode);
+    final account = AccountScope.of(context);
+
+    ref.listen(widget.focusNode, (previous, next) async {
       if (!next.hasFocus) {
-        Future(() async {
-          await Future.delayed(
-              Duration(milliseconds: ref.read(inputComplementDelayedProvider)));
-          if (!mounted) return;
-          if (!ref.read(widget.focusNode).hasFocus) {
-            setState(() {
-              isClose = true;
-            });
-          }
-        });
+        await Future.delayed(
+          Duration(milliseconds: ref.read(inputComplementDelayedProvider)),
+        );
+        if (!mounted) return;
+        if (!ref.read(widget.focusNode).hasFocus) {
+          setState(() {
+            isClose = true;
+          });
+        }
       } else {
         setState(() {
           isClose = false;
@@ -139,43 +111,17 @@ class InputComplementState extends ConsumerState<InputComplement> {
               child: ConstrainedBox(
                 constraints:
                     BoxConstraints(minWidth: MediaQuery.of(context).size.width),
-                child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.max,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      if (filteredInputEmoji.isNotEmpty) ...[
-                        for (final emoji in filteredInputEmoji)
-                          GestureDetector(
-                            onTap: () => insertEmoji(emoji, ref),
-                            child: Padding(
-                              padding: const EdgeInsets.all(5),
-                              child: SizedBox(
-                                  height: 32 *
-                                      MediaQuery.of(context).textScaleFactor,
-                                  child: CustomEmoji(emojiData: emoji)),
-                            ),
-                          ),
-                        TextButton.icon(
-                            onPressed: () async {
-                              final selected = await showDialog(
-                                  context: context,
-                                  builder: (context2) => ReactionPickerDialog(
-                                        account: AccountScope.of(context),
-                                        isAcceptSensitive: true,
-                                      ));
-                              if (selected != null) {
-                                insertEmoji(selected, ref);
-                              }
-                            },
-                            icon: const Icon(Icons.add_reaction_outlined),
-                            label: const Text("他のん"))
-                      ] else
-                        CustomKeyboardList(
-                          controller: widget.controller,
-                          focusNode: ref.read(widget.focusNode),
-                        ),
-                    ]),
+                child: switch (inputCompletionType) {
+                  InputCompletionType.basic => BasicKeyboard(
+                      controller: widget.controller,
+                      focusNode: focusNode,
+                    ),
+                  InputCompletionType.emoji => EmojiKeyboard(
+                      account: account,
+                      controller: widget.controller,
+                      focusNode: focusNode,
+                    ),
+                },
               ),
             ),
           ),

--- a/lib/view/common/note_create/mfm_fn_keyboard.dart
+++ b/lib/view/common/note_create/mfm_fn_keyboard.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/extensions/text_editing_controller_extension.dart';
+import 'package:miria/model/input_completion_type.dart';
+import 'package:miria/view/common/note_create/basic_keyboard.dart';
+import 'package:miria/view/common/note_create/custom_keyboard_button.dart';
+import 'package:miria/view/common/note_create/input_completation.dart';
+
+const mfmFn = [
+  "tada",
+  "jelly",
+  "twitch",
+  "shake",
+  "spin",
+  "jump",
+  "bounce",
+  "flip",
+  "x2",
+  "x3",
+  "x4",
+  "scale",
+  "position",
+  "fg",
+  "bg",
+  "font",
+  "blur",
+  "rainbow",
+  // "sparkle",
+  "rotate",
+];
+
+final _filteredMfmFnProvider = Provider.autoDispose<List<String>>((ref) {
+  final type = ref.watch(inputCompletionTypeProvider);
+  if (type is MfmFn) {
+    return mfmFn.where((name) => name.startsWith(type.query)).toList();
+  } else {
+    return mfmFn;
+  }
+});
+
+class MfmFnKeyboard extends ConsumerWidget {
+  const MfmFnKeyboard({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+
+  void insertMfmFn(String mfmFn) {
+    final textBeforeSelection = controller.textBeforeSelection;
+    final lastOpenTagIndex = textBeforeSelection!.lastIndexOf(r"$[");
+    final queryLength = textBeforeSelection.length - lastOpenTagIndex - 2;
+    controller.insert("${mfmFn.substring(queryLength)} ");
+    focusNode.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filteredMfmFn = ref.watch(_filteredMfmFnProvider);
+
+    if (filteredMfmFn.isEmpty) {
+      return BasicKeyboard(
+        controller: controller,
+        focusNode: focusNode,
+      );
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        for (final mfmFn in filteredMfmFn)
+          CustomKeyboardButton(
+            keyboard: mfmFn,
+            controller: controller,
+            focusNode: focusNode,
+            onTap: () => insertMfmFn(mfmFn),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Resolve #308
Resolve #309

絵文字の入力補完を微修正しました

- `:` の後の文字列が絵文字にマッチしないとき、他のんを表示します
- Unicode絵文字を挿入したときのカーソルの位置を修正しました

MFMの関数名の入力補完を追加しました

- sparkle以外の関数名に対応しています
- `$[` の後の文字列が関数名にマッチしないとき、デフォルトの入力補完を表示します

ハッシュタグの入力補完を追加しました

- `hashtags/search` の返り値をキャッシュして表示します
- `#` の後に文字がないとき、`hashtags/trend` を表示します
  - 履歴を表示したほうがいいと思いますが面倒なのでしませんでした
    - Account周りを整理してからやるかもしれません
- `#` の後の文字列が関数名にマッチしないとき、デフォルトの入力補完を表示します

shiosyakeyakini-info/misskey_dart#18 に依存します
