### PR TITLE
リストの編集機能を追加

### DIFF
--- a/lib/extensions/users_lists_show_response_extension.dart
+++ b/lib/extensions/users_lists_show_response_extension.dart
@@ -1,0 +1,13 @@
+import 'package:misskey_dart/misskey_dart.dart';
+
+extension UsersListsShowResponseExtension on UsersListsShowResponse {
+  UsersList toUsersList() {
+    return UsersList(
+      id: id,
+      createdAt: createdAt,
+      name: name,
+      userIds: userIds,
+      isPublic: isPublic,
+    );
+  }
+}

--- a/lib/model/users_list_settings.dart
+++ b/lib/model/users_list_settings.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+part 'users_list_settings.freezed.dart';
+
+@freezed
+class UsersListSettings with _$UsersListSettings {
+  const factory UsersListSettings({
+    @Default("") String name,
+    @Default(false) bool isPublic,
+  }) = _UsersListSettings;
+  const UsersListSettings._();
+
+  factory UsersListSettings.fromUsersList(UsersList list) {
+    return UsersListSettings(
+      name: list.name ?? "",
+      isPublic: list.isPublic ?? false,
+    );
+  }
+}

--- a/lib/model/users_list_settings.freezed.dart
+++ b/lib/model/users_list_settings.freezed.dart
@@ -1,0 +1,155 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'users_list_settings.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$UsersListSettings {
+  String get name => throw _privateConstructorUsedError;
+  bool get isPublic => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $UsersListSettingsCopyWith<UsersListSettings> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UsersListSettingsCopyWith<$Res> {
+  factory $UsersListSettingsCopyWith(
+          UsersListSettings value, $Res Function(UsersListSettings) then) =
+      _$UsersListSettingsCopyWithImpl<$Res, UsersListSettings>;
+  @useResult
+  $Res call({String name, bool isPublic});
+}
+
+/// @nodoc
+class _$UsersListSettingsCopyWithImpl<$Res, $Val extends UsersListSettings>
+    implements $UsersListSettingsCopyWith<$Res> {
+  _$UsersListSettingsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? isPublic = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isPublic: null == isPublic
+          ? _value.isPublic
+          : isPublic // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_UsersListSettingsCopyWith<$Res>
+    implements $UsersListSettingsCopyWith<$Res> {
+  factory _$$_UsersListSettingsCopyWith(_$_UsersListSettings value,
+          $Res Function(_$_UsersListSettings) then) =
+      __$$_UsersListSettingsCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, bool isPublic});
+}
+
+/// @nodoc
+class __$$_UsersListSettingsCopyWithImpl<$Res>
+    extends _$UsersListSettingsCopyWithImpl<$Res, _$_UsersListSettings>
+    implements _$$_UsersListSettingsCopyWith<$Res> {
+  __$$_UsersListSettingsCopyWithImpl(
+      _$_UsersListSettings _value, $Res Function(_$_UsersListSettings) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? isPublic = null,
+  }) {
+    return _then(_$_UsersListSettings(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isPublic: null == isPublic
+          ? _value.isPublic
+          : isPublic // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_UsersListSettings extends _UsersListSettings {
+  const _$_UsersListSettings({this.name = "", this.isPublic = false})
+      : super._();
+
+  @override
+  @JsonKey()
+  final String name;
+  @override
+  @JsonKey()
+  final bool isPublic;
+
+  @override
+  String toString() {
+    return 'UsersListSettings(name: $name, isPublic: $isPublic)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_UsersListSettings &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isPublic, isPublic) ||
+                other.isPublic == isPublic));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name, isPublic);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_UsersListSettingsCopyWith<_$_UsersListSettings> get copyWith =>
+      __$$_UsersListSettingsCopyWithImpl<_$_UsersListSettings>(
+          this, _$identity);
+}
+
+abstract class _UsersListSettings extends UsersListSettings {
+  const factory _UsersListSettings({final String name, final bool isPublic}) =
+      _$_UsersListSettings;
+  const _UsersListSettings._() : super._();
+
+  @override
+  String get name;
+  @override
+  bool get isPublic;
+  @override
+  @JsonKey(ignore: true)
+  _$$_UsersListSettingsCopyWith<_$_UsersListSettings> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -36,6 +36,7 @@ import 'package:miria/view/time_line_page/time_line_page.dart';
 import 'package:miria/view/user_page/user_followee.dart';
 import 'package:miria/view/user_page/user_follower.dart';
 import 'package:miria/view/user_page/user_page.dart';
+import 'package:miria/view/users_list_page/users_list_detail_page.dart';
 import 'package:miria/view/users_list_page/users_list_page.dart';
 import 'package:miria/view/users_list_page/users_list_timeline_page.dart';
 import 'package:miria/view/splash_page/splash_page.dart';
@@ -66,6 +67,7 @@ class AppRouter extends _$AppRouter {
     AutoRoute(page: AntennaNotesRoute.page),
     AutoRoute(page: UsersListRoute.page),
     AutoRoute(page: UsersListTimelineRoute.page),
+    AutoRoute(page: UsersListDetailRoute.page),
     AutoRoute(page: NotificationRoute.page),
     AutoRoute(page: FavoritedNoteRoute.page),
     AutoRoute(page: ClipListRoute.page),

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -398,6 +398,17 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    UsersListDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListDetailRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UsersListDetailPage(
+          key: args.key,
+          account: args.account,
+          listId: args.listId,
+        ),
+      );
+    },
   };
 }
 
@@ -1804,5 +1815,48 @@ class TimeLineRouteArgs {
   @override
   String toString() {
     return 'TimeLineRouteArgs{key: $key, initialTabSetting: $initialTabSetting}';
+  }
+}
+
+/// generated route for
+/// [UsersListDetailPage]
+class UsersListDetailRoute extends PageRouteInfo<UsersListDetailRouteArgs> {
+  UsersListDetailRoute({
+    Key? key,
+    required Account account,
+    required String listId,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UsersListDetailRoute.name,
+          args: UsersListDetailRouteArgs(
+            key: key,
+            account: account,
+            listId: listId,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UsersListDetailRoute';
+
+  static const PageInfo<UsersListDetailRouteArgs> page =
+      PageInfo<UsersListDetailRouteArgs>(name);
+}
+
+class UsersListDetailRouteArgs {
+  const UsersListDetailRouteArgs({
+    this.key,
+    required this.account,
+    required this.listId,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String listId;
+
+  @override
+  String toString() {
+    return 'UsersListDetailRouteArgs{key: $key, account: $account, listId: $listId}';
   }
 }

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -350,7 +350,7 @@ abstract class _$AppRouter extends RootStackRouter {
         routeData: routeData,
         child: UsersListTimelinePage(
           args.account,
-          args.listId,
+          args.list,
           key: args.key,
         ),
       );
@@ -1603,14 +1603,14 @@ class UsersListRouteArgs {
 class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
   UsersListTimelineRoute({
     required Account account,
-    required String listId,
+    required UsersList list,
     Key? key,
     List<PageRouteInfo>? children,
   }) : super(
           UsersListTimelineRoute.name,
           args: UsersListTimelineRouteArgs(
             account: account,
-            listId: listId,
+            list: list,
             key: key,
           ),
           initialChildren: children,
@@ -1625,19 +1625,19 @@ class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
 class UsersListTimelineRouteArgs {
   const UsersListTimelineRouteArgs({
     required this.account,
-    required this.listId,
+    required this.list,
     this.key,
   });
 
   final Account account;
 
-  final String listId;
+  final UsersList list;
 
   final Key? key;
 
   @override
   String toString() {
-    return 'UsersListTimelineRouteArgs{account: $account, listId: $listId, key: $key}';
+    return 'UsersListTimelineRouteArgs{account: $account, list: $list, key: $key}';
   }
 }
 

--- a/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
+import 'package:miria/extensions/users_lists_show_response_extension.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/model/tab_icon.dart';
 import 'package:miria/model/tab_setting.dart';
@@ -77,11 +78,12 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
       }
       if (listId != null) {
         Future(() async {
-          selectedUserList = await ref
+          final response = await ref
               .read(misskeyProvider(tabSetting.account))
               .users
               .list
               .show(UsersListsShowRequest(listId: listId));
+          selectedUserList = response.toUsersList();
           setState(() {});
         });
       }

--- a/lib/view/time_line_page/time_line_page.dart
+++ b/lib/view/time_line_page/time_line_page.dart
@@ -250,6 +250,18 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                       },
                       icon: const Icon(Icons.info_outline),
                     )
+                  else if (currentTabSetting.tabType == TabType.userList)
+                    IconButton(
+                      icon: const Icon(Icons.info_outline),
+                      onPressed: () {
+                        context.pushRoute(
+                          UsersListDetailRoute(
+                            account: currentTabSetting.account,
+                            listId: currentTabSetting.listId!,
+                          ),
+                        );
+                      },
+                    )
                   else if ([
                     TabType.hybridTimeline,
                     TabType.localTimeline,

--- a/lib/view/users_list_page/users_list_detail_page.dart
+++ b/lib/view/users_list_page/users_list_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
+import 'package:miria/model/users_list_settings.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/error_detail.dart';
@@ -9,6 +10,7 @@ import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
 import 'package:miria/view/user_page/user_list_item.dart';
 import 'package:miria/view/user_select_dialog.dart';
+import 'package:miria/view/users_list_page/users_list_settings_dialog.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 final _usersListNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
@@ -26,6 +28,25 @@ class _UsersListNotifier
   Misskey get _misskey => arg.$1;
 
   String get _listId => arg.$2;
+
+  Future<void> updateList(UsersListSettings settings) async {
+    await _misskey.users.list.update(
+      UsersListsUpdateRequest(
+        listId: _listId,
+        name: settings.name,
+        isPublic: settings.isPublic,
+      ),
+    );
+    final list = state.valueOrNull;
+    if (list != null) {
+      state = AsyncValue.data(
+        list.copyWith(
+          name: settings.name,
+          isPublic: settings.isPublic,
+        ),
+      );
+    }
+  }
 }
 
 final _usersListUsersProvider = AutoDisposeAsyncNotifierProviderFamily<
@@ -92,8 +113,32 @@ class UsersListDetailPage extends ConsumerWidget {
     final users = ref.watch(_usersListUsersProvider(arg));
 
     return Scaffold(
-      appBar: AppBar(
-        title: list.whenOrNull(data: (list) => Text(list.name ?? "")),
+      appBar: list.maybeWhen(
+        data: (list) => AppBar(
+          title: Text(list.name ?? ""),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.settings),
+              onPressed: () async {
+                final settings = await showDialog<UsersListSettings>(
+                  context: context,
+                  builder: (context) => UsersListSettingsDialog(
+                    title: const Text("編集"),
+                    initialSettings: UsersListSettings.fromUsersList(list),
+                  ),
+                );
+                if (!context.mounted) return;
+                if (settings != null) {
+                  ref
+                      .read(_usersListNotifierProvider(arg).notifier)
+                      .updateList(settings)
+                      .expectFailure(context);
+                }
+              },
+            ),
+          ],
+        ),
+        orElse: () => AppBar(),
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10),

--- a/lib/view/users_list_page/users_list_detail_page.dart
+++ b/lib/view/users_list_page/users_list_detail_page.dart
@@ -1,0 +1,177 @@
+import 'package:auto_route/annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/model/account.dart';
+import 'package:miria/providers.dart';
+import 'package:miria/view/common/account_scope.dart';
+import 'package:miria/view/common/error_detail.dart';
+import 'package:miria/view/common/error_dialog_handler.dart';
+import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
+import 'package:miria/view/user_page/user_list_item.dart';
+import 'package:miria/view/user_select_dialog.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+final _usersListNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
+    _UsersListNotifier, UsersList, (Misskey, String)>(_UsersListNotifier.new);
+
+class _UsersListNotifier
+    extends AutoDisposeFamilyAsyncNotifier<UsersList, (Misskey, String)> {
+  @override
+  Future<UsersList> build((Misskey, String) arg) {
+    return _misskey.users.list.show(
+      UsersListsShowRequest(listId: _listId),
+    );
+  }
+
+  Misskey get _misskey => arg.$1;
+
+  String get _listId => arg.$2;
+}
+
+final _usersListUsersProvider = AutoDisposeAsyncNotifierProviderFamily<
+    _UsersListUsers, List<User>, (Misskey, String)>(
+  _UsersListUsers.new,
+);
+
+class _UsersListUsers
+    extends AutoDisposeFamilyAsyncNotifier<List<User>, (Misskey, String)> {
+  @override
+  Future<List<User>> build((Misskey, String) arg) async {
+    final list = await ref.watch(_usersListNotifierProvider(arg).future);
+    final response = await _misskey.users.showByIds(
+      UsersShowByIdsRequest(
+        userIds: list.userIds,
+      ),
+    );
+    return response.map((e) => e.toUser()).toList();
+  }
+
+  Misskey get _misskey => arg.$1;
+
+  String get _listId => arg.$2;
+
+  Future<void> push(User user) async {
+    await _misskey.users.list.push(
+      UsersListsPushRequest(
+        listId: _listId,
+        userId: user.id,
+      ),
+    );
+    state = AsyncValue.data([...?state.valueOrNull, user]);
+  }
+
+  Future<void> pull(User user) async {
+    await _misskey.users.list.pull(
+      UsersListsPullRequest(
+        listId: _listId,
+        userId: user.id,
+      ),
+    );
+    state = AsyncValue.data(
+      state.valueOrNull?.where((e) => e.id != user.id).toList() ?? [],
+    );
+  }
+}
+
+@RoutePage()
+class UsersListDetailPage extends ConsumerWidget {
+  const UsersListDetailPage({
+    super.key,
+    required this.account,
+    required this.listId,
+  });
+
+  final Account account;
+  final String listId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final misskey = ref.watch(misskeyProvider(account));
+    final arg = (misskey, listId);
+    final list = ref.watch(_usersListNotifierProvider(arg));
+    final users = ref.watch(_usersListUsersProvider(arg));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: list.whenOrNull(data: (list) => Text(list.name ?? "")),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        child: users.when(
+          data: (users) {
+            return AccountScope(
+              account: account,
+              child: Column(
+                children: [
+                  ListTile(
+                    title: const Text("メンバー"),
+                    subtitle: Text(
+                      "${users.length}/${account.i.policies.userEachUserListsLimit} 人",
+                    ),
+                    trailing: ElevatedButton(
+                      child: const Text("ユーザーを追加"),
+                      onPressed: () async {
+                        final user = await showDialog<User>(
+                          context: context,
+                          builder: (context) =>
+                              UserSelectDialog(account: account),
+                        );
+                        if (user == null) {
+                          return;
+                        }
+                        if (!context.mounted) return;
+                        await ref
+                            .read(_usersListUsersProvider(arg).notifier)
+                            .push(user)
+                            .expectFailure(context);
+                      },
+                    ),
+                  ),
+                  const Divider(),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: users.length,
+                      itemBuilder: (context, index) {
+                        final user = users[index];
+                        return Row(
+                          children: [
+                            Expanded(
+                              child: UserListItem(user: user),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.close),
+                              onPressed: () async {
+                                final result = await SimpleConfirmDialog.show(
+                                  context: context,
+                                  message: "このユーザーをリストから外しますか？",
+                                  primary: "外す",
+                                  secondary: "やめる",
+                                );
+                                if (!context.mounted) return;
+                                if (result ?? false) {
+                                  await ref
+                                      .read(
+                                        _usersListUsersProvider(arg).notifier,
+                                      )
+                                      .pull(user)
+                                      .expectFailure(context);
+                                }
+                              },
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+          error: (e, st) =>
+              Center(child: ErrorDetail(error: e, stackTrace: st)),
+          loading: () => const Center(child: CircularProgressIndicator()),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/users_list_page/users_list_detail_page.dart
+++ b/lib/view/users_list_page/users_list_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/extensions/users_lists_show_response_extension.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/model/users_list_settings.dart';
 import 'package:miria/providers.dart';
@@ -19,10 +20,11 @@ final _usersListNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
 class _UsersListNotifier
     extends AutoDisposeFamilyAsyncNotifier<UsersList, (Misskey, String)> {
   @override
-  Future<UsersList> build((Misskey, String) arg) {
-    return _misskey.users.list.show(
+  Future<UsersList> build((Misskey, String) arg) async {
+    final response = await _misskey.users.list.show(
       UsersListsShowRequest(listId: _listId),
     );
+    return response.toUsersList();
   }
 
   Misskey get _misskey => arg.$1;

--- a/lib/view/users_list_page/users_list_page.dart
+++ b/lib/view/users_list_page/users_list_page.dart
@@ -15,17 +15,22 @@ class UsersListPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-        appBar: AppBar(title: const Text("リスト")),
-        body: Padding(
-            padding: const EdgeInsets.only(left: 10, right: 10),
-            child: FutureListView(
-              future: ref.read(misskeyProvider(account)).users.list.list(),
-              builder: (context, item) => ListTile(
-                  onTap: () => context.pushRoute(
-                        UsersListTimelineRoute(
-                            account: account, listId: item.id),
-                      ),
-                  title: Text(item.name ?? "")),
-            )));
+      appBar: AppBar(title: const Text("リスト")),
+      body: Padding(
+        padding: const EdgeInsets.only(left: 10, right: 10),
+        child: FutureListView(
+          future: ref.read(misskeyProvider(account)).users.list.list(),
+          builder: (context, item) => ListTile(
+            onTap: () => context.pushRoute(
+              UsersListTimelineRoute(
+                account: account,
+                list: item,
+              ),
+            ),
+            title: Text(item.name ?? ""),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/view/users_list_page/users_list_page.dart
+++ b/lib/view/users_list_page/users_list_page.dart
@@ -1,10 +1,55 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
+import 'package:miria/model/users_list_settings.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
-import 'package:miria/view/common/futable_list_builder.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/view/common/error_detail.dart';
+import 'package:miria/view/common/error_dialog_handler.dart';
+import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
+import 'package:miria/view/users_list_page/users_list_settings_dialog.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+final _usersListListNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
+    _UsersListListNotifier,
+    List<UsersList>,
+    Misskey>(_UsersListListNotifier.new);
+
+class _UsersListListNotifier
+    extends AutoDisposeFamilyAsyncNotifier<List<UsersList>, Misskey> {
+  @override
+  Future<List<UsersList>> build(Misskey arg) async {
+    final response = await _misskey.users.list.list();
+    return response.toList();
+  }
+
+  Misskey get _misskey => arg;
+
+  Future<void> create(UsersListSettings settings) async {
+    final list = await _misskey.users.list.create(
+      UsersListsCreateRequest(
+        name: settings.name,
+      ),
+    );
+    if (settings.isPublic) {
+      await _misskey.users.list.update(
+        UsersListsUpdateRequest(
+          listId: list.id,
+          isPublic: settings.isPublic,
+        ),
+      );
+    }
+    state = AsyncValue.data([...?state.valueOrNull, list]);
+  }
+
+  Future<void> delete(String listId) async {
+    await _misskey.users.list.delete(UsersListsDeleteRequest(listId: listId));
+    state = AsyncValue.data(
+      state.valueOrNull?.where((e) => e.id != listId).toList() ?? [],
+    );
+  }
+}
 
 @RoutePage()
 class UsersListPage extends ConsumerWidget {
@@ -14,21 +59,76 @@ class UsersListPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final misskey = ref.watch(misskeyProvider(account));
+    final list = ref.watch(_usersListListNotifierProvider(misskey));
+
     return Scaffold(
-      appBar: AppBar(title: const Text("リスト")),
-      body: Padding(
-        padding: const EdgeInsets.only(left: 10, right: 10),
-        child: FutureListView(
-          future: ref.read(misskeyProvider(account)).users.list.list(),
-          builder: (context, item) => ListTile(
-            onTap: () => context.pushRoute(
-              UsersListTimelineRoute(
-                account: account,
-                list: item,
-              ),
-            ),
-            title: Text(item.name ?? ""),
+      appBar: AppBar(
+        title: const Text("リスト"),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () async {
+              final settings = await showDialog<UsersListSettings>(
+                context: context,
+                builder: (context) => const UsersListSettingsDialog(
+                  title: Text("作成"),
+                ),
+              );
+              if (!context.mounted) return;
+              if (settings != null) {
+                ref
+                    .read(_usersListListNotifierProvider(misskey).notifier)
+                    .create(settings)
+                    .expectFailure(context);
+              }
+            },
           ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        child: list.when(
+          data: (data) {
+            return ListView.builder(
+              itemCount: data.length,
+              itemBuilder: (context, index) {
+                final list = data[index];
+                return ListTile(
+                  title: Text(list.name ?? ""),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () async {
+                      final result = await SimpleConfirmDialog.show(
+                        context: context,
+                        message: "このリストを削除しますか？",
+                        primary: "削除する",
+                        secondary: "やめる",
+                      );
+                      if (!context.mounted) return;
+                      if (result ?? false) {
+                        await ref
+                            .read(
+                              _usersListListNotifierProvider(misskey).notifier,
+                            )
+                            .delete(list.id)
+                            .expectFailure(context);
+                      }
+                    },
+                  ),
+                  onTap: () => context.pushRoute(
+                    UsersListTimelineRoute(
+                      account: account,
+                      list: list,
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+          error: (e, st) =>
+              Center(child: ErrorDetail(error: e, stackTrace: st)),
+          loading: () => const Center(child: CircularProgressIndicator()),
         ),
       ),
     );

--- a/lib/view/users_list_page/users_list_settings_dialog.dart
+++ b/lib/view/users_list_page/users_list_settings_dialog.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/model/users_list_settings.dart';
+
+final _formKeyProvider = Provider.autoDispose((ref) => GlobalKey<FormState>());
+
+final _initialSettingsProvider = Provider.autoDispose<UsersListSettings>(
+  (ref) => throw UnimplementedError(),
+);
+
+final _usersListSettingsNotifierProvider =
+    NotifierProvider.autoDispose<_UsersListSettingsNotifier, UsersListSettings>(
+  _UsersListSettingsNotifier.new,
+  dependencies: [_initialSettingsProvider],
+);
+
+class _UsersListSettingsNotifier
+    extends AutoDisposeNotifier<UsersListSettings> {
+  @override
+  UsersListSettings build() {
+    return ref.watch(_initialSettingsProvider);
+  }
+
+  void updateName(String? name) {
+    if (name != null) {
+      state = state.copyWith(name: name);
+    }
+  }
+
+  void updateIsPublic(bool? isPublic) {
+    if (isPublic != null) {
+      state = state.copyWith(isPublic: isPublic);
+    }
+  }
+}
+
+class UsersListSettingsDialog extends StatelessWidget {
+  const UsersListSettingsDialog({
+    super.key,
+    this.title,
+    this.initialSettings = const UsersListSettings(),
+  });
+
+  final Widget? title;
+  final UsersListSettings initialSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: title,
+      content: ProviderScope(
+        overrides: [
+          _initialSettingsProvider.overrideWithValue(initialSettings),
+        ],
+        child: const UsersListSettingsForm(),
+      ),
+    );
+  }
+}
+
+class UsersListSettingsForm extends ConsumerWidget {
+  const UsersListSettingsForm({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = ref.watch(_formKeyProvider);
+    final initialSettings = ref.watch(_initialSettingsProvider);
+    final settings = ref.watch(_usersListSettingsNotifierProvider);
+
+    return Form(
+      key: formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextFormField(
+            initialValue: initialSettings.name,
+            maxLength: 100,
+            decoration: const InputDecoration(
+              labelText: "リスト名",
+              contentPadding: EdgeInsets.fromLTRB(12, 24, 12, 16),
+            ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return "入力してください";
+              }
+              return null;
+            },
+            onSaved: ref
+                .read(_usersListSettingsNotifierProvider.notifier)
+                .updateName,
+          ),
+          CheckboxListTile(
+            title: const Text("パブリック"),
+            value: settings.isPublic,
+            onChanged: ref
+                .read(_usersListSettingsNotifierProvider.notifier)
+                .updateIsPublic,
+          ),
+          ElevatedButton(
+            child: const Text("決定"),
+            onPressed: () {
+              if (formKey.currentState!.validate()) {
+                formKey.currentState!.save();
+                final settings = ref.read(_usersListSettingsNotifierProvider);
+                if (settings == initialSettings) {
+                  Navigator.of(context).pop();
+                } else {
+                  Navigator.of(context).pop(settings);
+                }
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/users_list_page/users_list_timeline_page.dart
+++ b/lib/view/users_list_page/users_list_timeline_page.dart
@@ -1,27 +1,29 @@
 import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/users_list_page/users_list_timeline.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:misskey_dart/misskey_dart.dart';
 
 @RoutePage()
 class UsersListTimelinePage extends ConsumerWidget {
   final Account account;
-  final String listId;
+  final UsersList list;
 
-  const UsersListTimelinePage(this.account, this.listId, {super.key});
+  const UsersListTimelinePage(this.account, this.list, {super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(),
       body: AccountScope(
-          account: account,
-          child: Padding(
-            padding: const EdgeInsets.only(left: 10, right: 10),
-            child: UsersListTimeline(listId: listId),
-          )),
+        account: account,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 10, right: 10),
+          child: UsersListTimeline(listId: list.id),
+        ),
+      ),
     );
   }
 }

--- a/lib/view/users_list_page/users_list_timeline_page.dart
+++ b/lib/view/users_list_page/users_list_timeline_page.dart
@@ -16,7 +16,9 @@ class UsersListTimelinePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(),
+      appBar: AppBar(
+        title: Text(list.name ?? ""),
+      ),
       body: AccountScope(
         account: account,
         child: Padding(

--- a/lib/view/users_list_page/users_list_timeline_page.dart
+++ b/lib/view/users_list_page/users_list_timeline_page.dart
@@ -1,7 +1,8 @@
-import 'package:auto_route/annotations.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
+import 'package:miria/router/app_router.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/users_list_page/users_list_timeline.dart';
 import 'package:misskey_dart/misskey_dart.dart';
@@ -18,6 +19,17 @@ class UsersListTimelinePage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(list.name ?? ""),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () => context.pushRoute(
+              UsersListDetailRoute(
+                account: account,
+                listId: list.id,
+              ),
+            ),
+          ),
+        ],
       ),
       body: AccountScope(
         account: account,

--- a/test/test_util/mock.mocks.dart
+++ b/test/test_util/mock.mocks.dart
@@ -1675,6 +1675,71 @@ class MockMisskey extends _i1.Mock implements _i6.Misskey {
         ),
       ) as _i6.SocketController);
   @override
+  _i6.SocketController roleTimelineStream({
+    required String? roleId,
+    _i16.FutureOr<void> Function(_i6.Note)? onNoteReceived,
+    _i16.FutureOr<void> Function(
+      String,
+      _i6.TimelineReacted,
+    )? onReacted,
+    _i16.FutureOr<void> Function(
+      String,
+      _i6.TimelineReacted,
+    )? onUnreacted,
+    _i16.FutureOr<void> Function(
+      String,
+      DateTime,
+    )? onDeleted,
+    _i16.FutureOr<void> Function(
+      String,
+      _i6.TimelineVoted,
+    )? onVoted,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #roleTimelineStream,
+          [],
+          {
+            #roleId: roleId,
+            #onNoteReceived: onNoteReceived,
+            #onReacted: onReacted,
+            #onUnreacted: onUnreacted,
+            #onDeleted: onDeleted,
+            #onVoted: onVoted,
+          },
+        ),
+        returnValue: _FakeSocketController_26(
+          this,
+          Invocation.method(
+            #roleTimelineStream,
+            [],
+            {
+              #roleId: roleId,
+              #onNoteReceived: onNoteReceived,
+              #onReacted: onReacted,
+              #onUnreacted: onUnreacted,
+              #onDeleted: onDeleted,
+              #onVoted: onVoted,
+            },
+          ),
+        ),
+        returnValueForMissingStub: _FakeSocketController_26(
+          this,
+          Invocation.method(
+            #roleTimelineStream,
+            [],
+            {
+              #roleId: roleId,
+              #onNoteReceived: onNoteReceived,
+              #onReacted: onReacted,
+              #onUnreacted: onUnreacted,
+              #onDeleted: onDeleted,
+              #onVoted: onVoted,
+            },
+          ),
+        ),
+      ) as _i6.SocketController);
+  @override
   _i6.SocketController channelStream({
     required String? channelId,
     _i16.FutureOr<void> Function(_i6.Note)? onNoteReceived,


### PR DESCRIPTION
リストを編集できるようにしました
以下の機能に対応しています

- メンバーの追加、削除
- 名前、パブリックの変更
- リストの追加、削除

公開リストからのリストの作成はユーザー詳細画面で行うべきだと思うので対応していません

shiosyakeyakini-info/misskey_dart#19 がマージされるまでユーザーの名前の代わりにユーザーネームが表示されます

shiosyakeyakini-info/misskey_dart#20 に依存します

Related to #17