### PR TITLE
#349 対応

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -790,7 +790,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "4ad730370a8b37722b165e8952a2cbd8da45fa56"
+      resolved-ref: "36af52ecd72cabe825448c9ff11304b83b33f447"
       url: "https://github.com/shiosyakeyakini-info/misskey_dart.git"
     source: git
     version: "1.0.0"


### PR DESCRIPTION
#349 対応
  - `api/i`の`mutingNotificationTypes`をnull許容に