### PR TITLE
リンクのプレビューを追加

### DIFF
--- a/lib/model/summaly_result.dart
+++ b/lib/model/summaly_result.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'summaly_result.freezed.dart';
+part 'summaly_result.g.dart';
+
+// https://github.com/misskey-dev/summaly
+@freezed
+class SummalyResult with _$SummalyResult {
+  const factory SummalyResult({
+    String? title,
+    String? icon,
+    String? description,
+    String? thumbnail,
+    required Player player,
+    String? sitename,
+    bool? sensitive,
+    String? url,
+  }) = _SummalyResult;
+
+  factory SummalyResult.fromJson(Map<String, dynamic> json) =>
+      _$SummalyResultFromJson(json);
+}
+
+@freezed
+class Player with _$Player {
+  const factory Player({
+    String? url,
+    double? width,
+    double? height,
+    List<String>? allow,
+  }) = _Player;
+
+  factory Player.fromJson(Map<String, dynamic> json) => _$PlayerFromJson(json);
+}

--- a/lib/model/summaly_result.freezed.dart
+++ b/lib/model/summaly_result.freezed.dart
@@ -1,0 +1,505 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'summaly_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+SummalyResult _$SummalyResultFromJson(Map<String, dynamic> json) {
+  return _SummalyResult.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SummalyResult {
+  String? get title => throw _privateConstructorUsedError;
+  String? get icon => throw _privateConstructorUsedError;
+  String? get description => throw _privateConstructorUsedError;
+  String? get thumbnail => throw _privateConstructorUsedError;
+  Player get player => throw _privateConstructorUsedError;
+  String? get sitename => throw _privateConstructorUsedError;
+  bool? get sensitive => throw _privateConstructorUsedError;
+  String? get url => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SummalyResultCopyWith<SummalyResult> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SummalyResultCopyWith<$Res> {
+  factory $SummalyResultCopyWith(
+          SummalyResult value, $Res Function(SummalyResult) then) =
+      _$SummalyResultCopyWithImpl<$Res, SummalyResult>;
+  @useResult
+  $Res call(
+      {String? title,
+      String? icon,
+      String? description,
+      String? thumbnail,
+      Player player,
+      String? sitename,
+      bool? sensitive,
+      String? url});
+
+  $PlayerCopyWith<$Res> get player;
+}
+
+/// @nodoc
+class _$SummalyResultCopyWithImpl<$Res, $Val extends SummalyResult>
+    implements $SummalyResultCopyWith<$Res> {
+  _$SummalyResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = freezed,
+    Object? icon = freezed,
+    Object? description = freezed,
+    Object? thumbnail = freezed,
+    Object? player = null,
+    Object? sitename = freezed,
+    Object? sensitive = freezed,
+    Object? url = freezed,
+  }) {
+    return _then(_value.copyWith(
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      icon: freezed == icon
+          ? _value.icon
+          : icon // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      thumbnail: freezed == thumbnail
+          ? _value.thumbnail
+          : thumbnail // ignore: cast_nullable_to_non_nullable
+              as String?,
+      player: null == player
+          ? _value.player
+          : player // ignore: cast_nullable_to_non_nullable
+              as Player,
+      sitename: freezed == sitename
+          ? _value.sitename
+          : sitename // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sensitive: freezed == sensitive
+          ? _value.sensitive
+          : sensitive // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      url: freezed == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PlayerCopyWith<$Res> get player {
+    return $PlayerCopyWith<$Res>(_value.player, (value) {
+      return _then(_value.copyWith(player: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_SummalyResultCopyWith<$Res>
+    implements $SummalyResultCopyWith<$Res> {
+  factory _$$_SummalyResultCopyWith(
+          _$_SummalyResult value, $Res Function(_$_SummalyResult) then) =
+      __$$_SummalyResultCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? title,
+      String? icon,
+      String? description,
+      String? thumbnail,
+      Player player,
+      String? sitename,
+      bool? sensitive,
+      String? url});
+
+  @override
+  $PlayerCopyWith<$Res> get player;
+}
+
+/// @nodoc
+class __$$_SummalyResultCopyWithImpl<$Res>
+    extends _$SummalyResultCopyWithImpl<$Res, _$_SummalyResult>
+    implements _$$_SummalyResultCopyWith<$Res> {
+  __$$_SummalyResultCopyWithImpl(
+      _$_SummalyResult _value, $Res Function(_$_SummalyResult) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = freezed,
+    Object? icon = freezed,
+    Object? description = freezed,
+    Object? thumbnail = freezed,
+    Object? player = null,
+    Object? sitename = freezed,
+    Object? sensitive = freezed,
+    Object? url = freezed,
+  }) {
+    return _then(_$_SummalyResult(
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      icon: freezed == icon
+          ? _value.icon
+          : icon // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      thumbnail: freezed == thumbnail
+          ? _value.thumbnail
+          : thumbnail // ignore: cast_nullable_to_non_nullable
+              as String?,
+      player: null == player
+          ? _value.player
+          : player // ignore: cast_nullable_to_non_nullable
+              as Player,
+      sitename: freezed == sitename
+          ? _value.sitename
+          : sitename // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sensitive: freezed == sensitive
+          ? _value.sensitive
+          : sensitive // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      url: freezed == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_SummalyResult implements _SummalyResult {
+  const _$_SummalyResult(
+      {this.title,
+      this.icon,
+      this.description,
+      this.thumbnail,
+      required this.player,
+      this.sitename,
+      this.sensitive,
+      this.url});
+
+  factory _$_SummalyResult.fromJson(Map<String, dynamic> json) =>
+      _$$_SummalyResultFromJson(json);
+
+  @override
+  final String? title;
+  @override
+  final String? icon;
+  @override
+  final String? description;
+  @override
+  final String? thumbnail;
+  @override
+  final Player player;
+  @override
+  final String? sitename;
+  @override
+  final bool? sensitive;
+  @override
+  final String? url;
+
+  @override
+  String toString() {
+    return 'SummalyResult(title: $title, icon: $icon, description: $description, thumbnail: $thumbnail, player: $player, sitename: $sitename, sensitive: $sensitive, url: $url)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_SummalyResult &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.icon, icon) || other.icon == icon) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.thumbnail, thumbnail) ||
+                other.thumbnail == thumbnail) &&
+            (identical(other.player, player) || other.player == player) &&
+            (identical(other.sitename, sitename) ||
+                other.sitename == sitename) &&
+            (identical(other.sensitive, sensitive) ||
+                other.sensitive == sensitive) &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, title, icon, description,
+      thumbnail, player, sitename, sensitive, url);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_SummalyResultCopyWith<_$_SummalyResult> get copyWith =>
+      __$$_SummalyResultCopyWithImpl<_$_SummalyResult>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_SummalyResultToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SummalyResult implements SummalyResult {
+  const factory _SummalyResult(
+      {final String? title,
+      final String? icon,
+      final String? description,
+      final String? thumbnail,
+      required final Player player,
+      final String? sitename,
+      final bool? sensitive,
+      final String? url}) = _$_SummalyResult;
+
+  factory _SummalyResult.fromJson(Map<String, dynamic> json) =
+      _$_SummalyResult.fromJson;
+
+  @override
+  String? get title;
+  @override
+  String? get icon;
+  @override
+  String? get description;
+  @override
+  String? get thumbnail;
+  @override
+  Player get player;
+  @override
+  String? get sitename;
+  @override
+  bool? get sensitive;
+  @override
+  String? get url;
+  @override
+  @JsonKey(ignore: true)
+  _$$_SummalyResultCopyWith<_$_SummalyResult> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Player _$PlayerFromJson(Map<String, dynamic> json) {
+  return _Player.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Player {
+  String? get url => throw _privateConstructorUsedError;
+  double? get width => throw _privateConstructorUsedError;
+  double? get height => throw _privateConstructorUsedError;
+  List<String>? get allow => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PlayerCopyWith<Player> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PlayerCopyWith<$Res> {
+  factory $PlayerCopyWith(Player value, $Res Function(Player) then) =
+      _$PlayerCopyWithImpl<$Res, Player>;
+  @useResult
+  $Res call({String? url, double? width, double? height, List<String>? allow});
+}
+
+/// @nodoc
+class _$PlayerCopyWithImpl<$Res, $Val extends Player>
+    implements $PlayerCopyWith<$Res> {
+  _$PlayerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? url = freezed,
+    Object? width = freezed,
+    Object? height = freezed,
+    Object? allow = freezed,
+  }) {
+    return _then(_value.copyWith(
+      url: freezed == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+      width: freezed == width
+          ? _value.width
+          : width // ignore: cast_nullable_to_non_nullable
+              as double?,
+      height: freezed == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as double?,
+      allow: freezed == allow
+          ? _value.allow
+          : allow // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_PlayerCopyWith<$Res> implements $PlayerCopyWith<$Res> {
+  factory _$$_PlayerCopyWith(_$_Player value, $Res Function(_$_Player) then) =
+      __$$_PlayerCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? url, double? width, double? height, List<String>? allow});
+}
+
+/// @nodoc
+class __$$_PlayerCopyWithImpl<$Res>
+    extends _$PlayerCopyWithImpl<$Res, _$_Player>
+    implements _$$_PlayerCopyWith<$Res> {
+  __$$_PlayerCopyWithImpl(_$_Player _value, $Res Function(_$_Player) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? url = freezed,
+    Object? width = freezed,
+    Object? height = freezed,
+    Object? allow = freezed,
+  }) {
+    return _then(_$_Player(
+      url: freezed == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+      width: freezed == width
+          ? _value.width
+          : width // ignore: cast_nullable_to_non_nullable
+              as double?,
+      height: freezed == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as double?,
+      allow: freezed == allow
+          ? _value._allow
+          : allow // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Player implements _Player {
+  const _$_Player(
+      {this.url, this.width, this.height, final List<String>? allow})
+      : _allow = allow;
+
+  factory _$_Player.fromJson(Map<String, dynamic> json) =>
+      _$$_PlayerFromJson(json);
+
+  @override
+  final String? url;
+  @override
+  final double? width;
+  @override
+  final double? height;
+  final List<String>? _allow;
+  @override
+  List<String>? get allow {
+    final value = _allow;
+    if (value == null) return null;
+    if (_allow is EqualUnmodifiableListView) return _allow;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'Player(url: $url, width: $width, height: $height, allow: $allow)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Player &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.width, width) || other.width == width) &&
+            (identical(other.height, height) || other.height == height) &&
+            const DeepCollectionEquality().equals(other._allow, _allow));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, url, width, height,
+      const DeepCollectionEquality().hash(_allow));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_PlayerCopyWith<_$_Player> get copyWith =>
+      __$$_PlayerCopyWithImpl<_$_Player>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_PlayerToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Player implements Player {
+  const factory _Player(
+      {final String? url,
+      final double? width,
+      final double? height,
+      final List<String>? allow}) = _$_Player;
+
+  factory _Player.fromJson(Map<String, dynamic> json) = _$_Player.fromJson;
+
+  @override
+  String? get url;
+  @override
+  double? get width;
+  @override
+  double? get height;
+  @override
+  List<String>? get allow;
+  @override
+  @JsonKey(ignore: true)
+  _$$_PlayerCopyWith<_$_Player> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/summaly_result.g.dart
+++ b/lib/model/summaly_result.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'summaly_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_SummalyResult _$$_SummalyResultFromJson(Map<String, dynamic> json) =>
+    _$_SummalyResult(
+      title: json['title'] as String?,
+      icon: json['icon'] as String?,
+      description: json['description'] as String?,
+      thumbnail: json['thumbnail'] as String?,
+      player: Player.fromJson(json['player'] as Map<String, dynamic>),
+      sitename: json['sitename'] as String?,
+      sensitive: json['sensitive'] as bool?,
+      url: json['url'] as String?,
+    );
+
+Map<String, dynamic> _$$_SummalyResultToJson(_$_SummalyResult instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'icon': instance.icon,
+      'description': instance.description,
+      'thumbnail': instance.thumbnail,
+      'player': instance.player.toJson(),
+      'sitename': instance.sitename,
+      'sensitive': instance.sensitive,
+      'url': instance.url,
+    };
+
+_$_Player _$$_PlayerFromJson(Map<String, dynamic> json) => _$_Player(
+      url: json['url'] as String?,
+      width: (json['width'] as num?)?.toDouble(),
+      height: (json['height'] as num?)?.toDouble(),
+      allow:
+          (json['allow'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$$_PlayerToJson(_$_Player instance) => <String, dynamic>{
+      'url': instance.url,
+      'width': instance.width,
+      'height': instance.height,
+      'allow': instance.allow,
+    };

--- a/lib/view/common/misskey_notes/link_preview.dart
+++ b/lib/view/common/misskey_notes/link_preview.dart
@@ -1,0 +1,170 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/model/account.dart';
+import 'package:miria/model/summaly_result.dart';
+import 'package:miria/providers.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+final _summalyProvider =
+    AsyncNotifierProvider.family<_Summaly, SummalyResult, (String, String)>(
+  _Summaly.new,
+);
+
+class _Summaly extends FamilyAsyncNotifier<SummalyResult, (String, String)> {
+  @override
+  Future<SummalyResult> build((String, String) arg) async {
+    final (host, link) = arg;
+    final dio = ref.watch(dioProvider);
+    final url = Uri.parse(link);
+    // https://github.com/misskey-dev/misskey/blob/2023.9.3/packages/frontend/src/components/MkUrlPreview.vue#L141-L145
+    final replacedUrl = url
+        .replace(
+          host: url.host == "music.youtube.com" &&
+                  ["watch", "channel"].contains(url.pathSegments.firstOrNull)
+              ? "www.youtube.com"
+              : null,
+        )
+        .removeFragment();
+    final response = await dio.getUri<Map<String, dynamic>>(
+      Uri.https(
+        host,
+        "url",
+        {
+          "url": replacedUrl.toString(),
+          // TODO: l10n
+          "lang": "ja-JP",
+        },
+      ),
+    );
+    return SummalyResult.fromJson(response.data!);
+  }
+}
+
+class LinkPreview extends ConsumerWidget {
+  const LinkPreview({
+    super.key,
+    required this.account,
+    required this.link,
+  });
+
+  final Account account;
+  final String link;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summalyResult = ref.watch(_summalyProvider((account.host, link)));
+    return summalyResult.maybeWhen(
+      data: (summalyResult) => LinkPreviewItem(
+        link: link,
+        summalyResult: summalyResult,
+      ),
+      orElse: () => LinkPreviewItem(link: link),
+    );
+  }
+}
+
+class LinkPreviewItem extends StatelessWidget {
+  const LinkPreviewItem({
+    super.key,
+    required this.link,
+    this.summalyResult = const SummalyResult(player: Player()),
+  });
+
+  final String link;
+  final SummalyResult summalyResult;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final imageSize = (textTheme.titleSmall?.fontSize ?? 15) * 5;
+    final thumbnail = summalyResult.thumbnail;
+    final icon = summalyResult.icon;
+    return Padding(
+      padding: const EdgeInsets.all(5),
+      child: InkWell(
+        onTap: () async {
+          final url = Uri.parse(link);
+          if (await canLaunchUrl(url)) {
+            launchUrl(url, mode: LaunchMode.externalApplication);
+          }
+        },
+        onLongPress: () {
+          Clipboard.setData(ClipboardData(text: link));
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text("コピーしました")),
+          );
+        },
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Theme.of(context).dividerColor,
+            ),
+            borderRadius: BorderRadius.circular(5),
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(5),
+            child: Row(
+              children: [
+                if (thumbnail == null)
+                  SizedBox(height: imageSize)
+                else
+                  CachedNetworkImage(
+                    imageUrl: thumbnail,
+                    height: imageSize,
+                    width: imageSize,
+                    fit: BoxFit.cover,
+                  ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          summalyResult.title ?? link,
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                          style: textTheme.titleSmall,
+                        ),
+                        const SizedBox(height: 5),
+                        Text(
+                          summalyResult.description ?? "",
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                          style: textTheme.bodySmall,
+                        ),
+                        const SizedBox(height: 5),
+                        Row(
+                          children: [
+                            if (icon != null)
+                              Padding(
+                                padding: const EdgeInsets.only(right: 5),
+                                child: CachedNetworkImage(
+                                  imageUrl: icon,
+                                  height: textTheme.labelMedium?.fontSize,
+                                  width: textTheme.labelMedium?.fontSize,
+                                ),
+                              ),
+                            Text(
+                              summalyResult.sitename ?? "",
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                              style: textTheme.labelMedium,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/common/misskey_notes/player_embed.dart
+++ b/lib/view/common/misskey_notes/player_embed.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:miria/model/summaly_result.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
+
+class PlayerEmbed extends StatefulWidget {
+  const PlayerEmbed({super.key, required this.player});
+
+  final Player player;
+
+  @override
+  State<PlayerEmbed> createState() => _PlayerEmbedState();
+}
+
+class _PlayerEmbedState extends State<PlayerEmbed> {
+  WebViewController? controller;
+
+  @override
+  void initState() {
+    super.initState();
+    final playerUrl = widget.player.url;
+    if (playerUrl == null) {
+      return;
+    }
+    final url = Uri.tryParse(playerUrl);
+    if (url == null || WebViewPlatform.instance == null) {
+      return;
+    }
+    // https://github.com/misskey-dev/misskey/blob/2023.9.3/packages/frontend/src/components/MkUrlPreview.vue#L18
+    final replacedUrl = url.replace(
+      queryParameters: {
+        ...url.queryParameters,
+        "autoplay": "1",
+        "auto_play": "1",
+      },
+    );
+    if (WebViewPlatform.instance is WebKitWebViewPlatform) {
+      controller = WebViewController.fromPlatformCreationParams(
+        WebKitWebViewControllerCreationParams(
+          allowsInlineMediaPlayback: true,
+          mediaTypesRequiringUserAction: const <PlaybackMediaTypes>{},
+        ),
+      );
+    } else {
+      controller = WebViewController();
+    }
+    controller
+      ?..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onNavigationRequest: (request) async {
+            final url = Uri.tryParse(request.url);
+            if (url != null && await canLaunchUrl(url)) {
+              launchUrl(url, mode: LaunchMode.externalApplication);
+            }
+            return NavigationDecision.prevent;
+          },
+        ),
+      )
+      ..loadRequest(replacedUrl);
+    if (controller?.platform is AndroidWebViewController) {
+      (controller!.platform as AndroidWebViewController)
+          .setMediaPlaybackRequiresUserGesture(false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = this.controller;
+    if (controller == null) {
+      return const SizedBox.shrink();
+    }
+    final width = widget.player.width;
+    final height = widget.player.height;
+    if (width != null && height != null) {
+      final aspectRatio = width / height;
+      return AspectRatio(
+        aspectRatio: aspectRatio,
+        child: WebViewWidget(controller: controller),
+      );
+    }
+    return SizedBox(
+      height: height?.toDouble() ?? 200,
+      child: WebViewWidget(controller: controller),
+    );
+  }
+}

--- a/lib/view/common/misskey_notes/twitter_embed.dart
+++ b/lib/view/common/misskey_notes/twitter_embed.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class TwitterEmbed extends StatefulWidget {
+  const TwitterEmbed({
+    super.key,
+    required this.tweetId,
+    this.isDark = false,
+
+    // https://developer.twitter.com/en/docs/twitter-for-websites/supported-languages
+    this.lang,
+  });
+
+  final String tweetId;
+  final bool isDark;
+  final String? lang;
+
+  @override
+  State<TwitterEmbed> createState() => _TwitterEmbedState();
+}
+
+class _TwitterEmbedState extends State<TwitterEmbed> {
+  WebViewController? controller;
+  double? height;
+
+  @override
+  void initState() {
+    super.initState();
+
+    controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onNavigationRequest: (request) async {
+            final url = Uri.tryParse(request.url);
+            if (url != null && await canLaunchUrl(url)) {
+              launchUrl(url, mode: LaunchMode.externalApplication);
+            }
+            return NavigationDecision.prevent;
+          },
+        ),
+      )
+      ..addJavaScriptChannel(
+        "Twitter",
+        onMessageReceived: (message) {
+          setState(() {
+            // そのままだと下が見切れる
+            height = double.parse(message.message) + 10;
+          });
+        },
+      )
+      // https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-javascript-factory-function
+      ..loadHtmlString(
+        """
+<html>
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+
+  <body>
+    <div id="container"></div>
+  </body>
+
+  <script>
+    window.twttr = (function (d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0],
+        t = window.twttr || {};
+      if (d.getElementById(id)) return t;
+      js = d.createElement(s);
+      js.id = id;
+      js.src = "https://platform.twitter.com/widgets.js";
+      fjs.parentNode.insertBefore(js, fjs);
+
+      t._e = [];
+      t.ready = function (f) {
+        t._e.push(f);
+      };
+
+      return t;
+    }(document, "script", "twitter-wjs"));
+    window.twttr.ready(
+      (twttr) => twttr.widgets.createTweet(
+        "${widget.tweetId}",
+        document.getElementById("container"),
+        {
+          ${widget.isDark ? "theme: 'dark'," : ""}
+          ${widget.lang != null ? "lang: '${widget.lang}'," : ""}
+        }
+      ).then((el) => Twitter.postMessage(el.clientHeight))
+    );
+  </script>
+
+</html>""",
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = this.controller;
+    if (controller == null) {
+      return const SizedBox.shrink();
+    }
+    return SizedBox(
+      height: height ?? 200,
+      child: WebViewWidget(controller: controller),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1479,6 +1479,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: "053d454c9475546b4382e9498601fb46293cdac9b3ca93f1a738375bc9a1eee4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  webview_flutter_android:
+    dependency: "direct main"
+    description:
+      name: webview_flutter_android
+      sha256: b0cd33dd7d3dd8e5f664e11a19e17ba12c352647269921a3b568406b001f1dff
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.12.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "6d9213c65f1060116757a7c473247c60f3f7f332cac33dc417c9e362a9a13e4f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
+  webview_flutter_wkwebview:
+    dependency: "direct main"
+    description:
+      name: webview_flutter_wkwebview
+      sha256: "3c7d56ca4b82654ad1f58aeefb8d593a59224f26d6b2bf8feed074361eb34c86"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.0"
   win32:
     dependency: transitive
     description:
@@ -1521,4 +1553,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.7.0-0"
+  flutter: ">=3.7.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -386,10 +386,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_cache_manager
-      sha256: "32cd900555219333326a2d0653aaaf8671264c29befa65bbd9856d204a4c9fb3"
+      sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   flutter_highlighting:
     dependency: "direct main"
     description:
@@ -577,10 +577,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "6b6f10f0ce3c42f6552d1c70d2c28d764cf22bb487f50f66cca31dcd5194f4d6"
+      sha256: "2776c66b3e97c6cdd58d1bd3281548b074b64f1fd5c8f82391f7456e38849567"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   graphs:
     dependency: transitive
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -946,14 +946,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.6"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   percent_indicator:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,9 @@ dependencies:
   matrix2d: ^1.0.4
   twemoji_v2: ^0.5.3
   flutter_image_compress: ^2.0.4
+  webview_flutter: ^4.3.0
+  webview_flutter_android: ^3.12.0
+  webview_flutter_wkwebview: ^3.9.0
 
 dependency_overrides:
   image_editor:


### PR DESCRIPTION
Resolve #153

`https://<host>/url?url=<target_url>` が返すリンクの要約を表示します

タップすると外部ブラウザでリンクを開き、長押しするとリンクをコピーするようにしました

また、Misskey Webと同様にプレイヤーの表示とツイートの展開ができるようにしました
これには[webview_flutter](https://pub.dev/packages/webview_flutter)を使っています
AndroidとiOS以外では表示されません

| リンク | プレイヤー | ツイート |
| ---- | ---- | ---- |
| ![](https://media.misskeyusercontent.com/io/15ac7a6d-4698-4d2c-bd15-96128134f8cb.png) | ![](https://media.misskeyusercontent.com/io/09a20442-fc65-49ee-8b7c-3d3bf3843644.png) | ![](https://media.misskeyusercontent.com/io/0b5a410e-dfd8-409d-978c-7cdbd9a08527.png) |
