### PR TITLE
チェックボックスにチェックが入っていないときの色を背景色に

### DIFF
--- a/lib/view/themes/app_theme_scope.dart
+++ b/lib/view/themes/app_theme_scope.dart
@@ -106,7 +106,7 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
           fontFamilyFallback: ["Segoe UI Emoji", "Noto Color Emoji", "Meiryo"]);
     }
     if (defaultTargetPlatform == TargetPlatform.android ||
-       defaultTargetPlatform == TargetPlatform.linux) {
+        defaultTargetPlatform == TargetPlatform.linux) {
       return const TextStyle(
           fontFamily: "Noto Color Emoji",
           fontFamilyFallback: ["Noto Color Emoji", "Noto Sans JP"]);
@@ -222,8 +222,19 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
         suffixIconColor: theme.primary,
         isDense: true,
       ),
-      checkboxTheme:
-          CheckboxThemeData(fillColor: MaterialStatePropertyAll(theme.primary)),
+      checkboxTheme: CheckboxThemeData(
+        fillColor: MaterialStateProperty.resolveWith(
+          (states) {
+            if (states.contains(MaterialState.disabled)) {
+              return null;
+            }
+            if (states.contains(MaterialState.selected)) {
+              return theme.primary;
+            }
+            return null;
+          },
+        ),
+      ),
       expansionTileTheme: ExpansionTileThemeData(iconColor: theme.primary),
       toggleButtonsTheme: ToggleButtonsThemeData(
         color: theme.primary,


### PR DESCRIPTION
現在、CheckboxのfillColorにはチェックが入っているかどうかにかかわらずプライマリカラーが使われています
この変更によってチェックが入っていない場合は背景色が使われるようになり、視認性が向上します

デフォルトの設定に従って変更しました

https://github.com/flutter/flutter/blob/367203b3011fc1752cfa1f51adf9751d090c94e6/packages/flutter/lib/src/material/checkbox.dart#L449-L459