### PR TITLE
ノートの添付ファイル選択時に複数のファイルを同時に選択できるように

### DIFF
--- a/lib/model/image_file.dart
+++ b/lib/model/image_file.dart
@@ -3,10 +3,13 @@ import 'dart:typed_data';
 sealed class MisskeyPostFile {
   final String fileName;
   final bool isNsfw;
-  final String caption;
+  final String? caption;
 
-  const MisskeyPostFile(
-      {required this.fileName, required this.isNsfw, required this.caption});
+  const MisskeyPostFile({
+    required this.fileName,
+    this.isNsfw = false,
+    this.caption,
+  });
 }
 
 class ImageFile extends MisskeyPostFile {
@@ -14,8 +17,8 @@ class ImageFile extends MisskeyPostFile {
   const ImageFile({
     required this.data,
     required super.fileName,
-    required super.isNsfw,
-    required super.caption,
+    super.isNsfw,
+    super.caption,
   });
 }
 
@@ -26,10 +29,10 @@ class ImageFileAlreadyPostedFile extends MisskeyPostFile {
   const ImageFileAlreadyPostedFile({
     required this.data,
     required this.id,
-    required this.isEdited,
+    this.isEdited = false,
     required super.fileName,
-    required super.isNsfw,
-    required super.caption,
+    super.isNsfw,
+    super.caption,
   });
 }
 
@@ -38,8 +41,8 @@ class UnknownFile extends MisskeyPostFile {
   const UnknownFile({
     required this.data,
     required super.fileName,
-    required super.isNsfw,
-    required super.caption,
+    super.isNsfw,
+    super.caption,
   });
 }
 
@@ -50,9 +53,9 @@ class UnknownAlreadyPostedFile extends MisskeyPostFile {
   const UnknownAlreadyPostedFile({
     required this.url,
     required this.id,
-    required this.isEdited,
+    this.isEdited = false,
     required super.fileName,
-    required super.isNsfw,
-    required super.caption,
+    super.isNsfw,
+    super.caption,
   });
 }

--- a/lib/state_notifier/note_create_page/note_create_state_notifier.dart
+++ b/lib/state_notifier/note_create_page/note_create_state_notifier.dart
@@ -138,15 +138,11 @@ class NoteCreateNotifier extends StateNotifier<NoteCreate> {
               return ImageFile(
                 data: contents,
                 fileName: fileName,
-                isNsfw: false,
-                caption: "",
               );
             } else {
               return UnknownFile(
                 data: contents,
                 fileName: fileName,
-                isNsfw: false,
-                caption: "",
               );
             }
           }),
@@ -161,22 +157,25 @@ class NoteCreateNotifier extends StateNotifier<NoteCreate> {
         if (file.type.startsWith("image")) {
           final response = await dio.get(file.url,
               options: Options(responseType: ResponseType.bytes));
-          files.add(ImageFileAlreadyPostedFile(
+          files.add(
+            ImageFileAlreadyPostedFile(
               fileName: file.name,
               data: response.data,
               id: file.id,
               isNsfw: file.isSensitive,
-              caption: file.comment ?? "",
-              isEdited: false));
+              caption: file.comment,
+            ),
+          );
         } else {
-          files.add(UnknownAlreadyPostedFile(
-            url: file.url,
-            id: file.id,
-            fileName: file.name,
-            isNsfw: file.isSensitive,
-            caption: file.comment ?? "",
-            isEdited: false,
-          ));
+          files.add(
+            UnknownAlreadyPostedFile(
+              url: file.url,
+              id: file.id,
+              fileName: file.name,
+              isNsfw: file.isSensitive,
+              caption: file.comment,
+            ),
+          );
         }
       }
       final deletedNoteChannel = note.channel;
@@ -444,28 +443,31 @@ class NoteCreateNotifier extends StateNotifier<NoteCreate> {
         final fileContentResponse = await dio.get(result.url,
             options: Options(responseType: ResponseType.bytes));
 
-        state = state.copyWith(files: [
-          ...state.files,
-          ImageFileAlreadyPostedFile(
-            data: fileContentResponse.data,
-            fileName: result.name,
-            id: result.id,
-            isEdited: false,
-            isNsfw: result.isSensitive,
-            caption: result.comment ?? "",
-          )
-        ]);
+        state = state.copyWith(
+          files: [
+            ...state.files,
+            ImageFileAlreadyPostedFile(
+              data: fileContentResponse.data!,
+              fileName: result.name,
+              id: result.id,
+              isNsfw: result.isSensitive,
+              caption: result.comment,
+            ),
+          ],
+        );
       } else {
-        state = state.copyWith(files: [
-          ...state.files,
-          UnknownAlreadyPostedFile(
+        state = state.copyWith(
+          files: [
+            ...state.files,
+            UnknownAlreadyPostedFile(
               url: result.url,
               id: result.id,
-              isEdited: false,
               fileName: result.name,
               isNsfw: result.isSensitive,
-              caption: result.comment ?? "")
-        ]);
+              caption: result.comment,
+            ),
+          ],
+        );
       }
     } else if (result == DriveModalSheetReturnValue.upload) {
       final result = await FilePicker.platform.pickFiles(type: FileType.image);
@@ -481,8 +483,6 @@ class NoteCreateNotifier extends StateNotifier<NoteCreate> {
           ImageFile(
             data: await file.readAsBytes(),
             fileName: file.basename,
-            isNsfw: false,
-            caption: "",
           ),
         ],
       );

--- a/lib/view/note_create_page/drive_file_select_dialog.dart
+++ b/lib/view/note_create_page/drive_file_select_dialog.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/view/common/misskey_notes/network_image.dart';
 import 'package:miria/view/common/pushable_listview.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/view/themes/app_theme.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 class DriveFileSelectDialog extends ConsumerStatefulWidget {
   final Account account;
+  final bool allowMultiple;
+
   const DriveFileSelectDialog({
     super.key,
     required this.account,
+    this.allowMultiple = false,
   });
 
   @override
@@ -20,23 +24,41 @@ class DriveFileSelectDialog extends ConsumerStatefulWidget {
 
 class DriveFileSelectDialogState extends ConsumerState<DriveFileSelectDialog> {
   final List<DriveFolder> path = [];
+  final List<DriveFile> files = [];
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Row(
-        mainAxisSize: MainAxisSize.max,
-        children: [
-          if (path.isNotEmpty)
-            IconButton(
-                onPressed: () {
+      title: AppBar(
+        leading: IconButton(
+          onPressed: path.isEmpty
+              ? null
+              : () {
                   setState(() {
                     path.removeLast();
                   });
                 },
-                icon: const Icon(Icons.arrow_back)),
-          Expanded(child: Text(path.map((e) => e.name).join("/"))),
+          icon: const Icon(Icons.arrow_back),
+        ),
+        title: path.isEmpty
+            ? const Text("ファイルを選択")
+            : Text(path.map((e) => e.name).join("/")),
+        actions: [
+          if (files.isNotEmpty)
+            Center(
+              child: Text(
+                "(${files.length})",
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+          if (widget.allowMultiple)
+            IconButton(
+              onPressed:
+                  files.isEmpty ? null : () => Navigator.of(context).pop(files),
+              icon: const Icon(Icons.check),
+            ),
         ],
+        backgroundColor: Colors.transparent,
       ),
       content: SizedBox(
         width: MediaQuery.of(context).size.width * 0.8,
@@ -75,51 +97,84 @@ class DriveFileSelectDialogState extends ConsumerState<DriveFileSelectDialog> {
                     );
                   }),
               PushableListView(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  initializeFuture: () async {
-                    final misskey = ref.read(misskeyProvider(widget.account));
-                    final response = await misskey.drive.files.files(
-                        DriveFilesRequest(
-                            folderId: path.isEmpty ? null : path.last.id));
-                    return response.toList();
-                  },
-                  nextFuture: (lastItem, _) async {
-                    final misskey = ref.read(misskeyProvider(widget.account));
-                    final response = await misskey.drive.files.files(
-                        DriveFilesRequest(
-                            untilId: lastItem.id,
-                            folderId: path.isEmpty ? null : path.last.id));
-                    return response.toList();
-                  },
-                  listKey: path.map((e) => e.id).join("/"),
-                  itemBuilder: (context, item) {
-                    return GestureDetector(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                initializeFuture: () async {
+                  final misskey = ref.read(misskeyProvider(widget.account));
+                  final response = await misskey.drive.files.files(
+                    DriveFilesRequest(
+                      folderId: path.isEmpty ? null : path.last.id,
+                    ),
+                  );
+                  return response.toList();
+                },
+                nextFuture: (lastItem, _) async {
+                  final misskey = ref.read(misskeyProvider(widget.account));
+                  final response = await misskey.drive.files.files(
+                    DriveFilesRequest(
+                      untilId: lastItem.id,
+                      folderId: path.isEmpty ? null : path.last.id,
+                    ),
+                  );
+                  return response.toList();
+                },
+                listKey: path.map((e) => e.id).join("/"),
+                itemBuilder: (context, item) {
+                  final isSelected = files.any((file) => file.id == item.id);
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: InkWell(
+                      customBorder: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5),
+                      ),
                       onTap: () {
-                        Navigator.of(context).pop(item);
+                        if (widget.allowMultiple) {
+                          setState(() {
+                            if (isSelected) {
+                              files.removeWhere((file) => file.id == item.id);
+                            } else {
+                              files.add(item);
+                            }
+                          });
+                        } else {
+                          Navigator.of(context).pop(item);
+                        }
                       },
-                      child: Padding(
+                      child: Container(
                         padding: const EdgeInsets.all(10),
+                        decoration: (widget.allowMultiple && isSelected)
+                            ? BoxDecoration(
+                                color: AppTheme.of(context)
+                                    .currentDisplayTabColor
+                                    .withOpacity(0.7),
+                                borderRadius: BorderRadius.circular(5),
+                              )
+                            : null,
                         child: Column(
-                          mainAxisSize: MainAxisSize.max,
-                          mainAxisAlignment: MainAxisAlignment.start,
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             SizedBox(
-                                width: double.infinity,
-                                height: 200,
-                                child: item.thumbnailUrl == null
-                                    ? Container()
-                                    : NetworkImageView(
+                              width: double.infinity,
+                              height: 200,
+                              child: item.thumbnailUrl == null
+                                  ? const SizedBox.shrink()
+                                  : ClipRRect(
+                                      borderRadius: BorderRadius.circular(5),
+                                      child: NetworkImageView(
                                         fit: BoxFit.cover,
                                         url: item.thumbnailUrl!,
-                                        type: ImageType.imageThumbnail)),
+                                        type: ImageType.imageThumbnail,
+                                      ),
+                                    ),
+                            ),
                             Text(item.name),
                           ],
                         ),
                       ),
-                    );
-                  }),
+                    ),
+                  );
+                },
+              ),
             ],
           ),
         ),

--- a/lib/view/note_create_page/file_settings_dialog.dart
+++ b/lib/view/note_create_page/file_settings_dialog.dart
@@ -22,21 +22,22 @@ class FileSettingsDialog extends ConsumerStatefulWidget {
 }
 
 class FileSettingsDialogState extends ConsumerState<FileSettingsDialog> {
-  final fileNameController = TextEditingController();
+  late final TextEditingController fileNameController;
+  late final TextEditingController captionController;
   bool isNsfw = false;
-  final captionController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
 
-    fileNameController.text = widget.file.fileName;
-    captionController.text = widget.file.caption;
+    fileNameController = TextEditingController(text: widget.file.fileName);
+    captionController = TextEditingController(text: widget.file.caption);
     isNsfw = widget.file.isNsfw;
   }
 
   @override
   void dispose() {
+    fileNameController.dispose();
     captionController.dispose();
     super.dispose();
   }

--- a/test/view/note_create_page/note_create_page_test.dart
+++ b/test/view/note_create_page/note_create_page_test.dart
@@ -2141,6 +2141,8 @@ void main() {
 
         await tester.tap(find.text(TestData.drive1.name), warnIfMissed: false);
         await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.check));
+        await tester.pumpAndSettle();
 
         await tester.enterText(
             find.byType(TextField).hitTestable(), ":ai_yay:");

--- a/test/view/note_create_page/note_create_page_test.dart
+++ b/test/view/note_create_page/note_create_page_test.dart
@@ -802,11 +802,15 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(mockDriveFiles.createAsBinary(
-            argThat(equals(const DriveFilesCreateRequest(
-                name: "test.png",
-                force: true,
-                comment: "",
-                isSensitive: false))),
+            argThat(
+              equals(
+                const DriveFilesCreateRequest(
+                  name: "test.png",
+                  force: true,
+                  isSensitive: false,
+                ),
+              ),
+            ),
             argThat(equals(predicate<Uint8List>((value) =>
                 const DeepCollectionEquality().equals(value, binaryImage))))));
         verify(mockNote.create(argThat(equals(predicate<NotesCreateRequest>(
@@ -856,11 +860,15 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(mockDriveFiles.createAsBinary(
-            argThat(equals(const DriveFilesCreateRequest(
-                name: "test.txt",
-                force: true,
-                comment: "",
-                isSensitive: false))),
+            argThat(
+              equals(
+                const DriveFilesCreateRequest(
+                  name: "test.txt",
+                  force: true,
+                  isSensitive: false,
+                ),
+              ),
+            ),
             argThat(equals(predicate<Uint8List>((value) =>
                 const DeepCollectionEquality().equals(value, binaryData))))));
         verify(mockNote.create(argThat(equals(predicate<NotesCreateRequest>(
@@ -1146,11 +1154,15 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(mockDriveFiles.createAsBinary(
-            argThat(equals(const DriveFilesCreateRequest(
-                name: "test.txt",
-                force: true,
-                comment: "",
-                isSensitive: false))),
+            argThat(
+              equals(
+                const DriveFilesCreateRequest(
+                  name: "test.txt",
+                  force: true,
+                  isSensitive: false,
+                ),
+              ),
+            ),
             argThat(equals(predicate<Uint8List>((value) =>
                 const DeepCollectionEquality().equals(value, binaryData))))));
         verify(mockNote.create(argThat(equals(predicate<NotesCreateRequest>(
@@ -2207,11 +2219,15 @@ void main() {
                 .equals([TestData.drive1.id], arg.fileIds))))));
 
         verify(mockDriveFiles.createAsBinary(
-            argThat(equals(const DriveFilesCreateRequest(
-                name: "test.png",
-                force: true,
-                comment: "",
-                isSensitive: false))),
+            argThat(
+              equals(
+                const DriveFilesCreateRequest(
+                  name: "test.png",
+                  force: true,
+                  isSensitive: false,
+                ),
+              ),
+            ),
             argThat(equals(predicate<Uint8List>((value) =>
                 const DeepCollectionEquality().equals(value, binaryImage))))));
       });


### PR DESCRIPTION
アップロードするファイルを選択するときに複数選択できるようにFilePickerで指定しました

ドライブからファイルを複数選択できるように、ダイアログを変更しました

Fix #362 