### PR TITLE
TabSettingからAccountを削除

### DIFF
--- a/lib/model/account.dart
+++ b/lib/model/account.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:miria/model/acct.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 part 'account.freezed.dart';
@@ -28,6 +29,13 @@ class Account with _$Account {
 
   @override
   int get hashCode => Object.hash(runtimeType, host, userId);
+
+  Acct get acct {
+    return Acct(
+      host: host,
+      username: userId,
+    );
+  }
 
   factory Account.demoAccount(String host) => Account(
       host: host,

--- a/lib/model/account_settings.dart
+++ b/lib/model/account_settings.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:miria/model/acct.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 part 'account_settings.freezed.dart';
@@ -6,6 +7,8 @@ part 'account_settings.g.dart';
 
 @freezed
 class AccountSettings with _$AccountSettings {
+  const AccountSettings._();
+
   const factory AccountSettings({
     required String userId,
     required String host,
@@ -17,4 +20,11 @@ class AccountSettings with _$AccountSettings {
 
   factory AccountSettings.fromJson(Map<String, dynamic> json) =>
       _$AccountSettingsFromJson(json);
+
+  Acct get acct {
+    return Acct(
+      host: host,
+      username: userId,
+    );
+  }
 }

--- a/lib/model/account_settings.freezed.dart
+++ b/lib/model/account_settings.freezed.dart
@@ -165,7 +165,7 @@ class __$$_AccountSettingsCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_AccountSettings implements _AccountSettings {
+class _$_AccountSettings extends _AccountSettings {
   const _$_AccountSettings(
       {required this.userId,
       required this.host,
@@ -173,7 +173,8 @@ class _$_AccountSettings implements _AccountSettings {
       this.defaultNoteVisibility = NoteVisibility.public,
       this.defaultIsLocalOnly = false,
       this.defaultReactionAcceptance = null})
-      : _reactions = reactions;
+      : _reactions = reactions,
+        super._();
 
   factory _$_AccountSettings.fromJson(Map<String, dynamic> json) =>
       _$$_AccountSettingsFromJson(json);
@@ -249,7 +250,7 @@ class _$_AccountSettings implements _AccountSettings {
   }
 }
 
-abstract class _AccountSettings implements AccountSettings {
+abstract class _AccountSettings extends AccountSettings {
   const factory _AccountSettings(
           {required final String userId,
           required final String host,
@@ -258,6 +259,7 @@ abstract class _AccountSettings implements AccountSettings {
           final bool defaultIsLocalOnly,
           final ReactionAcceptance? defaultReactionAcceptance}) =
       _$_AccountSettings;
+  const _AccountSettings._() : super._();
 
   factory _AccountSettings.fromJson(Map<String, dynamic> json) =
       _$_AccountSettings.fromJson;

--- a/lib/model/acct.dart
+++ b/lib/model/acct.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'acct.freezed.dart';
+part 'acct.g.dart';
+
+@freezed
+class Acct with _$Acct {
+  const factory Acct({
+    required String host,
+    required String username,
+  }) = _Acct;
+  const Acct._();
+
+  factory Acct.fromJson(Map<String, Object?> json) => _$AcctFromJson(json);
+
+  @override
+  String toString() {
+    return "@$username@$host";
+  }
+}

--- a/lib/model/acct.freezed.dart
+++ b/lib/model/acct.freezed.dart
@@ -1,0 +1,156 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'acct.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Acct _$AcctFromJson(Map<String, dynamic> json) {
+  return _Acct.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Acct {
+  String get host => throw _privateConstructorUsedError;
+  String get username => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $AcctCopyWith<Acct> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AcctCopyWith<$Res> {
+  factory $AcctCopyWith(Acct value, $Res Function(Acct) then) =
+      _$AcctCopyWithImpl<$Res, Acct>;
+  @useResult
+  $Res call({String host, String username});
+}
+
+/// @nodoc
+class _$AcctCopyWithImpl<$Res, $Val extends Acct>
+    implements $AcctCopyWith<$Res> {
+  _$AcctCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? host = null,
+    Object? username = null,
+  }) {
+    return _then(_value.copyWith(
+      host: null == host
+          ? _value.host
+          : host // ignore: cast_nullable_to_non_nullable
+              as String,
+      username: null == username
+          ? _value.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_AcctCopyWith<$Res> implements $AcctCopyWith<$Res> {
+  factory _$$_AcctCopyWith(_$_Acct value, $Res Function(_$_Acct) then) =
+      __$$_AcctCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String host, String username});
+}
+
+/// @nodoc
+class __$$_AcctCopyWithImpl<$Res> extends _$AcctCopyWithImpl<$Res, _$_Acct>
+    implements _$$_AcctCopyWith<$Res> {
+  __$$_AcctCopyWithImpl(_$_Acct _value, $Res Function(_$_Acct) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? host = null,
+    Object? username = null,
+  }) {
+    return _then(_$_Acct(
+      host: null == host
+          ? _value.host
+          : host // ignore: cast_nullable_to_non_nullable
+              as String,
+      username: null == username
+          ? _value.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Acct extends _Acct {
+  const _$_Acct({required this.host, required this.username}) : super._();
+
+  factory _$_Acct.fromJson(Map<String, dynamic> json) => _$$_AcctFromJson(json);
+
+  @override
+  final String host;
+  @override
+  final String username;
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Acct &&
+            (identical(other.host, host) || other.host == host) &&
+            (identical(other.username, username) ||
+                other.username == username));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, host, username);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_AcctCopyWith<_$_Acct> get copyWith =>
+      __$$_AcctCopyWithImpl<_$_Acct>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_AcctToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Acct extends Acct {
+  const factory _Acct(
+      {required final String host, required final String username}) = _$_Acct;
+  const _Acct._() : super._();
+
+  factory _Acct.fromJson(Map<String, dynamic> json) = _$_Acct.fromJson;
+
+  @override
+  String get host;
+  @override
+  String get username;
+  @override
+  @JsonKey(ignore: true)
+  _$$_AcctCopyWith<_$_Acct> get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/model/acct.g.dart
+++ b/lib/model/acct.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'acct.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Acct _$$_AcctFromJson(Map<String, dynamic> json) => _$_Acct(
+      host: json['host'] as String,
+      username: json['username'] as String,
+    );
+
+Map<String, dynamic> _$$_AcctToJson(_$_Acct instance) => <String, dynamic>{
+      'host': instance.host,
+      'username': instance.username,
+    };

--- a/lib/model/tab_setting.dart
+++ b/lib/model/tab_setting.dart
@@ -1,13 +1,24 @@
-import 'package:miria/model/account.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:miria/model/acct.dart';
 import 'package:miria/model/converters/icon_converter.dart';
 import 'package:miria/model/tab_icon.dart';
 import 'package:miria/model/tab_type.dart';
 import 'package:miria/repository/time_line_repository.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'tab_setting.freezed.dart';
 part 'tab_setting.g.dart';
+
+Map<String, dynamic> _readAcct(Map<dynamic, dynamic> json, String name) {
+  final account = json["account"];
+  if (account != null) {
+    return {
+      "host": account["host"],
+      "username": account["userId"],
+    };
+  }
+  return json[name]! as Map<String, dynamic>;
+}
 
 @freezed
 class TabSetting with _$TabSetting {
@@ -35,19 +46,23 @@ class TabSetting with _$TabSetting {
     String? antennaId,
 
     /// ノートの投稿のキャプチャをするかどうか
-    @Default(true) isSubscribe,
+    @Default(true) bool isSubscribe,
 
     /// 返信を含むかどうか
-    @Default(true) isIncludeReplies,
+    @Default(true) bool isIncludeReplies,
 
     /// ファイルのみにするかどうか
-    @Default(false) isMediaOnly,
+    @Default(false) bool isMediaOnly,
 
     /// タブ名
     required String name,
 
     /// アカウント情報
-    required Account account,
+    // https://github.com/rrousselGit/freezed/issues/488
+    // ignore: invalid_annotation_target
+    @JsonKey(readValue: _readAcct) required Acct acct,
+
+    /// Renoteを表示するかどうか
     @Default(true) bool renoteDisplay,
   }) = _TabSetting;
 

--- a/lib/model/tab_setting.freezed.dart
+++ b/lib/model/tab_setting.freezed.dart
@@ -39,19 +39,24 @@ mixin _$TabSetting {
   String? get antennaId => throw _privateConstructorUsedError;
 
   /// ノートの投稿のキャプチャをするかどうか
-  dynamic get isSubscribe => throw _privateConstructorUsedError;
+  bool get isSubscribe => throw _privateConstructorUsedError;
 
   /// 返信を含むかどうか
-  dynamic get isIncludeReplies => throw _privateConstructorUsedError;
+  bool get isIncludeReplies => throw _privateConstructorUsedError;
 
   /// ファイルのみにするかどうか
-  dynamic get isMediaOnly => throw _privateConstructorUsedError;
+  bool get isMediaOnly => throw _privateConstructorUsedError;
 
   /// タブ名
   String get name => throw _privateConstructorUsedError;
 
   /// アカウント情報
-  Account get account => throw _privateConstructorUsedError;
+// https://github.com/rrousselGit/freezed/issues/488
+// ignore: invalid_annotation_target
+  @JsonKey(readValue: _readAcct)
+  Acct get acct => throw _privateConstructorUsedError;
+
+  /// Renoteを表示するかどうか
   bool get renoteDisplay => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -73,15 +78,15 @@ abstract class $TabSettingCopyWith<$Res> {
       String? channelId,
       String? listId,
       String? antennaId,
-      dynamic isSubscribe,
-      dynamic isIncludeReplies,
-      dynamic isMediaOnly,
+      bool isSubscribe,
+      bool isIncludeReplies,
+      bool isMediaOnly,
       String name,
-      Account account,
+      @JsonKey(readValue: _readAcct) Acct acct,
       bool renoteDisplay});
 
   $TabIconCopyWith<$Res> get icon;
-  $AccountCopyWith<$Res> get account;
+  $AcctCopyWith<$Res> get acct;
 }
 
 /// @nodoc
@@ -103,11 +108,11 @@ class _$TabSettingCopyWithImpl<$Res, $Val extends TabSetting>
     Object? channelId = freezed,
     Object? listId = freezed,
     Object? antennaId = freezed,
-    Object? isSubscribe = freezed,
-    Object? isIncludeReplies = freezed,
-    Object? isMediaOnly = freezed,
+    Object? isSubscribe = null,
+    Object? isIncludeReplies = null,
+    Object? isMediaOnly = null,
     Object? name = null,
-    Object? account = null,
+    Object? acct = null,
     Object? renoteDisplay = null,
   }) {
     return _then(_value.copyWith(
@@ -135,26 +140,26 @@ class _$TabSettingCopyWithImpl<$Res, $Val extends TabSetting>
           ? _value.antennaId
           : antennaId // ignore: cast_nullable_to_non_nullable
               as String?,
-      isSubscribe: freezed == isSubscribe
+      isSubscribe: null == isSubscribe
           ? _value.isSubscribe
           : isSubscribe // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-      isIncludeReplies: freezed == isIncludeReplies
+              as bool,
+      isIncludeReplies: null == isIncludeReplies
           ? _value.isIncludeReplies
           : isIncludeReplies // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-      isMediaOnly: freezed == isMediaOnly
+              as bool,
+      isMediaOnly: null == isMediaOnly
           ? _value.isMediaOnly
           : isMediaOnly // ignore: cast_nullable_to_non_nullable
-              as dynamic,
+              as bool,
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      account: null == account
-          ? _value.account
-          : account // ignore: cast_nullable_to_non_nullable
-              as Account,
+      acct: null == acct
+          ? _value.acct
+          : acct // ignore: cast_nullable_to_non_nullable
+              as Acct,
       renoteDisplay: null == renoteDisplay
           ? _value.renoteDisplay
           : renoteDisplay // ignore: cast_nullable_to_non_nullable
@@ -172,9 +177,9 @@ class _$TabSettingCopyWithImpl<$Res, $Val extends TabSetting>
 
   @override
   @pragma('vm:prefer-inline')
-  $AccountCopyWith<$Res> get account {
-    return $AccountCopyWith<$Res>(_value.account, (value) {
-      return _then(_value.copyWith(account: value) as $Val);
+  $AcctCopyWith<$Res> get acct {
+    return $AcctCopyWith<$Res>(_value.acct, (value) {
+      return _then(_value.copyWith(acct: value) as $Val);
     });
   }
 }
@@ -194,17 +199,17 @@ abstract class _$$_TabSettingCopyWith<$Res>
       String? channelId,
       String? listId,
       String? antennaId,
-      dynamic isSubscribe,
-      dynamic isIncludeReplies,
-      dynamic isMediaOnly,
+      bool isSubscribe,
+      bool isIncludeReplies,
+      bool isMediaOnly,
       String name,
-      Account account,
+      @JsonKey(readValue: _readAcct) Acct acct,
       bool renoteDisplay});
 
   @override
   $TabIconCopyWith<$Res> get icon;
   @override
-  $AccountCopyWith<$Res> get account;
+  $AcctCopyWith<$Res> get acct;
 }
 
 /// @nodoc
@@ -224,11 +229,11 @@ class __$$_TabSettingCopyWithImpl<$Res>
     Object? channelId = freezed,
     Object? listId = freezed,
     Object? antennaId = freezed,
-    Object? isSubscribe = freezed,
-    Object? isIncludeReplies = freezed,
-    Object? isMediaOnly = freezed,
+    Object? isSubscribe = null,
+    Object? isIncludeReplies = null,
+    Object? isMediaOnly = null,
     Object? name = null,
-    Object? account = null,
+    Object? acct = null,
     Object? renoteDisplay = null,
   }) {
     return _then(_$_TabSetting(
@@ -256,19 +261,26 @@ class __$$_TabSettingCopyWithImpl<$Res>
           ? _value.antennaId
           : antennaId // ignore: cast_nullable_to_non_nullable
               as String?,
-      isSubscribe: freezed == isSubscribe ? _value.isSubscribe! : isSubscribe,
-      isIncludeReplies: freezed == isIncludeReplies
-          ? _value.isIncludeReplies!
-          : isIncludeReplies,
-      isMediaOnly: freezed == isMediaOnly ? _value.isMediaOnly! : isMediaOnly,
+      isSubscribe: null == isSubscribe
+          ? _value.isSubscribe
+          : isSubscribe // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isIncludeReplies: null == isIncludeReplies
+          ? _value.isIncludeReplies
+          : isIncludeReplies // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isMediaOnly: null == isMediaOnly
+          ? _value.isMediaOnly
+          : isMediaOnly // ignore: cast_nullable_to_non_nullable
+              as bool,
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      account: null == account
-          ? _value.account
-          : account // ignore: cast_nullable_to_non_nullable
-              as Account,
+      acct: null == acct
+          ? _value.acct
+          : acct // ignore: cast_nullable_to_non_nullable
+              as Acct,
       renoteDisplay: null == renoteDisplay
           ? _value.renoteDisplay
           : renoteDisplay // ignore: cast_nullable_to_non_nullable
@@ -291,7 +303,7 @@ class _$_TabSetting extends _TabSetting {
       this.isIncludeReplies = true,
       this.isMediaOnly = false,
       required this.name,
-      required this.account,
+      @JsonKey(readValue: _readAcct) required this.acct,
       this.renoteDisplay = true})
       : super._();
 
@@ -325,32 +337,37 @@ class _$_TabSetting extends _TabSetting {
   /// ノートの投稿のキャプチャをするかどうか
   @override
   @JsonKey()
-  final dynamic isSubscribe;
+  final bool isSubscribe;
 
   /// 返信を含むかどうか
   @override
   @JsonKey()
-  final dynamic isIncludeReplies;
+  final bool isIncludeReplies;
 
   /// ファイルのみにするかどうか
   @override
   @JsonKey()
-  final dynamic isMediaOnly;
+  final bool isMediaOnly;
 
   /// タブ名
   @override
   final String name;
 
   /// アカウント情報
+// https://github.com/rrousselGit/freezed/issues/488
+// ignore: invalid_annotation_target
   @override
-  final Account account;
+  @JsonKey(readValue: _readAcct)
+  final Acct acct;
+
+  /// Renoteを表示するかどうか
   @override
   @JsonKey()
   final bool renoteDisplay;
 
   @override
   String toString() {
-    return 'TabSetting(icon: $icon, tabType: $tabType, roleId: $roleId, channelId: $channelId, listId: $listId, antennaId: $antennaId, isSubscribe: $isSubscribe, isIncludeReplies: $isIncludeReplies, isMediaOnly: $isMediaOnly, name: $name, account: $account, renoteDisplay: $renoteDisplay)';
+    return 'TabSetting(icon: $icon, tabType: $tabType, roleId: $roleId, channelId: $channelId, listId: $listId, antennaId: $antennaId, isSubscribe: $isSubscribe, isIncludeReplies: $isIncludeReplies, isMediaOnly: $isMediaOnly, name: $name, acct: $acct, renoteDisplay: $renoteDisplay)';
   }
 
   @override
@@ -366,14 +383,14 @@ class _$_TabSetting extends _TabSetting {
             (identical(other.listId, listId) || other.listId == listId) &&
             (identical(other.antennaId, antennaId) ||
                 other.antennaId == antennaId) &&
-            const DeepCollectionEquality()
-                .equals(other.isSubscribe, isSubscribe) &&
-            const DeepCollectionEquality()
-                .equals(other.isIncludeReplies, isIncludeReplies) &&
-            const DeepCollectionEquality()
-                .equals(other.isMediaOnly, isMediaOnly) &&
+            (identical(other.isSubscribe, isSubscribe) ||
+                other.isSubscribe == isSubscribe) &&
+            (identical(other.isIncludeReplies, isIncludeReplies) ||
+                other.isIncludeReplies == isIncludeReplies) &&
+            (identical(other.isMediaOnly, isMediaOnly) ||
+                other.isMediaOnly == isMediaOnly) &&
             (identical(other.name, name) || other.name == name) &&
-            (identical(other.account, account) || other.account == account) &&
+            (identical(other.acct, acct) || other.acct == acct) &&
             (identical(other.renoteDisplay, renoteDisplay) ||
                 other.renoteDisplay == renoteDisplay));
   }
@@ -388,11 +405,11 @@ class _$_TabSetting extends _TabSetting {
       channelId,
       listId,
       antennaId,
-      const DeepCollectionEquality().hash(isSubscribe),
-      const DeepCollectionEquality().hash(isIncludeReplies),
-      const DeepCollectionEquality().hash(isMediaOnly),
+      isSubscribe,
+      isIncludeReplies,
+      isMediaOnly,
       name,
-      account,
+      acct,
       renoteDisplay);
 
   @JsonKey(ignore: true)
@@ -417,11 +434,11 @@ abstract class _TabSetting extends TabSetting {
       final String? channelId,
       final String? listId,
       final String? antennaId,
-      final dynamic isSubscribe,
-      final dynamic isIncludeReplies,
-      final dynamic isMediaOnly,
+      final bool isSubscribe,
+      final bool isIncludeReplies,
+      final bool isMediaOnly,
       required final String name,
-      required final Account account,
+      @JsonKey(readValue: _readAcct) required final Acct acct,
       final bool renoteDisplay}) = _$_TabSetting;
   const _TabSetting._() : super._();
 
@@ -454,15 +471,15 @@ abstract class _TabSetting extends TabSetting {
   @override
 
   /// ノートの投稿のキャプチャをするかどうか
-  dynamic get isSubscribe;
+  bool get isSubscribe;
   @override
 
   /// 返信を含むかどうか
-  dynamic get isIncludeReplies;
+  bool get isIncludeReplies;
   @override
 
   /// ファイルのみにするかどうか
-  dynamic get isMediaOnly;
+  bool get isMediaOnly;
   @override
 
   /// タブ名
@@ -470,8 +487,13 @@ abstract class _TabSetting extends TabSetting {
   @override
 
   /// アカウント情報
-  Account get account;
+// https://github.com/rrousselGit/freezed/issues/488
+// ignore: invalid_annotation_target
+  @JsonKey(readValue: _readAcct)
+  Acct get acct;
   @override
+
+  /// Renoteを表示するかどうか
   bool get renoteDisplay;
   @override
   @JsonKey(ignore: true)

--- a/lib/model/tab_setting.g.dart
+++ b/lib/model/tab_setting.g.dart
@@ -14,11 +14,11 @@ _$_TabSetting _$$_TabSettingFromJson(Map<String, dynamic> json) =>
       channelId: json['channelId'] as String?,
       listId: json['listId'] as String?,
       antennaId: json['antennaId'] as String?,
-      isSubscribe: json['isSubscribe'] ?? true,
-      isIncludeReplies: json['isIncludeReplies'] ?? true,
-      isMediaOnly: json['isMediaOnly'] ?? false,
+      isSubscribe: json['isSubscribe'] as bool? ?? true,
+      isIncludeReplies: json['isIncludeReplies'] as bool? ?? true,
+      isMediaOnly: json['isMediaOnly'] as bool? ?? false,
       name: json['name'] as String,
-      account: Account.fromJson(json['account'] as Map<String, dynamic>),
+      acct: Acct.fromJson(_readAcct(json, 'acct') as Map<String, dynamic>),
       renoteDisplay: json['renoteDisplay'] as bool? ?? true,
     );
 
@@ -34,7 +34,7 @@ Map<String, dynamic> _$$_TabSettingToJson(_$_TabSetting instance) =>
       'isIncludeReplies': instance.isIncludeReplies,
       'isMediaOnly': instance.isMediaOnly,
       'name': instance.name,
-      'account': instance.account.toJson(),
+      'acct': instance.acct.toJson(),
       'renoteDisplay': instance.renoteDisplay,
     };
 

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -3,6 +3,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
 import 'package:miria/model/account.dart';
+import 'package:miria/model/acct.dart';
 import 'package:miria/model/tab_setting.dart';
 import 'package:miria/repository/account_repository.dart';
 import 'package:miria/repository/account_settings_repository.dart';
@@ -30,117 +31,145 @@ import 'package:misskey_dart/misskey_dart.dart';
 final dioProvider = Provider((ref) => Dio());
 final fileSystemProvider =
     Provider<FileSystem>((ref) => const LocalFileSystem());
-final misskeyProvider = Provider.family<Misskey, Account>((ref, account) =>
-    Misskey(
-        token: account.token,
-        host: account.host,
-        socketConnectionTimeout: const Duration(seconds: 20)));
+final misskeyProvider = Provider.family<Misskey, Account>(
+  (ref, account) => Misskey(
+    token: account.token,
+    host: account.host,
+    socketConnectionTimeout: const Duration(seconds: 20),
+  ),
+);
 
 final localTimeLineProvider =
     ChangeNotifierProvider.family<TimelineRepository, TabSetting>(
-        (ref, tabSetting) => LocalTimeLineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              tabSetting.account,
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(accountRepository),
-              ref.read(emojiRepositoryProvider(tabSetting.account)),
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return LocalTimeLineRepository(
+    ref.read(misskeyProvider(account)),
+    account,
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(accountRepository),
+    ref.read(emojiRepositoryProvider(account)),
+  );
+});
+
 final homeTimeLineProvider =
     ChangeNotifierProvider.family<TimelineRepository, TabSetting>(
-        (ref, tabSetting) => HomeTimeLineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              tabSetting.account,
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(accountRepository),
-              ref.read(emojiRepositoryProvider(tabSetting.account)),
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return HomeTimeLineRepository(
+    ref.read(misskeyProvider(account)),
+    account,
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(accountRepository),
+    ref.read(emojiRepositoryProvider(account)),
+  );
+});
+
 final globalTimeLineProvider =
     ChangeNotifierProvider.family<TimelineRepository, TabSetting>(
-        (ref, tabSetting) => GlobalTimeLineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return GlobalTimeLineRepository(
+    ref.read(misskeyProvider(account)),
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+  );
+});
 
 final hybridTimeLineProvider =
     ChangeNotifierProvider.family<TimelineRepository, TabSetting>(
-        (ref, tabSetting) => HybridTimelineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              tabSetting.account,
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(accountRepository),
-              ref.read(emojiRepositoryProvider(tabSetting.account)),
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return HybridTimelineRepository(
+    ref.read(misskeyProvider(account)),
+    account,
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(accountRepository),
+    ref.read(emojiRepositoryProvider(account)),
+  );
+});
 
 final roleTimelineProvider =
     ChangeNotifierProvider.family<RoleTimelineRepository, TabSetting>(
-        (ref, tabSetting) => RoleTimelineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              tabSetting.account,
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(accountRepository),
-              ref.read(emojiRepositoryProvider(tabSetting.account)),
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return RoleTimelineRepository(
+    ref.read(misskeyProvider(account)),
+    account,
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(accountRepository),
+    ref.read(emojiRepositoryProvider(account)),
+  );
+});
 
 final channelTimelineProvider =
     ChangeNotifierProvider.family<ChannelTimelineRepository, TabSetting>(
-        (ref, tabSetting) => ChannelTimelineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              tabSetting.account,
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(accountRepository),
-              ref.read(emojiRepositoryProvider(tabSetting.account)),
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return ChannelTimelineRepository(
+    ref.read(misskeyProvider(account)),
+    account,
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(accountRepository),
+    ref.read(emojiRepositoryProvider(account)),
+  );
+});
 
 final userListTimelineProvider =
     ChangeNotifierProvider.family<UserListTimelineRepository, TabSetting>(
-        (ref, tabSetting) => UserListTimelineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              tabSetting.account,
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(accountRepository),
-              ref.read(emojiRepositoryProvider(tabSetting.account)),
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return UserListTimelineRepository(
+    ref.read(misskeyProvider(account)),
+    account,
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(accountRepository),
+    ref.read(emojiRepositoryProvider(account)),
+  );
+});
 
 final antennaTimelineProvider =
     ChangeNotifierProvider.family<AntennaTimelineRepository, TabSetting>(
-        (ref, tabSetting) => AntennaTimelineRepository(
-              ref.read(misskeyProvider(tabSetting.account)),
-              tabSetting.account,
-              ref.read(notesProvider(tabSetting.account)),
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(generalSettingsRepositoryProvider),
-              tabSetting,
-              ref.read(mainStreamRepositoryProvider(tabSetting.account)),
-              ref.read(accountRepository),
-              ref.read(emojiRepositoryProvider(tabSetting.account)),
-            ));
+        (ref, tabSetting) {
+  final account = ref.watch(accountProvider(tabSetting.acct));
+  return AntennaTimelineRepository(
+    ref.read(misskeyProvider(account)),
+    account,
+    ref.read(notesProvider(account)),
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(generalSettingsRepositoryProvider),
+    tabSetting,
+    ref.read(mainStreamRepositoryProvider(account)),
+    ref.read(accountRepository),
+    ref.read(emojiRepositoryProvider(account)),
+  );
+});
 
 final mainStreamRepositoryProvider =
     ChangeNotifierProvider.family<MainStreamRepository, Account>(
@@ -171,6 +200,18 @@ final accountRepository = ChangeNotifierProvider((ref) => AccountRepository(
     ref.read(tabSettingsRepositoryProvider),
     ref.read(accountSettingsRepositoryProvider),
     ref.read));
+
+final accountProvider = Provider.family<Account, Acct>(
+  (ref, acct) => ref.watch(
+    accountRepository.select(
+      (repository) => repository.account.firstWhere(
+        (account) =>
+            account.host == acct.host && account.userId == acct.username,
+      ),
+    ),
+  ),
+);
+
 final tabSettingsRepositoryProvider =
     ChangeNotifierProvider((ref) => TabSettingsRepository());
 

--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
+import 'package:miria/model/acct.dart';
 import 'package:miria/model/tab_icon.dart';
 import 'package:miria/model/tab_setting.dart';
 import 'package:miria/model/tab_type.dart';
@@ -54,13 +55,13 @@ class AccountRepository extends ChangeNotifier {
     }
   }
 
-  Future<void> loadFromSourceIfNeed(Account account) async {
-    final index = _account.indexOf(account);
+  Future<void> loadFromSourceIfNeed(Acct acct) async {
+    final index =
+        _account.map((account) => account.acct).toList().indexOf(acct);
     if (index == -1) return;
     if (accountDataValidated.isNotEmpty && accountDataValidated[index]) return;
     final i = await reader(misskeyProvider(_account[index])).i.i();
     _account[index] = _account[index].copyWith(i: i);
-    tabSettingsRepository.updateAccount(account, i);
 
     accountDataValidated[index] = true;
     notifyListeners();
@@ -75,7 +76,6 @@ class AccountRepository extends ChangeNotifier {
         ]);
     _account[_account.indexOf(account)] =
         _account[_account.indexOf(account)].copyWith(i: i);
-    tabSettingsRepository.updateAccount(account, i);
     notifyListeners();
   }
 
@@ -84,7 +84,6 @@ class AccountRepository extends ChangeNotifier {
         _account[_account.indexOf(account)].i.copyWith(unreadAnnouncements: []);
     _account[_account.indexOf(account)] =
         _account[_account.indexOf(account)].copyWith(i: i);
-    tabSettingsRepository.updateAccount(account, i);
     notifyListeners();
   }
 
@@ -94,20 +93,23 @@ class AccountRepository extends ChangeNotifier {
       final account = _account.first;
       await tabSettingsRepository.save([
         TabSetting(
-            icon: TabIcon(codePoint: Icons.home.codePoint),
-            tabType: TabType.homeTimeline,
-            name: "ホームタイムライン",
-            account: account),
+          icon: TabIcon(codePoint: Icons.home.codePoint),
+          tabType: TabType.homeTimeline,
+          name: "ホームタイムライン",
+          acct: account.acct,
+        ),
         TabSetting(
-            icon: TabIcon(codePoint: Icons.public.codePoint),
-            tabType: TabType.localTimeline,
-            name: "ローカルタイムライン",
-            account: account),
+          icon: TabIcon(codePoint: Icons.public.codePoint),
+          tabType: TabType.localTimeline,
+          name: "ローカルタイムライン",
+          acct: account.acct,
+        ),
         TabSetting(
-            icon: TabIcon(codePoint: Icons.rocket_launch.codePoint),
-            tabType: TabType.globalTimeline,
-            name: "グローバルタイムライン",
-            account: account),
+          icon: TabIcon(codePoint: Icons.rocket_launch.codePoint),
+          tabType: TabType.globalTimeline,
+          name: "グローバルタイムライン",
+          acct: account.acct,
+        ),
       ]);
     }
   }

--- a/lib/repository/account_settings_repository.dart
+++ b/lib/repository/account_settings_repository.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/model/account_settings.dart';
+import 'package:miria/model/acct.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AccountSettingsRepository extends ChangeNotifier {
@@ -28,8 +29,7 @@ class AccountSettingsRepository extends ChangeNotifier {
 
   Future<void> save(AccountSettings settings) async {
     _accountSettings = _accountSettings
-      ..removeWhere((element) =>
-          element.userId == settings.userId && element.host == settings.host)
+      ..removeWhere((oldSettings) => oldSettings.acct == settings.acct)
       ..add(settings)
       ..toList();
     await _saveAsList(_accountSettings);
@@ -43,19 +43,23 @@ class AccountSettingsRepository extends ChangeNotifier {
   }
 
   Future<void> removeAccount(Account account) async {
-    _accountSettings.removeWhere((element) =>
-        element.host == account.host && element.userId == account.userId);
+    _accountSettings
+        .removeWhere((accountSettings) => accountSettings.acct == account.acct);
     await _saveAsList(_accountSettings);
     notifyListeners();
   }
 
-  AccountSettings fromAccount(Account account) {
+  AccountSettings fromAcct(Acct acct) {
     return _accountSettings.firstWhereOrNull(
-            (e) => e.host == account.host && e.userId == account.userId) ??
+          (accountSettings) => accountSettings.acct == acct,
+        ) ??
         AccountSettings(
-          userId: account.userId,
-          host: account.host,
-          reactions: [],
+          userId: acct.username,
+          host: acct.host,
         );
+  }
+
+  AccountSettings fromAccount(Account account) {
+    return fromAcct(account.acct);
   }
 }

--- a/lib/repository/socket_timeline_repository.dart
+++ b/lib/repository/socket_timeline_repository.dart
@@ -82,7 +82,7 @@ abstract class SocketTimelineRepository extends TimelineRepository {
   Future<void> startTimeLine() async {
     try {
       await emojiRepository.loadFromSourceIfNeed();
-      await accountRepository.loadFromSourceIfNeed(tabSetting.account);
+      await accountRepository.loadFromSourceIfNeed(tabSetting.acct);
       await mainStreamRepository.reconnect();
       isLoading = false;
       error = null;

--- a/lib/repository/tab_settings_repository.dart
+++ b/lib/repository/tab_settings_repository.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/model/tab_setting.dart';
-import 'package:misskey_dart/misskey_dart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class TabSettingsRepository extends ChangeNotifier {
@@ -29,16 +28,6 @@ class TabSettingsRepository extends ChangeNotifier {
     }
   }
 
-  void updateAccount(Account account, IResponse response) {
-    for (var i = 0; i < _tabSettings.length; i++) {
-      if (_tabSettings[i].account == account) {
-        _tabSettings[i] = _tabSettings[i]
-            .copyWith(account: _tabSettings[i].account.copyWith(i: response));
-      }
-    }
-    notifyListeners();
-  }
-
   Future<void> save(List<TabSetting> tabSettings) async {
     _tabSettings = tabSettings.toList();
     final prefs = await SharedPreferences.getInstance();
@@ -48,9 +37,7 @@ class TabSettingsRepository extends ChangeNotifier {
   }
 
   Future<void> removeAccount(Account account) async {
-    _tabSettings.removeWhere((element) =>
-        element.account.host == account.host &&
-        element.account.userId == account.userId);
+    _tabSettings.removeWhere((tabSetting) => tabSetting.acct == account.acct);
     await save(_tabSettings);
     notifyListeners();
   }

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -15,24 +15,13 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
-    NotesAfterRenoteRoute.name: (routeData) {
-      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
+    AnnouncementRoute.name: (routeData) {
+      final args = routeData.argsAs<AnnouncementRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotesAfterRenotePage(
+        child: AnnouncementPage(
           key: args.key,
-          note: args.note,
           account: args.account,
-        ),
-      );
-    },
-    AntennaRoute.name: (routeData) {
-      final args = routeData.argsAs<AntennaRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: AntennaPage(
-          account: args.account,
-          key: args.key,
         ),
       );
     },
@@ -47,20 +36,35 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    NotificationRoute.name: (routeData) {
-      final args = routeData.argsAs<NotificationRouteArgs>();
+    AntennaRoute.name: (routeData) {
+      final args = routeData.argsAs<AntennaRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotificationPage(
+        child: AntennaPage(
+          account: args.account,
+          key: args.key,
+        ),
+      );
+    },
+    ChannelsRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelsRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ChannelsPage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    LoginRoute.name: (routeData) {
+    ChannelDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const LoginPage(),
+        child: ChannelDetailPage(
+          key: args.key,
+          account: args.account,
+          channelId: args.channelId,
+        ),
       );
     },
     ClipDetailRoute.name: (routeData) {
@@ -84,6 +88,87 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    ExploreRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExplorePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ExploreRoleUsersRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExploreRoleUsersPage(
+          key: args.key,
+          item: args.item,
+          account: args.account,
+        ),
+      );
+    },
+    FavoritedNoteRoute.name: (routeData) {
+      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FavoritedNotePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    FederationRoute.name: (routeData) {
+      final args = routeData.argsAs<FederationRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FederationPage(
+          key: args.key,
+          account: args.account,
+          host: args.host,
+        ),
+      );
+    },
+    HashtagRoute.name: (routeData) {
+      final args = routeData.argsAs<HashtagRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: HashtagPage(
+          key: args.key,
+          hashtag: args.hashtag,
+          account: args.account,
+        ),
+      );
+    },
+    LoginRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const LoginPage(),
+      );
+    },
+    MisskeyRouteRoute.name: (routeData) {
+      final args = routeData.argsAs<MisskeyRouteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: MisskeyPagePage(
+          key: args.key,
+          account: args.account,
+          page: args.page,
+        ),
+      );
+    },
+    NotesAfterRenoteRoute.name: (routeData) {
+      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: NotesAfterRenotePage(
+          key: args.key,
+          note: args.note,
+          account: args.account,
+        ),
+      );
+    },
     NoteCreateRoute.name: (routeData) {
       final args = routeData.argsAs<NoteCreateRouteArgs>();
       return AutoRoutePage<dynamic>(
@@ -101,46 +186,23 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    HashtagRoute.name: (routeData) {
-      final args = routeData.argsAs<HashtagRouteArgs>();
+    NoteDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<NoteDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: HashtagPage(
+        child: NoteDetailPage(
           key: args.key,
-          hashtag: args.hashtag,
+          note: args.note,
           account: args.account,
         ),
       );
     },
-    UserFolloweeRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFolloweeRouteArgs>();
+    NotificationRoute.name: (routeData) {
+      final args = routeData.argsAs<NotificationRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserFolloweePage(
+        child: NotificationPage(
           key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserRoute.name: (routeData) {
-      final args = routeData.argsAs<UserRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserPage(
-          key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserFollowerRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFollowerRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserFollowerPage(
-          key: args.key,
-          userId: args.userId,
           account: args.account,
         ),
       );
@@ -157,20 +219,92 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    AnnouncementRoute.name: (routeData) {
-      final args = routeData.argsAs<AnnouncementRouteArgs>();
+    SearchRoute.name: (routeData) {
+      final args = routeData.argsAs<SearchRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: AnnouncementPage(
+        child: SearchPage(
+          key: args.key,
+          initialSearchText: args.initialSearchText,
+          account: args.account,
+        ),
+      );
+    },
+    AccountListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AccountListPage(),
+      );
+    },
+    AppInfoRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AppInfoPage(),
+      );
+    },
+    GeneralSettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const GeneralSettingsPage(),
+      );
+    },
+    ImportExportRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const ImportExportPage(),
+      );
+    },
+    SettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SettingsPage(),
+      );
+    },
+    TabSettingsListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const TabSettingsListPage(),
+      );
+    },
+    TabSettingsRoute.name: (routeData) {
+      final args = routeData.argsAs<TabSettingsRouteArgs>(
+          orElse: () => const TabSettingsRouteArgs());
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: TabSettingsPage(
+          key: args.key,
+          tabIndex: args.tabIndex,
+        ),
+      );
+    },
+    HardMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<HardMuteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: HardMutePage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    SplashRoute.name: (routeData) {
+    InstanceMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<InstanceMuteRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const SplashPage(),
+        child: InstanceMutePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ReactionDeckRoute.name: (routeData) {
+      final args = routeData.argsAs<ReactionDeckRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ReactionDeckPage(
+          key: args.key,
+          account: args.account,
+        ),
       );
     },
     SeveralAccountGeneralSettingsRoute.name: (routeData) {
@@ -193,54 +327,31 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    InstanceMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<InstanceMuteRouteArgs>();
+    SharingAccountSelectRoute.name: (routeData) {
+      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
+          orElse: () => const SharingAccountSelectRouteArgs());
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: InstanceMutePage(
+        child: SharingAccountSelectPage(
           key: args.key,
-          account: args.account,
+          sharingText: args.sharingText,
+          filePath: args.filePath,
         ),
       );
     },
-    HardMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<HardMuteRouteArgs>();
+    SplashRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: HardMutePage(
-          key: args.key,
-          account: args.account,
-        ),
+        child: const SplashPage(),
       );
     },
-    ReactionDeckRoute.name: (routeData) {
-      final args = routeData.argsAs<ReactionDeckRouteArgs>();
+    TimeLineRoute.name: (routeData) {
+      final args = routeData.argsAs<TimeLineRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ReactionDeckPage(
+        child: TimeLinePage(
           key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    UsersListTimelineRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListTimelineRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UsersListTimelinePage(
-          args.account,
-          args.list,
-          key: args.key,
-        ),
-      );
-    },
-    UsersListRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UsersListPage(
-          args.account,
-          key: args.key,
+          initialTabSetting: args.initialTabSetting,
         ),
       );
     },
@@ -255,168 +366,57 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    ChannelDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelDetailRouteArgs>();
+    UsersListRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ChannelDetailPage(
+        child: UsersListPage(
+          args.account,
           key: args.key,
-          account: args.account,
-          channelId: args.channelId,
         ),
       );
     },
-    ChannelsRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelsRouteArgs>();
+    UsersListTimelineRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListTimelineRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: ChannelsPage(
+        child: UsersListTimelinePage(
+          args.account,
+          args.list,
           key: args.key,
-          account: args.account,
         ),
       );
     },
-    FederationRoute.name: (routeData) {
-      final args = routeData.argsAs<FederationRouteArgs>();
+    UserFolloweeRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFolloweeRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: FederationPage(
+        child: UserFolloweePage(
           key: args.key,
-          account: args.account,
-          host: args.host,
-        ),
-      );
-    },
-    NoteDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<NoteDetailRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: NoteDetailPage(
-          key: args.key,
-          note: args.note,
+          userId: args.userId,
           account: args.account,
         ),
       );
     },
-    SearchRoute.name: (routeData) {
-      final args = routeData.argsAs<SearchRouteArgs>();
+    UserFollowerRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFollowerRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: SearchPage(
+        child: UserFollowerPage(
           key: args.key,
-          initialSearchText: args.initialSearchText,
+          userId: args.userId,
           account: args.account,
         ),
       );
     },
-    SharingAccountSelectRoute.name: (routeData) {
-      final args = routeData.argsAs<SharingAccountSelectRouteArgs>(
-          orElse: () => const SharingAccountSelectRouteArgs());
+    UserRoute.name: (routeData) {
+      final args = routeData.argsAs<UserRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: SharingAccountSelectPage(
+        child: UserPage(
           key: args.key,
-          sharingText: args.sharingText,
-          filePath: args.filePath,
-        ),
-      );
-    },
-    ImportExportRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const ImportExportPage(),
-      );
-    },
-    GeneralSettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const GeneralSettingsPage(),
-      );
-    },
-    TabSettingsRoute.name: (routeData) {
-      final args = routeData.argsAs<TabSettingsRouteArgs>(
-          orElse: () => const TabSettingsRouteArgs());
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TabSettingsPage(
-          key: args.key,
-          tabIndex: args.tabIndex,
-        ),
-      );
-    },
-    TabSettingsListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const TabSettingsListPage(),
-      );
-    },
-    AppInfoRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AppInfoPage(),
-      );
-    },
-    SettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const SettingsPage(),
-      );
-    },
-    AccountListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AccountListPage(),
-      );
-    },
-    ExploreRoleUsersRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExploreRoleUsersPage(
-          key: args.key,
-          item: args.item,
+          userId: args.userId,
           account: args.account,
-        ),
-      );
-    },
-    ExploreRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExplorePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    TimeLineRoute.name: (routeData) {
-      final args = routeData.argsAs<TimeLineRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TimeLinePage(
-          key: args.key,
-          initialTabSetting: args.initialTabSetting,
-        ),
-      );
-    },
-    FavoritedNoteRoute.name: (routeData) {
-      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: FavoritedNotePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    MisskeyRouteRoute.name: (routeData) {
-      final args = routeData.argsAs<MisskeyRouteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: MisskeyPagePage(
-          key: args.key,
-          account: args.account,
-          page: args.page,
         ),
       );
     },
@@ -424,83 +424,40 @@ abstract class _$AppRouter extends RootStackRouter {
 }
 
 /// generated route for
-/// [NotesAfterRenotePage]
-class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
-  NotesAfterRenoteRoute({
+/// [AnnouncementPage]
+class AnnouncementRoute extends PageRouteInfo<AnnouncementRouteArgs> {
+  AnnouncementRoute({
     Key? key,
-    required Note note,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotesAfterRenoteRoute.name,
-          args: NotesAfterRenoteRouteArgs(
+          AnnouncementRoute.name,
+          args: AnnouncementRouteArgs(
             key: key,
-            note: note,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotesAfterRenoteRoute';
+  static const String name = 'AnnouncementRoute';
 
-  static const PageInfo<NotesAfterRenoteRouteArgs> page =
-      PageInfo<NotesAfterRenoteRouteArgs>(name);
+  static const PageInfo<AnnouncementRouteArgs> page =
+      PageInfo<AnnouncementRouteArgs>(name);
 }
 
-class NotesAfterRenoteRouteArgs {
-  const NotesAfterRenoteRouteArgs({
+class AnnouncementRouteArgs {
+  const AnnouncementRouteArgs({
     this.key,
-    required this.note,
     required this.account,
   });
 
   final Key? key;
 
-  final Note note;
-
   final Account account;
 
   @override
   String toString() {
-    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
-  }
-}
-
-/// generated route for
-/// [AntennaPage]
-class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
-  AntennaRoute({
-    required Account account,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          AntennaRoute.name,
-          args: AntennaRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'AntennaRoute';
-
-  static const PageInfo<AntennaRouteArgs> page =
-      PageInfo<AntennaRouteArgs>(name);
-}
-
-class AntennaRouteArgs {
-  const AntennaRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'AntennaRouteArgs{account: $account, key: $key}';
+    return 'AnnouncementRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -548,29 +505,67 @@ class AntennaNotesRouteArgs {
 }
 
 /// generated route for
-/// [NotificationPage]
-class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
-  NotificationRoute({
+/// [AntennaPage]
+class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
+  AntennaRoute({
+    required Account account,
+    Key? key,
+    List<PageRouteInfo>? children,
+  }) : super(
+          AntennaRoute.name,
+          args: AntennaRouteArgs(
+            account: account,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'AntennaRoute';
+
+  static const PageInfo<AntennaRouteArgs> page =
+      PageInfo<AntennaRouteArgs>(name);
+}
+
+class AntennaRouteArgs {
+  const AntennaRouteArgs({
+    required this.account,
+    this.key,
+  });
+
+  final Account account;
+
+  final Key? key;
+
+  @override
+  String toString() {
+    return 'AntennaRouteArgs{account: $account, key: $key}';
+  }
+}
+
+/// generated route for
+/// [ChannelsPage]
+class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
+  ChannelsRoute({
     Key? key,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotificationRoute.name,
-          args: NotificationRouteArgs(
+          ChannelsRoute.name,
+          args: ChannelsRouteArgs(
             key: key,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotificationRoute';
+  static const String name = 'ChannelsRoute';
 
-  static const PageInfo<NotificationRouteArgs> page =
-      PageInfo<NotificationRouteArgs>(name);
+  static const PageInfo<ChannelsRouteArgs> page =
+      PageInfo<ChannelsRouteArgs>(name);
 }
 
-class NotificationRouteArgs {
-  const NotificationRouteArgs({
+class ChannelsRouteArgs {
+  const ChannelsRouteArgs({
     this.key,
     required this.account,
   });
@@ -581,22 +576,51 @@ class NotificationRouteArgs {
 
   @override
   String toString() {
-    return 'NotificationRouteArgs{key: $key, account: $account}';
+    return 'ChannelsRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [LoginPage]
-class LoginRoute extends PageRouteInfo<void> {
-  const LoginRoute({List<PageRouteInfo>? children})
-      : super(
-          LoginRoute.name,
+/// [ChannelDetailPage]
+class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
+  ChannelDetailRoute({
+    Key? key,
+    required Account account,
+    required String channelId,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ChannelDetailRoute.name,
+          args: ChannelDetailRouteArgs(
+            key: key,
+            account: account,
+            channelId: channelId,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'LoginRoute';
+  static const String name = 'ChannelDetailRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static const PageInfo<ChannelDetailRouteArgs> page =
+      PageInfo<ChannelDetailRouteArgs>(name);
+}
+
+class ChannelDetailRouteArgs {
+  const ChannelDetailRouteArgs({
+    this.key,
+    required this.account,
+    required this.channelId,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String channelId;
+
+  @override
+  String toString() {
+    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
+  }
 }
 
 /// generated route for
@@ -681,6 +705,311 @@ class ClipListRouteArgs {
 }
 
 /// generated route for
+/// [ExplorePage]
+class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
+  ExploreRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoute.name,
+          args: ExploreRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoute';
+
+  static const PageInfo<ExploreRouteArgs> page =
+      PageInfo<ExploreRouteArgs>(name);
+}
+
+class ExploreRouteArgs {
+  const ExploreRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ExploreRoleUsersPage]
+class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
+  ExploreRoleUsersRoute({
+    Key? key,
+    required RolesListResponse item,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoleUsersRoute.name,
+          args: ExploreRoleUsersRouteArgs(
+            key: key,
+            item: item,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoleUsersRoute';
+
+  static const PageInfo<ExploreRoleUsersRouteArgs> page =
+      PageInfo<ExploreRoleUsersRouteArgs>(name);
+}
+
+class ExploreRoleUsersRouteArgs {
+  const ExploreRoleUsersRouteArgs({
+    this.key,
+    required this.item,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final RolesListResponse item;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FavoritedNotePage]
+class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
+  FavoritedNoteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FavoritedNoteRoute.name,
+          args: FavoritedNoteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FavoritedNoteRoute';
+
+  static const PageInfo<FavoritedNoteRouteArgs> page =
+      PageInfo<FavoritedNoteRouteArgs>(name);
+}
+
+class FavoritedNoteRouteArgs {
+  const FavoritedNoteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FederationPage]
+class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
+  FederationRoute({
+    Key? key,
+    required Account account,
+    required String host,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FederationRoute.name,
+          args: FederationRouteArgs(
+            key: key,
+            account: account,
+            host: host,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FederationRoute';
+
+  static const PageInfo<FederationRouteArgs> page =
+      PageInfo<FederationRouteArgs>(name);
+}
+
+class FederationRouteArgs {
+  const FederationRouteArgs({
+    this.key,
+    required this.account,
+    required this.host,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String host;
+
+  @override
+  String toString() {
+    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
+  }
+}
+
+/// generated route for
+/// [HashtagPage]
+class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
+  HashtagRoute({
+    Key? key,
+    required String hashtag,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          HashtagRoute.name,
+          args: HashtagRouteArgs(
+            key: key,
+            hashtag: hashtag,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'HashtagRoute';
+
+  static const PageInfo<HashtagRouteArgs> page =
+      PageInfo<HashtagRouteArgs>(name);
+}
+
+class HashtagRouteArgs {
+  const HashtagRouteArgs({
+    this.key,
+    required this.hashtag,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String hashtag;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+  }
+}
+
+/// generated route for
+/// [LoginPage]
+class LoginRoute extends PageRouteInfo<void> {
+  const LoginRoute({List<PageRouteInfo>? children})
+      : super(
+          LoginRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'LoginRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [MisskeyPagePage]
+class MisskeyRouteRoute extends PageRouteInfo<MisskeyRouteRouteArgs> {
+  MisskeyRouteRoute({
+    Key? key,
+    required Account account,
+    required Page page,
+    List<PageRouteInfo>? children,
+  }) : super(
+          MisskeyRouteRoute.name,
+          args: MisskeyRouteRouteArgs(
+            key: key,
+            account: account,
+            page: page,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'MisskeyRouteRoute';
+
+  static const PageInfo<MisskeyRouteRouteArgs> page =
+      PageInfo<MisskeyRouteRouteArgs>(name);
+}
+
+class MisskeyRouteRouteArgs {
+  const MisskeyRouteRouteArgs({
+    this.key,
+    required this.account,
+    required this.page,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final Page page;
+
+  @override
+  String toString() {
+    return 'MisskeyRouteRouteArgs{key: $key, account: $account, page: $page}';
+  }
+}
+
+/// generated route for
+/// [NotesAfterRenotePage]
+class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
+  NotesAfterRenoteRoute({
+    Key? key,
+    required Note note,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          NotesAfterRenoteRoute.name,
+          args: NotesAfterRenoteRouteArgs(
+            key: key,
+            note: note,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'NotesAfterRenoteRoute';
+
+  static const PageInfo<NotesAfterRenoteRouteArgs> page =
+      PageInfo<NotesAfterRenoteRouteArgs>(name);
+}
+
+class NotesAfterRenoteRouteArgs {
+  const NotesAfterRenoteRouteArgs({
+    this.key,
+    required this.note,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Note note;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
+  }
+}
+
+/// generated route for
 /// [NoteCreatePage]
 class NoteCreateRoute extends PageRouteInfo<NoteCreateRouteArgs> {
   NoteCreateRoute({
@@ -754,173 +1083,83 @@ class NoteCreateRouteArgs {
 }
 
 /// generated route for
-/// [HashtagPage]
-class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
-  HashtagRoute({
+/// [NoteDetailPage]
+class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
+  NoteDetailRoute({
     Key? key,
-    required String hashtag,
+    required Note note,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          HashtagRoute.name,
-          args: HashtagRouteArgs(
+          NoteDetailRoute.name,
+          args: NoteDetailRouteArgs(
             key: key,
-            hashtag: hashtag,
+            note: note,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'HashtagRoute';
+  static const String name = 'NoteDetailRoute';
 
-  static const PageInfo<HashtagRouteArgs> page =
-      PageInfo<HashtagRouteArgs>(name);
+  static const PageInfo<NoteDetailRouteArgs> page =
+      PageInfo<NoteDetailRouteArgs>(name);
 }
 
-class HashtagRouteArgs {
-  const HashtagRouteArgs({
+class NoteDetailRouteArgs {
+  const NoteDetailRouteArgs({
     this.key,
-    required this.hashtag,
+    required this.note,
     required this.account,
   });
 
   final Key? key;
 
-  final String hashtag;
+  final Note note;
 
   final Account account;
 
   @override
   String toString() {
-    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
   }
 }
 
 /// generated route for
-/// [UserFolloweePage]
-class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
-  UserFolloweeRoute({
+/// [NotificationPage]
+class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
+  NotificationRoute({
     Key? key,
-    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          UserFolloweeRoute.name,
-          args: UserFolloweeRouteArgs(
+          NotificationRoute.name,
+          args: NotificationRouteArgs(
             key: key,
-            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UserFolloweeRoute';
+  static const String name = 'NotificationRoute';
 
-  static const PageInfo<UserFolloweeRouteArgs> page =
-      PageInfo<UserFolloweeRouteArgs>(name);
+  static const PageInfo<NotificationRouteArgs> page =
+      PageInfo<NotificationRouteArgs>(name);
 }
 
-class UserFolloweeRouteArgs {
-  const UserFolloweeRouteArgs({
+class NotificationRouteArgs {
+  const NotificationRouteArgs({
     this.key,
-    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String userId;
-
   final Account account;
 
   @override
   String toString() {
-    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserPage]
-class UserRoute extends PageRouteInfo<UserRouteArgs> {
-  UserRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserRoute.name,
-          args: UserRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserRoute';
-
-  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
-}
-
-class UserRouteArgs {
-  const UserRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserFollowerPage]
-class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
-  UserFollowerRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserFollowerRoute.name,
-          args: UserFollowerRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserFollowerRoute';
-
-  static const PageInfo<UserFollowerRouteArgs> page =
-      PageInfo<UserFollowerRouteArgs>(name);
-}
-
-class UserFollowerRouteArgs {
-  const UserFollowerRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
+    return 'NotificationRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -973,29 +1212,193 @@ class PhotoEditRouteArgs {
 }
 
 /// generated route for
-/// [AnnouncementPage]
-class AnnouncementRoute extends PageRouteInfo<AnnouncementRouteArgs> {
-  AnnouncementRoute({
+/// [SearchPage]
+class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
+  SearchRoute({
+    Key? key,
+    String? initialSearchText,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          SearchRoute.name,
+          args: SearchRouteArgs(
+            key: key,
+            initialSearchText: initialSearchText,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'SearchRoute';
+
+  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+}
+
+class SearchRouteArgs {
+  const SearchRouteArgs({
+    this.key,
+    this.initialSearchText,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String? initialSearchText;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
+  }
+}
+
+/// generated route for
+/// [AccountListPage]
+class AccountListRoute extends PageRouteInfo<void> {
+  const AccountListRoute({List<PageRouteInfo>? children})
+      : super(
+          AccountListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AccountListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [AppInfoPage]
+class AppInfoRoute extends PageRouteInfo<void> {
+  const AppInfoRoute({List<PageRouteInfo>? children})
+      : super(
+          AppInfoRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AppInfoRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [GeneralSettingsPage]
+class GeneralSettingsRoute extends PageRouteInfo<void> {
+  const GeneralSettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          GeneralSettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'GeneralSettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [ImportExportPage]
+class ImportExportRoute extends PageRouteInfo<void> {
+  const ImportExportRoute({List<PageRouteInfo>? children})
+      : super(
+          ImportExportRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'ImportExportRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [SettingsPage]
+class SettingsRoute extends PageRouteInfo<void> {
+  const SettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          SettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsListPage]
+class TabSettingsListRoute extends PageRouteInfo<void> {
+  const TabSettingsListRoute({List<PageRouteInfo>? children})
+      : super(
+          TabSettingsListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsPage]
+class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
+  TabSettingsRoute({
+    Key? key,
+    int? tabIndex,
+    List<PageRouteInfo>? children,
+  }) : super(
+          TabSettingsRoute.name,
+          args: TabSettingsRouteArgs(
+            key: key,
+            tabIndex: tabIndex,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsRoute';
+
+  static const PageInfo<TabSettingsRouteArgs> page =
+      PageInfo<TabSettingsRouteArgs>(name);
+}
+
+class TabSettingsRouteArgs {
+  const TabSettingsRouteArgs({
+    this.key,
+    this.tabIndex,
+  });
+
+  final Key? key;
+
+  final int? tabIndex;
+
+  @override
+  String toString() {
+    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
+  }
+}
+
+/// generated route for
+/// [HardMutePage]
+class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
+  HardMuteRoute({
     Key? key,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          AnnouncementRoute.name,
-          args: AnnouncementRouteArgs(
+          HardMuteRoute.name,
+          args: HardMuteRouteArgs(
             key: key,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'AnnouncementRoute';
+  static const String name = 'HardMuteRoute';
 
-  static const PageInfo<AnnouncementRouteArgs> page =
-      PageInfo<AnnouncementRouteArgs>(name);
+  static const PageInfo<HardMuteRouteArgs> page =
+      PageInfo<HardMuteRouteArgs>(name);
 }
 
-class AnnouncementRouteArgs {
-  const AnnouncementRouteArgs({
+class HardMuteRouteArgs {
+  const HardMuteRouteArgs({
     this.key,
     required this.account,
   });
@@ -1006,22 +1409,84 @@ class AnnouncementRouteArgs {
 
   @override
   String toString() {
-    return 'AnnouncementRouteArgs{key: $key, account: $account}';
+    return 'HardMuteRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [SplashPage]
-class SplashRoute extends PageRouteInfo<void> {
-  const SplashRoute({List<PageRouteInfo>? children})
-      : super(
-          SplashRoute.name,
+/// [InstanceMutePage]
+class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
+  InstanceMuteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          InstanceMuteRoute.name,
+          args: InstanceMuteRouteArgs(
+            key: key,
+            account: account,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'SplashRoute';
+  static const String name = 'InstanceMuteRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static const PageInfo<InstanceMuteRouteArgs> page =
+      PageInfo<InstanceMuteRouteArgs>(name);
+}
+
+class InstanceMuteRouteArgs {
+  const InstanceMuteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ReactionDeckPage]
+class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
+  ReactionDeckRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ReactionDeckRoute.name,
+          args: ReactionDeckRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ReactionDeckRoute';
+
+  static const PageInfo<ReactionDeckRouteArgs> page =
+      PageInfo<ReactionDeckRouteArgs>(name);
+}
+
+class ReactionDeckRouteArgs {
+  const ReactionDeckRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
+  }
 }
 
 /// generated route for
@@ -1103,197 +1568,98 @@ class SeveralAccountSettingsRouteArgs {
 }
 
 /// generated route for
-/// [InstanceMutePage]
-class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
-  InstanceMuteRoute({
+/// [SharingAccountSelectPage]
+class SharingAccountSelectRoute
+    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
+  SharingAccountSelectRoute({
     Key? key,
-    required Account account,
+    String? sharingText,
+    List<String>? filePath,
     List<PageRouteInfo>? children,
   }) : super(
-          InstanceMuteRoute.name,
-          args: InstanceMuteRouteArgs(
+          SharingAccountSelectRoute.name,
+          args: SharingAccountSelectRouteArgs(
             key: key,
-            account: account,
+            sharingText: sharingText,
+            filePath: filePath,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'InstanceMuteRoute';
+  static const String name = 'SharingAccountSelectRoute';
 
-  static const PageInfo<InstanceMuteRouteArgs> page =
-      PageInfo<InstanceMuteRouteArgs>(name);
+  static const PageInfo<SharingAccountSelectRouteArgs> page =
+      PageInfo<SharingAccountSelectRouteArgs>(name);
 }
 
-class InstanceMuteRouteArgs {
-  const InstanceMuteRouteArgs({
+class SharingAccountSelectRouteArgs {
+  const SharingAccountSelectRouteArgs({
     this.key,
-    required this.account,
+    this.sharingText,
+    this.filePath,
   });
 
   final Key? key;
 
-  final Account account;
+  final String? sharingText;
+
+  final List<String>? filePath;
 
   @override
   String toString() {
-    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
   }
 }
 
 /// generated route for
-/// [HardMutePage]
-class HardMuteRoute extends PageRouteInfo<HardMuteRouteArgs> {
-  HardMuteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          HardMuteRoute.name,
-          args: HardMuteRouteArgs(
-            key: key,
-            account: account,
-          ),
+/// [SplashPage]
+class SplashRoute extends PageRouteInfo<void> {
+  const SplashRoute({List<PageRouteInfo>? children})
+      : super(
+          SplashRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'HardMuteRoute';
+  static const String name = 'SplashRoute';
 
-  static const PageInfo<HardMuteRouteArgs> page =
-      PageInfo<HardMuteRouteArgs>(name);
-}
-
-class HardMuteRouteArgs {
-  const HardMuteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'HardMuteRouteArgs{key: $key, account: $account}';
-  }
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for
-/// [ReactionDeckPage]
-class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
-  ReactionDeckRoute({
+/// [TimeLinePage]
+class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
+  TimeLineRoute({
     Key? key,
-    required Account account,
+    required TabSetting initialTabSetting,
     List<PageRouteInfo>? children,
   }) : super(
-          ReactionDeckRoute.name,
-          args: ReactionDeckRouteArgs(
+          TimeLineRoute.name,
+          args: TimeLineRouteArgs(
             key: key,
-            account: account,
+            initialTabSetting: initialTabSetting,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ReactionDeckRoute';
+  static const String name = 'TimeLineRoute';
 
-  static const PageInfo<ReactionDeckRouteArgs> page =
-      PageInfo<ReactionDeckRouteArgs>(name);
+  static const PageInfo<TimeLineRouteArgs> page =
+      PageInfo<TimeLineRouteArgs>(name);
 }
 
-class ReactionDeckRouteArgs {
-  const ReactionDeckRouteArgs({
+class TimeLineRouteArgs {
+  const TimeLineRouteArgs({
     this.key,
-    required this.account,
+    required this.initialTabSetting,
   });
 
   final Key? key;
 
-  final Account account;
+  final TabSetting initialTabSetting;
 
   @override
   String toString() {
-    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UsersListTimelinePage]
-class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
-  UsersListTimelineRoute({
-    required Account account,
-    required UsersList list,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListTimelineRoute.name,
-          args: UsersListTimelineRouteArgs(
-            account: account,
-            list: list,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListTimelineRoute';
-
-  static const PageInfo<UsersListTimelineRouteArgs> page =
-      PageInfo<UsersListTimelineRouteArgs>(name);
-}
-
-class UsersListTimelineRouteArgs {
-  const UsersListTimelineRouteArgs({
-    required this.account,
-    required this.list,
-    this.key,
-  });
-
-  final Account account;
-
-  final UsersList list;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'UsersListTimelineRouteArgs{account: $account, list: $list, key: $key}';
-  }
-}
-
-/// generated route for
-/// [UsersListPage]
-class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
-  UsersListRoute({
-    required Account account,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListRoute.name,
-          args: UsersListRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListRoute';
-
-  static const PageInfo<UsersListRouteArgs> page =
-      PageInfo<UsersListRouteArgs>(name);
-}
-
-class UsersListRouteArgs {
-  const UsersListRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'UsersListRouteArgs{account: $account, key: $key}';
+    return 'TimeLineRouteArgs{key: $key, initialTabSetting: $initialTabSetting}';
   }
 }
 
@@ -1341,576 +1707,210 @@ class UsersListDetailRouteArgs {
 }
 
 /// generated route for
-/// [ChannelDetailPage]
-class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
-  ChannelDetailRoute({
-    Key? key,
+/// [UsersListPage]
+class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
+  UsersListRoute({
     required Account account,
-    required String channelId,
+    Key? key,
     List<PageRouteInfo>? children,
   }) : super(
-          ChannelDetailRoute.name,
-          args: ChannelDetailRouteArgs(
-            key: key,
+          UsersListRoute.name,
+          args: UsersListRouteArgs(
             account: account,
-            channelId: channelId,
+            key: key,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ChannelDetailRoute';
+  static const String name = 'UsersListRoute';
 
-  static const PageInfo<ChannelDetailRouteArgs> page =
-      PageInfo<ChannelDetailRouteArgs>(name);
+  static const PageInfo<UsersListRouteArgs> page =
+      PageInfo<UsersListRouteArgs>(name);
 }
 
-class ChannelDetailRouteArgs {
-  const ChannelDetailRouteArgs({
-    this.key,
+class UsersListRouteArgs {
+  const UsersListRouteArgs({
     required this.account,
-    required this.channelId,
+    this.key,
   });
-
-  final Key? key;
 
   final Account account;
 
-  final String channelId;
+  final Key? key;
 
   @override
   String toString() {
-    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
+    return 'UsersListRouteArgs{account: $account, key: $key}';
   }
 }
 
 /// generated route for
-/// [ChannelsPage]
-class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
-  ChannelsRoute({
-    Key? key,
+/// [UsersListTimelinePage]
+class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
+  UsersListTimelineRoute({
     required Account account,
+    required UsersList list,
+    Key? key,
     List<PageRouteInfo>? children,
   }) : super(
-          ChannelsRoute.name,
-          args: ChannelsRouteArgs(
-            key: key,
+          UsersListTimelineRoute.name,
+          args: UsersListTimelineRouteArgs(
             account: account,
+            list: list,
+            key: key,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ChannelsRoute';
+  static const String name = 'UsersListTimelineRoute';
 
-  static const PageInfo<ChannelsRouteArgs> page =
-      PageInfo<ChannelsRouteArgs>(name);
+  static const PageInfo<UsersListTimelineRouteArgs> page =
+      PageInfo<UsersListTimelineRouteArgs>(name);
 }
 
-class ChannelsRouteArgs {
-  const ChannelsRouteArgs({
-    this.key,
+class UsersListTimelineRouteArgs {
+  const UsersListTimelineRouteArgs({
     required this.account,
+    required this.list,
+    this.key,
   });
-
-  final Key? key;
 
   final Account account;
 
+  final UsersList list;
+
+  final Key? key;
+
   @override
   String toString() {
-    return 'ChannelsRouteArgs{key: $key, account: $account}';
+    return 'UsersListTimelineRouteArgs{account: $account, list: $list, key: $key}';
   }
 }
 
 /// generated route for
-/// [FederationPage]
-class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
-  FederationRoute({
+/// [UserFolloweePage]
+class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
+  UserFolloweeRoute({
     Key? key,
-    required Account account,
-    required String host,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FederationRoute.name,
-          args: FederationRouteArgs(
-            key: key,
-            account: account,
-            host: host,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FederationRoute';
-
-  static const PageInfo<FederationRouteArgs> page =
-      PageInfo<FederationRouteArgs>(name);
-}
-
-class FederationRouteArgs {
-  const FederationRouteArgs({
-    this.key,
-    required this.account,
-    required this.host,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String host;
-
-  @override
-  String toString() {
-    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
-  }
-}
-
-/// generated route for
-/// [NoteDetailPage]
-class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
-  NoteDetailRoute({
-    Key? key,
-    required Note note,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NoteDetailRoute.name,
-          args: NoteDetailRouteArgs(
+          UserFolloweeRoute.name,
+          args: UserFolloweeRouteArgs(
             key: key,
-            note: note,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NoteDetailRoute';
+  static const String name = 'UserFolloweeRoute';
 
-  static const PageInfo<NoteDetailRouteArgs> page =
-      PageInfo<NoteDetailRouteArgs>(name);
+  static const PageInfo<UserFolloweeRouteArgs> page =
+      PageInfo<UserFolloweeRouteArgs>(name);
 }
 
-class NoteDetailRouteArgs {
-  const NoteDetailRouteArgs({
+class UserFolloweeRouteArgs {
+  const UserFolloweeRouteArgs({
     this.key,
-    required this.note,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final Note note;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
+    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }
 
 /// generated route for
-/// [SearchPage]
-class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
-  SearchRoute({
+/// [UserFollowerPage]
+class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
+  UserFollowerRoute({
     Key? key,
-    String? initialSearchText,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          SearchRoute.name,
-          args: SearchRouteArgs(
+          UserFollowerRoute.name,
+          args: UserFollowerRouteArgs(
             key: key,
-            initialSearchText: initialSearchText,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'SearchRoute';
+  static const String name = 'UserFollowerRoute';
 
-  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+  static const PageInfo<UserFollowerRouteArgs> page =
+      PageInfo<UserFollowerRouteArgs>(name);
 }
 
-class SearchRouteArgs {
-  const SearchRouteArgs({
+class UserFollowerRouteArgs {
+  const UserFollowerRouteArgs({
     this.key,
-    this.initialSearchText,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String? initialSearchText;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
+    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }
 
 /// generated route for
-/// [SharingAccountSelectPage]
-class SharingAccountSelectRoute
-    extends PageRouteInfo<SharingAccountSelectRouteArgs> {
-  SharingAccountSelectRoute({
+/// [UserPage]
+class UserRoute extends PageRouteInfo<UserRouteArgs> {
+  UserRoute({
     Key? key,
-    String? sharingText,
-    List<String>? filePath,
-    List<PageRouteInfo>? children,
-  }) : super(
-          SharingAccountSelectRoute.name,
-          args: SharingAccountSelectRouteArgs(
-            key: key,
-            sharingText: sharingText,
-            filePath: filePath,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'SharingAccountSelectRoute';
-
-  static const PageInfo<SharingAccountSelectRouteArgs> page =
-      PageInfo<SharingAccountSelectRouteArgs>(name);
-}
-
-class SharingAccountSelectRouteArgs {
-  const SharingAccountSelectRouteArgs({
-    this.key,
-    this.sharingText,
-    this.filePath,
-  });
-
-  final Key? key;
-
-  final String? sharingText;
-
-  final List<String>? filePath;
-
-  @override
-  String toString() {
-    return 'SharingAccountSelectRouteArgs{key: $key, sharingText: $sharingText, filePath: $filePath}';
-  }
-}
-
-/// generated route for
-/// [ImportExportPage]
-class ImportExportRoute extends PageRouteInfo<void> {
-  const ImportExportRoute({List<PageRouteInfo>? children})
-      : super(
-          ImportExportRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'ImportExportRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [GeneralSettingsPage]
-class GeneralSettingsRoute extends PageRouteInfo<void> {
-  const GeneralSettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          GeneralSettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'GeneralSettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [TabSettingsPage]
-class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
-  TabSettingsRoute({
-    Key? key,
-    int? tabIndex,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TabSettingsRoute.name,
-          args: TabSettingsRouteArgs(
-            key: key,
-            tabIndex: tabIndex,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsRoute';
-
-  static const PageInfo<TabSettingsRouteArgs> page =
-      PageInfo<TabSettingsRouteArgs>(name);
-}
-
-class TabSettingsRouteArgs {
-  const TabSettingsRouteArgs({
-    this.key,
-    this.tabIndex,
-  });
-
-  final Key? key;
-
-  final int? tabIndex;
-
-  @override
-  String toString() {
-    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
-  }
-}
-
-/// generated route for
-/// [TabSettingsListPage]
-class TabSettingsListRoute extends PageRouteInfo<void> {
-  const TabSettingsListRoute({List<PageRouteInfo>? children})
-      : super(
-          TabSettingsListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AppInfoPage]
-class AppInfoRoute extends PageRouteInfo<void> {
-  const AppInfoRoute({List<PageRouteInfo>? children})
-      : super(
-          AppInfoRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AppInfoRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [SettingsPage]
-class SettingsRoute extends PageRouteInfo<void> {
-  const SettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          SettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'SettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AccountListPage]
-class AccountListRoute extends PageRouteInfo<void> {
-  const AccountListRoute({List<PageRouteInfo>? children})
-      : super(
-          AccountListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AccountListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [ExploreRoleUsersPage]
-class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
-  ExploreRoleUsersRoute({
-    Key? key,
-    required RolesListResponse item,
+    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          ExploreRoleUsersRoute.name,
-          args: ExploreRoleUsersRouteArgs(
+          UserRoute.name,
+          args: UserRouteArgs(
             key: key,
-            item: item,
+            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'ExploreRoleUsersRoute';
+  static const String name = 'UserRoute';
 
-  static const PageInfo<ExploreRoleUsersRouteArgs> page =
-      PageInfo<ExploreRoleUsersRouteArgs>(name);
+  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
 }
 
-class ExploreRoleUsersRouteArgs {
-  const ExploreRoleUsersRouteArgs({
+class UserRouteArgs {
+  const UserRouteArgs({
     this.key,
-    required this.item,
+    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final RolesListResponse item;
+  final String userId;
 
   final Account account;
 
   @override
   String toString() {
-    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ExplorePage]
-class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
-  ExploreRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoute.name,
-          args: ExploreRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoute';
-
-  static const PageInfo<ExploreRouteArgs> page =
-      PageInfo<ExploreRouteArgs>(name);
-}
-
-class ExploreRouteArgs {
-  const ExploreRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [TimeLinePage]
-class TimeLineRoute extends PageRouteInfo<TimeLineRouteArgs> {
-  TimeLineRoute({
-    Key? key,
-    required TabSetting initialTabSetting,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TimeLineRoute.name,
-          args: TimeLineRouteArgs(
-            key: key,
-            initialTabSetting: initialTabSetting,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TimeLineRoute';
-
-  static const PageInfo<TimeLineRouteArgs> page =
-      PageInfo<TimeLineRouteArgs>(name);
-}
-
-class TimeLineRouteArgs {
-  const TimeLineRouteArgs({
-    this.key,
-    required this.initialTabSetting,
-  });
-
-  final Key? key;
-
-  final TabSetting initialTabSetting;
-
-  @override
-  String toString() {
-    return 'TimeLineRouteArgs{key: $key, initialTabSetting: $initialTabSetting}';
-  }
-}
-
-/// generated route for
-/// [FavoritedNotePage]
-class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
-  FavoritedNoteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FavoritedNoteRoute.name,
-          args: FavoritedNoteRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FavoritedNoteRoute';
-
-  static const PageInfo<FavoritedNoteRouteArgs> page =
-      PageInfo<FavoritedNoteRouteArgs>(name);
-}
-
-class FavoritedNoteRouteArgs {
-  const FavoritedNoteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [MisskeyPagePage]
-class MisskeyRouteRoute extends PageRouteInfo<MisskeyRouteRouteArgs> {
-  MisskeyRouteRoute({
-    Key? key,
-    required Account account,
-    required Page page,
-    List<PageRouteInfo>? children,
-  }) : super(
-          MisskeyRouteRoute.name,
-          args: MisskeyRouteRouteArgs(
-            key: key,
-            account: account,
-            page: page,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'MisskeyRouteRoute';
-
-  static const PageInfo<MisskeyRouteRouteArgs> page =
-      PageInfo<MisskeyRouteRouteArgs>(name);
-}
-
-class MisskeyRouteRouteArgs {
-  const MisskeyRouteRouteArgs({
-    this.key,
-    required this.account,
-    required this.page,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final Page page;
-
-  @override
-  String toString() {
-    return 'MisskeyRouteRouteArgs{key: $key, account: $account, page: $page}';
+    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }

--- a/lib/view/common/common_drawer.dart
+++ b/lib/view/common/common_drawer.dart
@@ -1,6 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:miria/model/account.dart';
+import 'package:miria/model/acct.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
 import 'package:miria/view/common/account_scope.dart';
@@ -9,9 +9,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/view/common/misskey_notes/mfm_text.dart';
 
 class CommonDrawer extends ConsumerWidget {
-  final Account initialOpenAccount;
+  final Acct initialOpenAcct;
 
-  const CommonDrawer({super.key, required this.initialOpenAccount});
+  const CommonDrawer({super.key, required this.initialOpenAcct});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -25,9 +25,7 @@ class CommonDrawer extends ConsumerWidget {
                 account: account,
                 child: ExpansionTile(
                     leading: AvatarIcon.fromIResponse(account.i),
-                    initiallyExpanded:
-                        account.userId == initialOpenAccount.userId &&
-                            account.host == initialOpenAccount.host,
+                    initiallyExpanded: account.acct == initialOpenAcct,
                     title: SimpleMfmText(account.i.name ?? account.i.username,
                         style: Theme.of(context).textTheme.titleMedium),
                     subtitle: Text(

--- a/lib/view/settings_page/tab_settings_page/tab_settings_list_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_list_page.dart
@@ -1,4 +1,3 @@
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/model/tab_setting.dart';
@@ -46,14 +45,18 @@ class TabSettingsListPageState extends ConsumerState<TabSettingsListPage> {
           Expanded(
             child: ReorderableListView.builder(
                 itemBuilder: (context, index) {
+                  final tabSetting = tabSettings[index];
+                  final account = ref.watch(accountProvider(tabSetting.acct));
                   return ListTile(
                     key: Key("$index"),
                     leading: AccountScope(
-                        account: tabSettings[index].account,
-                        child: TabIconView(icon: tabSettings[index].icon)),
+                      account: account,
+                      child: TabIconView(icon: tabSettings[index].icon),
+                    ),
                     title: Text(tabSettings[index].name),
                     subtitle: Text(
-                        "${tabSettings[index].tabType.displayName} / @${tabSettings[index].account.userId}@${tabSettings[index].account.host} "),
+                      "${tabSetting.tabType.displayName} / ${account.acct}",
+                    ),
                     onTap: () =>
                         context.pushRoute(TabSettingsRoute(tabIndex: index)),
                   );

--- a/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
@@ -54,7 +54,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
     if (tab != null) {
       final tabSetting =
           ref.read(tabSettingsRepositoryProvider).tabSettings.toList()[tab];
-      selectedAccount = tabSetting.account;
+      selectedAccount = ref.read(accountProvider(tabSetting.acct));
       selectedTabType = tabSetting.tabType;
       final roleId = tabSetting.roleId;
       final channelId = tabSetting.channelId;
@@ -69,7 +69,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
       if (roleId != null) {
         Future(() async {
           selectedRole = await ref
-              .read(misskeyProvider(tabSetting.account))
+              .read(misskeyProvider(selectedAccount!))
               .roles
               .show(RolesShowRequest(roleId: roleId));
           setState(() {});
@@ -78,7 +78,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
       if (channelId != null) {
         Future(() async {
           selectedChannel = await ref
-              .read(misskeyProvider(tabSetting.account))
+              .read(misskeyProvider(selectedAccount!))
               .channels
               .show(ChannelsShowRequest(channelId: channelId));
           setState(() {});
@@ -87,7 +87,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
       if (listId != null) {
         Future(() async {
           final response = await ref
-              .read(misskeyProvider(tabSetting.account))
+              .read(misskeyProvider(selectedAccount!))
               .users
               .list
               .show(UsersListsShowRequest(listId: listId));
@@ -98,7 +98,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
       if (antennaId != null) {
         Future(() async {
           selectedAntenna = await ref
-              .read(misskeyProvider(tabSetting.account))
+              .read(misskeyProvider(selectedAccount!))
               .antennas
               .show(AntennasShowRequest(antennaId: antennaId));
           setState(() {});
@@ -381,7 +381,7 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
                       icon: icon,
                       tabType: tabType,
                       name: nameController.text,
-                      account: account,
+                      acct: account.acct,
                       roleId: selectedRole?.id,
                       channelId: selectedChannel?.id,
                       listId: selectedUserList?.id,

--- a/lib/view/time_line_page/time_line_page.dart
+++ b/lib/view/time_line_page/time_line_page.dart
@@ -70,11 +70,12 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
     try {
       final accountSettings = ref
           .read(accountSettingsRepositoryProvider)
-          .fromAccount(currentTabSetting.account);
+          .fromAcct(currentTabSetting.acct);
       ref.read(timelineNoteProvider).clear();
       FocusManager.instance.primaryFocus?.unfocus();
 
-      await ref.read(misskeyProvider(currentTabSetting.account)).notes.create(
+      final account = ref.read(accountProvider(currentTabSetting.acct));
+      await ref.read(misskeyProvider(account)).notes.create(
             NotesCreateRequest(
               text: text,
               channelId: currentTabSetting.channelId,
@@ -143,46 +144,49 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
     }
     final sendText = ref.read(timelineNoteProvider).text;
     ref.read(timelineNoteProvider).text = "";
+    final account = ref.read(accountProvider(currentTabSetting.acct));
     context.pushRoute(NoteCreateRoute(
       channel: channel,
       initialText: sendText,
-      initialAccount: currentTabSetting.account,
+      initialAccount: account,
     ));
   }
 
   Widget buildAppbar() {
+    final account = ref.watch(accountProvider(currentTabSetting.acct));
     return AppBar(
       title: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Row(
-          children: tabSettings
-              .mapIndexed(
-                (index, tabSetting) => Ink(
-                  color: tabSetting == currentTabSetting
-                      ? AppTheme.of(context).currentDisplayTabColor
-                      : Colors.transparent,
-                  child: AccountScope(
-                    account: tabSetting.account,
-                    child: IconButton(
-                      icon: TabIconView(
-                        icon: tabSetting.icon,
-                        color: tabSetting == currentTabSetting
-                            ? Theme.of(context).primaryColor
-                            : Colors.white,
-                      ),
-                      onPressed: () => tabSetting == currentTabSetting
-                          ? reload()
-                          : pageController.jumpToPage(index),
+          children: tabSettings.mapIndexed(
+            (index, tabSetting) {
+              final account = ref.watch(accountProvider(tabSetting.acct));
+              return Ink(
+                color: tabSetting == currentTabSetting
+                    ? AppTheme.of(context).currentDisplayTabColor
+                    : Colors.transparent,
+                child: AccountScope(
+                  account: account,
+                  child: IconButton(
+                    icon: TabIconView(
+                      icon: tabSetting.icon,
+                      color: tabSetting == currentTabSetting
+                          ? Theme.of(context).primaryColor
+                          : Colors.white,
                     ),
+                    onPressed: () => tabSetting == currentTabSetting
+                        ? reload()
+                        : pageController.jumpToPage(index),
                   ),
                 ),
-              )
-              .toList(),
+              );
+            },
+          ).toList(),
         ),
       ),
       actions: [
         AccountScope(
-          account: currentTabSetting.account,
+          account: account,
           child: const NotificationIcon(),
         ),
       ],
@@ -201,6 +205,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
     tabSettings = ref.watch(
       tabSettingsRepositoryProvider.select((repo) => repo.tabSettings.toList()),
     );
+    final account = ref.watch(accountProvider(currentTabSetting.acct));
 
     return Scaffold(
       key: scaffoldKey,
@@ -244,7 +249,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                           context: context,
                           builder: (context) => ChannelDialog(
                             channelId: currentTabSetting.channelId ?? "",
-                            account: currentTabSetting.account,
+                            account: account,
                           ),
                         );
                       },
@@ -256,7 +261,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                       onPressed: () {
                         context.pushRoute(
                           UsersListDetailRoute(
-                            account: currentTabSetting.account,
+                            account: account,
                             listId: currentTabSetting.listId!,
                           ),
                         );
@@ -274,7 +279,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                         showDialog(
                           context: context,
                           builder: (context) => ServerDetailDialog(
-                            account: currentTabSetting.account,
+                            account: account,
                           ),
                         );
                       },
@@ -316,8 +321,9 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                 onPageChanged: (index) => changeTab(index),
                 itemBuilder: (_, index) {
                   final tabSetting = tabSettings[index];
+                  final account = ref.watch(accountProvider(tabSetting.acct));
                   return AccountScope(
-                    account: tabSetting.account,
+                    account: account,
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -374,7 +380,7 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
       resizeToAvoidBottomInset: true,
       drawerEnableOpenDragGesture: true,
       drawer: CommonDrawer(
-        initialOpenAccount: currentTabSetting.account,
+        initialOpenAcct: currentTabSetting.acct,
       ),
     );
   }
@@ -387,22 +393,19 @@ class BannerArea extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final bannerAnnouncement = ref.watch(accountRepository.select((value) =>
-        value.account
-            .where((element) =>
-                element ==
-                ref
-                    .read(tabSettingsRepositoryProvider)
-                    .tabSettings
-                    .toList()[index]
-                    .account)
-            .firstOrNull
-            ?.i
-            .unreadAnnouncements));
+    final acct = ref.watch(
+      tabSettingsRepositoryProvider
+          .select((repository) => repository.tabSettings.toList()[index].acct),
+    );
+    final bannerAnnouncement = ref.watch(
+      accountProvider(acct).select(
+        (account) => account.i.unreadAnnouncements,
+      ),
+    );
 
     // ダイアログの実装が大変なので（状態管理とか）いったんバナーと一緒に扱う
     final bannerData = bannerAnnouncement
-        ?.where((element) =>
+        .where((element) =>
             element.display == AnnouncementDisplayType.banner ||
             element.display == AnnouncementDisplayType.dialog)
         .lastOrNull;
@@ -437,34 +440,25 @@ class AnnoucementInfo extends ConsumerWidget {
   const AnnoucementInfo({super.key, required this.index});
 
   void announcementsRoute(BuildContext context, WidgetRef ref) {
-    final account = ref.read(accountRepository.select((value) => value.account
-        .where((element) =>
-            element ==
-            ref
-                .read(tabSettingsRepositoryProvider)
-                .tabSettings
-                .toList()[index]
-                .account)
-        .firstOrNull));
-    if (account == null) return;
+    final acct = ref
+        .read(tabSettingsRepositoryProvider)
+        .tabSettings
+        .toList()[index]
+        .acct;
+    final account = ref.read(accountProvider(acct));
     context.pushRoute(AnnouncementRoute(account: account));
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final hasUnread = ref.watch(accountRepository.select((value) => value
-        .account
-        .where((element) =>
-            element ==
-            ref
-                .read(tabSettingsRepositoryProvider)
-                .tabSettings
-                .toList()[index]
-                .account)
-        .firstOrNull
-        ?.i
-        .unreadAnnouncements
-        .isNotEmpty));
+    final acct = ref.watch(
+      tabSettingsRepositoryProvider
+          .select((repository) => repository.tabSettings.toList()[index].acct),
+    );
+    final hasUnread = ref.watch(
+      accountProvider(acct)
+          .select((account) => account.i.unreadAnnouncements.isNotEmpty),
+    );
 
     if (hasUnread == true) {
       return IconButton(

--- a/test/test_util/mock.mocks.dart
+++ b/test/test_util/mock.mocks.dart
@@ -5,25 +5,26 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i18;
 import 'dart:io' as _i15;
-import 'dart:typed_data' as _i25;
+import 'dart:typed_data' as _i26;
 import 'dart:ui' as _i20;
 
-import 'package:dio/dio.dart' as _i26;
+import 'package:dio/dio.dart' as _i27;
 import 'package:dio/src/adapter.dart' as _i11;
-import 'package:dio/src/cancel_token.dart' as _i27;
+import 'package:dio/src/cancel_token.dart' as _i28;
 import 'package:dio/src/dio_mixin.dart' as _i13;
 import 'package:dio/src/options.dart' as _i10;
 import 'package:dio/src/response.dart' as _i14;
 import 'package:dio/src/transformer.dart' as _i12;
-import 'package:file_picker/file_picker.dart' as _i29;
+import 'package:file_picker/file_picker.dart' as _i30;
 import 'package:miria/model/account.dart' as _i19;
 import 'package:miria/model/account_settings.dart' as _i2;
+import 'package:miria/model/acct.dart' as _i22;
 import 'package:miria/model/general_settings.dart' as _i3;
-import 'package:miria/model/misskey_emoji_data.dart' as _i23;
+import 'package:miria/model/misskey_emoji_data.dart' as _i24;
 import 'package:miria/model/tab_setting.dart' as _i17;
 import 'package:miria/repository/account_settings_repository.dart' as _i21;
-import 'package:miria/repository/emoji_repository.dart' as _i22;
-import 'package:miria/repository/general_settings_repository.dart' as _i24;
+import 'package:miria/repository/emoji_repository.dart' as _i23;
+import 'package:miria/repository/general_settings_repository.dart' as _i25;
 import 'package:miria/repository/tab_settings_repository.dart' as _i16;
 import 'package:misskey_dart/misskey_dart.dart' as _i6;
 import 'package:misskey_dart/src/data/ping_response.dart' as _i9;
@@ -33,7 +34,7 @@ import 'package:misskey_dart/src/services/api_service.dart' as _i4;
 import 'package:misskey_dart/src/services/streaming_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 
-import 'mock.dart' as _i28;
+import 'mock.dart' as _i29;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -673,21 +674,6 @@ class MockTabSettingsRepository extends _i1.Mock
         returnValueForMissingStub: _i18.Future<void>.value(),
       ) as _i18.Future<void>);
   @override
-  void updateAccount(
-    _i19.Account? account,
-    _i6.IResponse? response,
-  ) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #updateAccount,
-          [
-            account,
-            response,
-          ],
-        ),
-        returnValueForMissingStub: null,
-      );
-  @override
   _i18.Future<void> save(List<_i17.TabSetting>? tabSettings) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -785,6 +771,27 @@ class MockAccountSettingsRepository extends _i1.Mock
         returnValueForMissingStub: _i18.Future<void>.value(),
       ) as _i18.Future<void>);
   @override
+  _i2.AccountSettings fromAcct(_i22.Acct? acct) => (super.noSuchMethod(
+        Invocation.method(
+          #fromAcct,
+          [acct],
+        ),
+        returnValue: _FakeAccountSettings_0(
+          this,
+          Invocation.method(
+            #fromAcct,
+            [acct],
+          ),
+        ),
+        returnValueForMissingStub: _FakeAccountSettings_0(
+          this,
+          Invocation.method(
+            #fromAcct,
+            [acct],
+          ),
+        ),
+      ) as _i2.AccountSettings);
+  @override
   _i2.AccountSettings fromAccount(_i19.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #fromAccount,
@@ -842,9 +849,9 @@ class MockAccountSettingsRepository extends _i1.Mock
 /// A class which mocks [EmojiRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEmojiRepository extends _i1.Mock implements _i22.EmojiRepository {
+class MockEmojiRepository extends _i1.Mock implements _i23.EmojiRepository {
   @override
-  set emoji(List<_i22.EmojiRepositoryData>? _emoji) => super.noSuchMethod(
+  set emoji(List<_i23.EmojiRepositoryData>? _emoji) => super.noSuchMethod(
         Invocation.setter(
           #emoji,
           _emoji,
@@ -879,7 +886,7 @@ class MockEmojiRepository extends _i1.Mock implements _i22.EmojiRepository {
         returnValueForMissingStub: _i18.Future<void>.value(),
       ) as _i18.Future<void>);
   @override
-  _i18.Future<List<_i23.MisskeyEmojiData>> searchEmojis(
+  _i18.Future<List<_i24.MisskeyEmojiData>> searchEmojis(
     String? name, {
     int? limit = 30,
   }) =>
@@ -889,30 +896,30 @@ class MockEmojiRepository extends _i1.Mock implements _i22.EmojiRepository {
           [name],
           {#limit: limit},
         ),
-        returnValue: _i18.Future<List<_i23.MisskeyEmojiData>>.value(
-            <_i23.MisskeyEmojiData>[]),
+        returnValue: _i18.Future<List<_i24.MisskeyEmojiData>>.value(
+            <_i24.MisskeyEmojiData>[]),
         returnValueForMissingStub:
-            _i18.Future<List<_i23.MisskeyEmojiData>>.value(
-                <_i23.MisskeyEmojiData>[]),
-      ) as _i18.Future<List<_i23.MisskeyEmojiData>>);
+            _i18.Future<List<_i24.MisskeyEmojiData>>.value(
+                <_i24.MisskeyEmojiData>[]),
+      ) as _i18.Future<List<_i24.MisskeyEmojiData>>);
   @override
-  List<_i23.MisskeyEmojiData> defaultEmojis({int? limit}) =>
+  List<_i24.MisskeyEmojiData> defaultEmojis({int? limit}) =>
       (super.noSuchMethod(
         Invocation.method(
           #defaultEmojis,
           [],
           {#limit: limit},
         ),
-        returnValue: <_i23.MisskeyEmojiData>[],
-        returnValueForMissingStub: <_i23.MisskeyEmojiData>[],
-      ) as List<_i23.MisskeyEmojiData>);
+        returnValue: <_i24.MisskeyEmojiData>[],
+        returnValueForMissingStub: <_i24.MisskeyEmojiData>[],
+      ) as List<_i24.MisskeyEmojiData>);
 }
 
 /// A class which mocks [GeneralSettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGeneralSettingsRepository extends _i1.Mock
-    implements _i24.GeneralSettingsRepository {
+    implements _i25.GeneralSettingsRepository {
   @override
   _i3.GeneralSettings get settings => (super.noSuchMethod(
         Invocation.getter(#settings),
@@ -2912,7 +2919,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i6.MisskeyDriveFiles {
   @override
   _i18.Future<_i6.DriveFile> createAsBinary(
     _i6.DriveFilesCreateRequest? request,
-    _i25.Uint8List? fileContent,
+    _i26.Uint8List? fileContent,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3989,7 +3996,7 @@ class MockMisskeyUsers extends _i1.Mock implements _i6.MisskeyUsers {
 /// A class which mocks [Dio].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDio extends _i1.Mock implements _i26.Dio {
+class MockDio extends _i1.Mock implements _i27.Dio {
   @override
   _i10.BaseOptions get options => (super.noSuchMethod(
         Invocation.getter(#options),
@@ -4078,7 +4085,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
@@ -4128,7 +4135,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Uri? uri, {
     Object? data,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
@@ -4176,7 +4183,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
@@ -4230,7 +4237,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Uri? uri, {
     Object? data,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
@@ -4282,7 +4289,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
@@ -4336,7 +4343,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Uri? uri, {
     Object? data,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
@@ -4388,7 +4395,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4434,7 +4441,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Uri? uri, {
     Object? data,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4478,7 +4485,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4524,7 +4531,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Uri? uri, {
     Object? data,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4568,7 +4575,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
@@ -4622,7 +4629,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Uri? uri, {
     Object? data,
     _i10.Options? options,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
   }) =>
@@ -4674,7 +4681,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     dynamic savePath, {
     _i10.ProgressCallback? onReceiveProgress,
     Map<String, dynamic>? queryParameters,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     bool? deleteOnError = true,
     String? lengthHeader = r'content-length',
     Object? data,
@@ -4743,7 +4750,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     Uri? uri,
     dynamic savePath, {
     _i10.ProgressCallback? onReceiveProgress,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     bool? deleteOnError = true,
     String? lengthHeader = r'content-length',
     Object? data,
@@ -4809,7 +4816,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.Options? options,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
@@ -4863,7 +4870,7 @@ class MockDio extends _i1.Mock implements _i26.Dio {
   _i18.Future<_i14.Response<T>> requestUri<T>(
     Uri? uri, {
     Object? data,
-    _i27.CancelToken? cancelToken,
+    _i28.CancelToken? cancelToken,
     _i10.Options? options,
     _i10.ProgressCallback? onSendProgress,
     _i10.ProgressCallback? onReceiveProgress,
@@ -5580,14 +5587,14 @@ class MockHttpClient extends _i1.Mock implements _i15.HttpClient {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFilePickerPlatform extends _i1.Mock
-    implements _i28.FakeFilePickerPlatform {
+    implements _i29.FakeFilePickerPlatform {
   @override
-  _i18.Future<_i29.FilePickerResult?> pickFiles({
+  _i18.Future<_i30.FilePickerResult?> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
-    _i29.FileType? type = _i29.FileType.any,
+    _i30.FileType? type = _i30.FileType.any,
     List<String>? allowedExtensions,
-    dynamic Function(_i29.FilePickerStatus)? onFileLoading,
+    dynamic Function(_i30.FilePickerStatus)? onFileLoading,
     bool? allowCompression = true,
     bool? allowMultiple = false,
     bool? withData = false,
@@ -5611,9 +5618,9 @@ class MockFilePickerPlatform extends _i1.Mock
             #lockParentWindow: lockParentWindow,
           },
         ),
-        returnValue: _i18.Future<_i29.FilePickerResult?>.value(),
-        returnValueForMissingStub: _i18.Future<_i29.FilePickerResult?>.value(),
-      ) as _i18.Future<_i29.FilePickerResult?>);
+        returnValue: _i18.Future<_i30.FilePickerResult?>.value(),
+        returnValueForMissingStub: _i18.Future<_i30.FilePickerResult?>.value(),
+      ) as _i18.Future<_i30.FilePickerResult?>);
   @override
   _i18.Future<bool?> clearTemporaryFiles() => (super.noSuchMethod(
         Invocation.method(
@@ -5647,7 +5654,7 @@ class MockFilePickerPlatform extends _i1.Mock
     String? dialogTitle,
     String? fileName,
     String? initialDirectory,
-    _i29.FileType? type = _i29.FileType.any,
+    _i30.FileType? type = _i30.FileType.any,
     List<String>? allowedExtensions,
     bool? lockParentWindow = false,
   }) =>


### PR DESCRIPTION
Fix #177

TabSettingからAccountを削除し、代わりにhostとusernameからなるAcctを加えました

- TabSettingからAccountを取得するために、Acctを引数としてAccountを返すaccountProviderを追加しました
- TabSetting.fromJsonで以前の形式のjsonも読めるようにしました
- TabSettingsRepository.updateAccountを削除しました
- Accountの比較に関する記述が簡潔になりました