### PR TITLE
MiAuthのテストでMisskey.endpointsをモックする

### DIFF
--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -150,7 +150,8 @@ class AccountRepository extends ChangeNotifier {
 
     final version = nodeInfoResult["software"]["version"];
 
-    final endpoints = await Misskey(host: server, token: null).endpoints();
+    final endpoints =
+        await reader(misskeyProvider(Account.demoAccount(server))).endpoints();
     if (!endpoints.contains("emojis")) {
       throw SpecifiedException("Miriaと互換性のないソフトウェアです。\n$software $version");
     }

--- a/test/repository/account_repository/open_mi_auth_test.dart
+++ b/test/repository/account_repository/open_mi_auth_test.dart
@@ -43,8 +43,14 @@ void main() {
         requestOptions: RequestOptions(), data: AuthTestData.calckeyNodeInfo));
     when(dio.get(any)).thenAnswer((realInvocation) async => Response(
         requestOptions: RequestOptions(), data: AuthTestData.calckeyNodeInfo2));
-    final provider =
-        ProviderContainer(overrides: [dioProvider.overrideWithValue(dio)]);
+    final mockMisskey = MockMisskey();
+    when(mockMisskey.endpoints()).thenAnswer((_) async => []);
+    final provider = ProviderContainer(
+      overrides: [
+        dioProvider.overrideWithValue(dio),
+        misskeyProvider.overrideWith((ref, arg) => mockMisskey),
+      ],
+    );
     final accountRepository = AccountRepository(MockTabSettingsRepository(),
         MockAccountSettingsRepository(), provider.read);
 
@@ -69,8 +75,14 @@ void main() {
     when(dio.get(any)).thenAnswer((realInvocation) async => Response(
         requestOptions: RequestOptions(),
         data: AuthTestData.oldVerMisskeyNodeInfo2));
-    final provider =
-        ProviderContainer(overrides: [dioProvider.overrideWithValue(dio)]);
+    final mockMisskey = MockMisskey();
+    when(mockMisskey.endpoints()).thenAnswer((_) async => []);
+    final provider = ProviderContainer(
+      overrides: [
+        dioProvider.overrideWithValue(dio),
+        misskeyProvider.overrideWith((ref, arg) => mockMisskey),
+      ],
+    );
     final accountRepository = AccountRepository(MockTabSettingsRepository(),
         MockAccountSettingsRepository(), provider.read);
 


### PR DESCRIPTION
Fix #322