### PR TITLE
テーマをインストールできるように

### DIFF
--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -391,7 +391,7 @@
             }
         }
     },
-    
+
     "notificationAll": "みんな",
     "notificationForMe": "自分宛て",
     "notificationDirect": "ダイレクト",
@@ -724,6 +724,10 @@
             }
         }
     },
+
+    "invalidThemeFormat": "テーマの形式が間違っています",
+    "alreadyInstalledTheme": "このテーマは既にインストールされています",
+
     "importFromThisFolder": "このフォルダーからインポートする",
     "exportedFileNotFound": "ここにMiriaの設定ファイルあれへんかったわ",
     "importCompleted": "インポート終わったで。",
@@ -820,6 +824,7 @@
         }
     },
     "selectLightOrDarkMode": "ライトモード・ダークモードのつかいわけ",
+    "manageThemes": "テーマの管理",
     "reaction": "リアクション",
     "emojiTapReaction": "ノート内の絵文字タップでリアクションする",
     "emojiTapReactionDescription": "ノート内の絵文字をタップしてリアクションします。MFMや外部サーバーの絵文字の場合うまく機能しないことがあります。",
@@ -831,6 +836,12 @@
     "fontFantasy": "フォント （$[font.fantasy 用）",
     "fontSize": "フォントサイズ",
     "systemFont": "システム標準",
+    "installTheme": "テーマのインストール",
+    "themeCode": "テーマコード",
+    "install": "インストール",
+    "installedThemes": "インストールされたテーマ",
+    "noInstalledThemes": "インストールされたテーマがありません",
+    "confirmDeleteTheme": "このテーマを削除しますか？",
 
     "cache": "キャッシュ",
     "cacheSize": "キャッシュサイズ",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1932,6 +1932,18 @@ abstract class S {
   /// **'{acct}で既にログインしています'**
   String alreadyLoggedIn(String acct);
 
+  /// No description provided for @invalidThemeFormat.
+  ///
+  /// In ja, this message translates to:
+  /// **'テーマの形式が間違っています'**
+  String get invalidThemeFormat;
+
+  /// No description provided for @alreadyInstalledTheme.
+  ///
+  /// In ja, this message translates to:
+  /// **'このテーマは既にインストールされています'**
+  String get alreadyInstalledTheme;
+
   /// No description provided for @importFromThisFolder.
   ///
   /// In ja, this message translates to:
@@ -2286,6 +2298,12 @@ abstract class S {
   /// **'ライトモード・ダークモードのつかいわけ'**
   String get selectLightOrDarkMode;
 
+  /// No description provided for @manageThemes.
+  ///
+  /// In ja, this message translates to:
+  /// **'テーマの管理'**
+  String get manageThemes;
+
   /// No description provided for @reaction.
   ///
   /// In ja, this message translates to:
@@ -2351,6 +2369,42 @@ abstract class S {
   /// In ja, this message translates to:
   /// **'システム標準'**
   String get systemFont;
+
+  /// No description provided for @installTheme.
+  ///
+  /// In ja, this message translates to:
+  /// **'テーマのインストール'**
+  String get installTheme;
+
+  /// No description provided for @themeCode.
+  ///
+  /// In ja, this message translates to:
+  /// **'テーマコード'**
+  String get themeCode;
+
+  /// No description provided for @install.
+  ///
+  /// In ja, this message translates to:
+  /// **'インストール'**
+  String get install;
+
+  /// No description provided for @installedThemes.
+  ///
+  /// In ja, this message translates to:
+  /// **'インストールされたテーマ'**
+  String get installedThemes;
+
+  /// No description provided for @noInstalledThemes.
+  ///
+  /// In ja, this message translates to:
+  /// **'インストールされたテーマがありません'**
+  String get noInstalledThemes;
+
+  /// No description provided for @confirmDeleteTheme.
+  ///
+  /// In ja, this message translates to:
+  /// **'このテーマを削除しますか？'**
+  String get confirmDeleteTheme;
 
   /// No description provided for @cache.
   ///

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1181,6 +1181,12 @@ class SJa extends S {
   }
 
   @override
+  String get invalidThemeFormat => 'テーマの形式が間違っています';
+
+  @override
+  String get alreadyInstalledTheme => 'このテーマは既にインストールされています';
+
+  @override
   String get importFromThisFolder => 'このフォルダーからインポートする';
 
   @override
@@ -1370,6 +1376,9 @@ class SJa extends S {
   String get selectLightOrDarkMode => 'ライトモード・ダークモードのつかいわけ';
 
   @override
+  String get manageThemes => 'テーマの管理';
+
+  @override
   String get reaction => 'リアクション';
 
   @override
@@ -1402,6 +1411,24 @@ class SJa extends S {
 
   @override
   String get systemFont => 'システム標準';
+
+  @override
+  String get installTheme => 'テーマのインストール';
+
+  @override
+  String get themeCode => 'テーマコード';
+
+  @override
+  String get install => 'インストール';
+
+  @override
+  String get installedThemes => 'インストールされたテーマ';
+
+  @override
+  String get noInstalledThemes => 'インストールされたテーマがありません';
+
+  @override
+  String get confirmDeleteTheme => 'このテーマを削除しますか？';
 
   @override
   String get cache => 'キャッシュ';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1178,6 +1178,12 @@ class SZh extends S {
   }
 
   @override
+  String get invalidThemeFormat => 'テーマの形式が間違っています';
+
+  @override
+  String get alreadyInstalledTheme => 'このテーマは既にインストールされています';
+
+  @override
   String get importFromThisFolder => '从该文件夹导入';
 
   @override
@@ -1365,6 +1371,9 @@ class SZh extends S {
   String get selectLightOrDarkMode => '选择浅色或深色模式';
 
   @override
+  String get manageThemes => 'テーマの管理';
+
+  @override
   String get reaction => '回应';
 
   @override
@@ -1397,6 +1406,24 @@ class SZh extends S {
 
   @override
   String get systemFont => '系统标准';
+
+  @override
+  String get installTheme => 'テーマのインストール';
+
+  @override
+  String get themeCode => 'テーマコード';
+
+  @override
+  String get install => 'インストール';
+
+  @override
+  String get installedThemes => 'インストールされたテーマ';
+
+  @override
+  String get noInstalledThemes => 'インストールされたテーマがありません';
+
+  @override
+  String get confirmDeleteTheme => 'このテーマを削除しますか？';
 
   @override
   String get cache => '快取';

--- a/lib/model/color_theme.dart
+++ b/lib/model/color_theme.dart
@@ -40,76 +40,26 @@ abstract class ColorTheme with _$ColorTheme {
             (key, value) => value.startsWith('"'),
           );
 
-    // https://github.com/misskey-dev/misskey/blob/13.14.1/packages/frontend/src/scripts/theme.ts#L98-L124
-    Color getColor(String val) {
-      if (val[0] == "@") {
-        return getColor(props[val.substring(1)]!);
-      } else if (val[0] == r"$") {
-        return getColor(props[val]!);
-      } else if (val[0] == ":") {
-        final parts = val.split("<");
-        final func = parts.removeAt(0).substring(1);
-        final arg = double.parse(parts.removeAt(0));
-        final color = getColor(parts.join("<"));
-
-        return switch (func) {
-          "darken" => color.darken(arg / 100),
-          "lighten" => color.lighten(arg / 100),
-          "alpha" => color.withValues(alpha: arg),
-          "hue" => color.spin(arg),
-          "saturate" => color.saturate(arg / 100),
-          _ => color,
-        };
-      }
-
-      final input = val.trim();
-
-      if (input.startsWith("rgb(") && input.endsWith(")")) {
-        final rgb = input
-            .substring(4, input.length - 1)
-            .split(RegExp("[, ]+"))
-            .map(int.parse)
-            .toList();
-        return Color.fromRGBO(rgb[0], rgb[1], rgb[2], 1);
-      }
-
-      if (input.startsWith("rgba(") && input.endsWith(")")) {
-        final rgbo = input.substring(5, input.length - 1).split(",");
-        final rgb = rgbo.sublist(0, 3).map(int.parse).toList();
-        final opacity = double.parse(rgbo[3]);
-        return Color.fromRGBO(rgb[0], rgb[1], rgb[2], opacity);
-      }
-
-      final color = input.toColor();
-      if (color != null) {
-        return color;
-      }
-
-      throw FormatException("invalid color format", val);
-    }
-
-    final colors = props.map((key, value) => MapEntry(key, getColor(value)));
-
     return ColorTheme(
       id: theme.id,
       name: theme.name,
       isDarkTheme: isDarkTheme,
-      primary: colors["accent"]!,
-      primaryDarken: colors["accentDarken"]!,
-      primaryLighten: colors["accentLighten"]!,
-      accentedBackground: colors["accentedBg"]!,
-      background: colors["bg"]!,
-      foreground: colors["fg"]!,
-      renote: colors["renote"]!,
-      mention: colors["mention"]!,
-      hashtag: colors["hashtag"]!,
-      link: colors["link"]!,
-      divider: colors["divider"]!,
-      buttonBackground: colors["buttonBg"]!,
-      buttonGradateA: colors["buttonGradateA"]!,
-      buttonGradateB: colors["buttonGradateB"]!,
-      panel: colors["panel"]!,
-      panelBackground: colors["panelHeaderBg"]!,
+      primary: _getThemeReferenceColor(props, "accent", [], 0),
+      primaryDarken: _getThemeReferenceColor(props, "accentDarken", [], 0),
+      primaryLighten: _getThemeReferenceColor(props, "accentLighten", [], 0),
+      accentedBackground: _getThemeReferenceColor(props, "accentedBg", [], 0),
+      background: _getThemeReferenceColor(props, "bg", [], 0),
+      foreground: _getThemeReferenceColor(props, "fg", [], 0),
+      renote: _getThemeReferenceColor(props, "renote", [], 0),
+      mention: _getThemeReferenceColor(props, "mention", [], 0),
+      hashtag: _getThemeReferenceColor(props, "hashtag", [], 0),
+      link: _getThemeReferenceColor(props, "link", [], 0),
+      divider: _getThemeReferenceColor(props, "divider", [], 0),
+      buttonBackground: _getThemeReferenceColor(props, "buttonBg", [], 0),
+      buttonGradateA: _getThemeReferenceColor(props, "buttonGradateA", [], 0),
+      buttonGradateB: _getThemeReferenceColor(props, "buttonGradateB", [], 0),
+      panel: _getThemeReferenceColor(props, "panel", [], 0),
+      panelBackground: _getThemeReferenceColor(props, "panelHeaderBg", [], 0),
     );
   }
 }
@@ -295,3 +245,86 @@ const defaultDarkThemeProps = {
   "X16": ":alpha<0.7<@panel",
   "X17": ":alpha<0.8<@bg",
 };
+
+const _maxThemeReferenceDepth = 8;
+
+Color _getThemeReferenceColor(
+  Map<String, String> props,
+  String key,
+  List<String> stack,
+  int depth,
+) {
+  if (depth >= _maxThemeReferenceDepth) {
+    throw FormatException("Theme reference limit exceeded");
+  }
+
+  if (stack.contains(key)) {
+    throw FormatException("Theme contains circular references");
+  }
+
+  final nextValue = props[key];
+  if (nextValue == null) {
+    throw FormatException("Theme references missing property", key);
+  }
+
+  return _getColor(props, nextValue, [...stack, key], depth + 1);
+}
+
+Color _getColor(
+  Map<String, String> props,
+  String val,
+  List<String> stack,
+  int depth,
+) {
+  if (val[0] == "@") {
+    return _getThemeReferenceColor(props, val.substring(1), stack, depth);
+  } else if (val[0] == r"$") {
+    return _getThemeReferenceColor(props, val, stack, depth);
+  } else if (val[0] == ":") {
+    if (depth >= _maxThemeReferenceDepth) {
+      throw FormatException("Theme reference limit exceeded");
+    }
+    final parts = val.split("<");
+    final func = parts.removeAt(0).substring(1);
+    final arg = double.parse(parts.removeAt(0));
+    final color = _getColor(props, parts.join("<"), stack, depth + 1);
+
+    switch (func) {
+      case "darken":
+        return color.darken(arg / 100);
+      case "lighten":
+        return color.lighten(arg / 100);
+      case "alpha":
+        return color.withValues(alpha: arg);
+      case "hue":
+        return color.spin(arg);
+      case "saturate":
+        return color.saturate(arg / 100);
+    }
+  }
+
+  final input = val.trim();
+
+  if (input.startsWith("rgb(") && input.endsWith(")")) {
+    final rgb = input
+        .substring(4, input.length - 1)
+        .split(RegExp("[, ]+"))
+        .map(int.parse)
+        .toList();
+    return Color.fromRGBO(rgb[0], rgb[1], rgb[2], 1);
+  }
+
+  if (input.startsWith("rgba(") && input.endsWith(")")) {
+    final rgbo = input.substring(5, input.length - 1).split(",");
+    final rgb = rgbo.sublist(0, 3).map(int.parse).toList();
+    final opacity = double.parse(rgbo[3]);
+    return Color.fromRGBO(rgb[0], rgb[1], rgb[2], opacity);
+  }
+
+  final color = input.toColor();
+  if (color != null) {
+    return color;
+  }
+
+  throw FormatException("invalid color format", val);
+}

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -64,6 +64,8 @@ import "package:miria/view/server_detail_dialog.dart";
 import "package:miria/view/settings_page/account_settings_page/account_list.dart";
 import "package:miria/view/settings_page/app_info_page/app_info_page.dart";
 import "package:miria/view/settings_page/general_settings_page/general_settings_page.dart";
+import "package:miria/view/settings_page/general_settings_page/install_theme_dialog.dart";
+import "package:miria/view/settings_page/general_settings_page/installed_themes_page.dart";
 import "package:miria/view/settings_page/import_export_page/folder_select_dialog.dart";
 import "package:miria/view/settings_page/import_export_page/import_export_page.dart";
 import "package:miria/view/settings_page/settings_page.dart";
@@ -162,6 +164,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: UserChatRoute.page),
     AutoRoute(page: ChatSearchRoute.page),
     AutoRoute(page: ChatMessageDetailRoute.page),
+    AutoRoute(page: InstalledThemesRoute.page),
 
     AutoRoute(path: "/share-extension", page: ShareExtensionRoute.page),
 
@@ -176,6 +179,7 @@ class AppRouter extends RootStackRouter {
     AutoDialogRoute(page: MisskeyServerListRoute.page),
     AutoDialogRoute(page: ServerDetailRoute.page),
     AutoDialogRoute(page: ReactionUserRoute.page),
+    AutoDialogRoute(page: InstallThemeRoute.page),
     AutoDialogRoute<CommunityChannel>(page: ChannelSelectRoute.page),
     AutoDialogRoute<ClipSettings>(page: ClipSettingsRoute.page),
     AutoDialogRoute<MisskeyEmojiData>(page: ReactionPickerRoute.page),

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -2119,6 +2119,38 @@ class ImportExportRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [InstallThemeDialog]
+class InstallThemeRoute extends PageRouteInfo<void> {
+  const InstallThemeRoute({List<PageRouteInfo>? children})
+    : super(InstallThemeRoute.name, initialChildren: children);
+
+  static const String name = 'InstallThemeRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const InstallThemeDialog();
+    },
+  );
+}
+
+/// generated route for
+/// [InstalledThemesPage]
+class InstalledThemesRoute extends PageRouteInfo<void> {
+  const InstalledThemesRoute({List<PageRouteInfo>? children})
+    : super(InstalledThemesRoute.name, initialChildren: children);
+
+  static const String name = 'InstalledThemesRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const InstalledThemesPage();
+    },
+  );
+}
+
+/// generated route for
 /// [InstanceMutePage]
 class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
   InstanceMuteRoute({

--- a/lib/state_notifier/installed_themes_page/misskey_theme_codes_notifier.dart
+++ b/lib/state_notifier/installed_themes_page/misskey_theme_codes_notifier.dart
@@ -1,0 +1,69 @@
+import "package:json5/json5.dart";
+import "package:miria/model/color_theme.dart";
+import "package:miria/model/misskey_theme.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+import "package:shared_preferences/shared_preferences.dart";
+
+part "misskey_theme_codes_notifier.g.dart";
+
+@riverpod
+class MisskeyThemeCodesNotifier extends _$MisskeyThemeCodesNotifier {
+  @override
+  FutureOr<List<String>> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_key) ?? [];
+  }
+
+  static const _key = "themes";
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = await future;
+    await prefs.setStringList(_key, value);
+  }
+
+  Future<void> install(String code) async {
+    state = AsyncData([...?state.value, code]);
+    await _save();
+  }
+
+  Future<void> uninstall(int index) async {
+    state = AsyncData([
+      ...?state.value?.sublist(0, index),
+      ...?state.value?.sublist(index + 1),
+    ]);
+    await _save();
+  }
+
+  Future<void> import(List<String> codes) async {
+    state = AsyncData(codes);
+    await _save();
+  }
+}
+
+@riverpod
+List<MisskeyTheme?> misskeyThemes(Ref ref) {
+  final codes = ref.watch(misskeyThemeCodesNotifierProvider).value ?? [];
+  return codes.map((code) {
+    try {
+      return MisskeyTheme.fromJson(json5Decode(code) as Map<String, dynamic>);
+    } catch (_) {
+      return null;
+    }
+  }).toList();
+}
+
+@riverpod
+List<ColorTheme> installedColorThemes(Ref ref) {
+  final themes = ref.watch(misskeyThemesProvider);
+  return themes.nonNulls
+      .map((theme) {
+        try {
+          return ColorTheme.misskey(theme);
+        } catch (_) {
+          return null;
+        }
+      })
+      .nonNulls
+      .toList();
+}

--- a/lib/state_notifier/installed_themes_page/misskey_theme_codes_notifier.g.dart
+++ b/lib/state_notifier/installed_themes_page/misskey_theme_codes_notifier.g.dart
@@ -1,0 +1,151 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'misskey_theme_codes_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+@ProviderFor(MisskeyThemeCodesNotifier)
+const misskeyThemeCodesNotifierProvider = MisskeyThemeCodesNotifierProvider._();
+
+final class MisskeyThemeCodesNotifierProvider
+    extends $AsyncNotifierProvider<MisskeyThemeCodesNotifier, List<String>> {
+  const MisskeyThemeCodesNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'misskeyThemeCodesNotifierProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$misskeyThemeCodesNotifierHash();
+
+  @$internal
+  @override
+  MisskeyThemeCodesNotifier create() => MisskeyThemeCodesNotifier();
+}
+
+String _$misskeyThemeCodesNotifierHash() =>
+    r'1652e8ab8d892a3318dec198f4086bef1f2357a3';
+
+abstract class _$MisskeyThemeCodesNotifier
+    extends $AsyncNotifier<List<String>> {
+  FutureOr<List<String>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<List<String>>, List<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<List<String>>, List<String>>,
+              AsyncValue<List<String>>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}
+
+@ProviderFor(misskeyThemes)
+const misskeyThemesProvider = MisskeyThemesProvider._();
+
+final class MisskeyThemesProvider
+    extends
+        $FunctionalProvider<
+          List<MisskeyTheme?>,
+          List<MisskeyTheme?>,
+          List<MisskeyTheme?>
+        >
+    with $Provider<List<MisskeyTheme?>> {
+  const MisskeyThemesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'misskeyThemesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$misskeyThemesHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<MisskeyTheme?>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<MisskeyTheme?> create(Ref ref) {
+    return misskeyThemes(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<MisskeyTheme?> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<MisskeyTheme?>>(value),
+    );
+  }
+}
+
+String _$misskeyThemesHash() => r'68aa53d2ad61a1c3aebf2fc77fea1ee5c7b382e9';
+
+@ProviderFor(installedColorThemes)
+const installedColorThemesProvider = InstalledColorThemesProvider._();
+
+final class InstalledColorThemesProvider
+    extends
+        $FunctionalProvider<
+          List<ColorTheme>,
+          List<ColorTheme>,
+          List<ColorTheme>
+        >
+    with $Provider<List<ColorTheme>> {
+  const InstalledColorThemesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'installedColorThemesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$installedColorThemesHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<ColorTheme>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<ColorTheme> create(Ref ref) {
+    return installedColorThemes(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<ColorTheme> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<ColorTheme>>(value),
+    );
+  }
+}
+
+String _$installedColorThemesHash() =>
+    r'c1886a43fd49580a58af6925298c31aa3338e279';
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -11,6 +11,7 @@ import "package:miria/model/general_settings.dart";
 import "package:miria/providers.dart";
 import "package:miria/router/app_router.dart";
 import "package:miria/state_notifier/common/cache_size_notifier.dart";
+import "package:miria/state_notifier/installed_themes_page/misskey_theme_codes_notifier.dart";
 import "package:miria/view/themes/built_in_color_themes.dart";
 
 @RoutePage()
@@ -139,6 +140,11 @@ class GeneralSettingsPage extends HookConsumerWidget {
     }, dependencies);
 
     useMemoized(() => unawaited(save()), dependencies);
+
+    final colorThemes = [
+      ...builtInColorThemes,
+      ...ref.watch(installedColorThemesProvider),
+    ];
 
     return Scaffold(
       appBar: AppBar(title: Text(S.of(context).generalSettings)),
@@ -282,8 +288,9 @@ class GeneralSettingsPage extends HookConsumerWidget {
                         const Padding(padding: EdgeInsets.only(top: 10)),
                         Text(S.of(context).themeForLightMode),
                         DropdownButton<String>(
+                          isExpanded: true,
                           items: [
-                            for (final element in builtInColorThemes.where(
+                            for (final element in colorThemes.where(
                               (element) => !element.isDarkTheme,
                             ))
                               DropdownMenuItem(
@@ -300,8 +307,9 @@ class GeneralSettingsPage extends HookConsumerWidget {
                         const Padding(padding: EdgeInsets.only(top: 10)),
                         Text(S.of(context).themeForDarkMode),
                         DropdownButton<String>(
+                          isExpanded: true,
                           items: [
-                            for (final element in builtInColorThemes.where(
+                            for (final element in colorThemes.where(
                               (element) => element.isDarkTheme,
                             ))
                               DropdownMenuItem(
@@ -318,6 +326,7 @@ class GeneralSettingsPage extends HookConsumerWidget {
                         const Padding(padding: EdgeInsets.only(top: 10)),
                         Text(S.of(context).selectLightOrDarkMode),
                         DropdownButton<ThemeColorSystem>(
+                          isExpanded: true,
                           items: [
                             for (final colorSystem in ThemeColorSystem.values)
                               DropdownMenuItem(
@@ -328,6 +337,15 @@ class GeneralSettingsPage extends HookConsumerWidget {
                           value: colorSystem.value,
                           onChanged: (value) => colorSystem.value =
                               value ?? ThemeColorSystem.system,
+                        ),
+                        ListTile(
+                          title: Text(S.of(context).manageThemes),
+                          trailing: const Icon(Icons.keyboard_arrow_right),
+                          onTap: () async {
+                            await context.pushRoute(
+                              const InstalledThemesRoute(),
+                            );
+                          },
                         ),
                       ],
                     ),

--- a/lib/view/settings_page/general_settings_page/install_theme_dialog.dart
+++ b/lib/view/settings_page/general_settings_page/install_theme_dialog.dart
@@ -1,0 +1,83 @@
+import "package:auto_route/auto_route.dart";
+import "package:flutter/material.dart";
+import "package:flutter_hooks/flutter_hooks.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:json5/json5.dart";
+import "package:miria/l10n/app_localizations.dart";
+import "package:miria/model/color_theme.dart";
+import "package:miria/model/misskey_theme.dart";
+import "package:miria/state_notifier/installed_themes_page/misskey_theme_codes_notifier.dart";
+import "package:miria/view/common/dialog/dialog_state.dart";
+import "package:miria/view/themes/built_in_color_themes.dart";
+
+@RoutePage()
+class InstallThemeDialog extends HookConsumerWidget {
+  const InstallThemeDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = useMemoized(() => GlobalKey<FormState>(), []);
+
+    return AlertDialog(
+      scrollable: true,
+      title: Text(S.of(context).installTheme),
+      content: Form(
+        key: formKey,
+        child: Column(
+          children: [
+            TextFormField(
+              decoration: InputDecoration(labelText: S.of(context).themeCode),
+              keyboardType: TextInputType.multiline,
+              maxLines: null,
+              minLines: 10,
+              textAlignVertical: TextAlignVertical.top,
+              validator: (code) {
+                if (code == null || code.isEmpty) {
+                  return S.of(context).pleaseInputSomething;
+                }
+                try {
+                  ColorTheme.misskey(
+                    MisskeyTheme.fromJson(
+                      json5Decode(code) as Map<String, dynamic>,
+                    ),
+                  );
+                } catch (e) {
+                  return S.of(context).invalidThemeFormat;
+                }
+                return null;
+              },
+              onSaved: (code) async {
+                if (code != null && formKey.currentState!.validate()) {
+                  final theme = MisskeyTheme.fromJson(
+                    json5Decode(code) as Map<String, dynamic>,
+                  );
+                  if (builtInColorThemes.any((e) => e.id == theme.id) ||
+                      ref
+                          .read(misskeyThemesProvider)
+                          .any((e) => e?.id == theme.id)) {
+                    await ref
+                        .read(dialogStateNotifierProvider.notifier)
+                        .showSimpleDialog(
+                          message: (context) =>
+                              S.of(context).alreadyInstalledTheme,
+                        );
+                    return;
+                  }
+                  await ref
+                      .read(misskeyThemeCodesNotifierProvider.notifier)
+                      .install(code);
+                  if (!context.mounted) return;
+                  Navigator.of(context).pop();
+                }
+              },
+            ),
+            ElevatedButton(
+              onPressed: () => formKey.currentState?.save(),
+              child: Text(S.of(context).install),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/settings_page/general_settings_page/installed_themes_page.dart
+++ b/lib/view/settings_page/general_settings_page/installed_themes_page.dart
@@ -1,0 +1,95 @@
+import "package:auto_route/auto_route.dart";
+import "package:flutter/material.dart";
+import "package:flutter/services.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:json5/json5.dart";
+import "package:miria/l10n/app_localizations.dart";
+import "package:miria/model/misskey_theme.dart";
+import "package:miria/router/app_router.dart";
+import "package:miria/state_notifier/installed_themes_page/misskey_theme_codes_notifier.dart";
+import "package:miria/view/dialogs/simple_confirm_dialog.dart";
+
+@RoutePage()
+class InstalledThemesPage extends ConsumerWidget {
+  const InstalledThemesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final codes = ref.watch(misskeyThemeCodesNotifierProvider).value ?? [];
+    final themes = codes
+        .map(
+          (code) =>
+              MisskeyTheme.fromJson(json5Decode(code) as Map<String, dynamic>),
+        )
+        .toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(S.of(context).installedThemes),
+        actions: [
+          IconButton(
+            onPressed: () async {
+              await context.pushRoute(const InstallThemeRoute());
+            },
+            icon: const Icon(Icons.add),
+          ),
+        ],
+      ),
+      body: themes.isEmpty
+          ? Center(child: Text(S.of(context).noInstalledThemes))
+          : ListView.builder(
+              itemCount: themes.length,
+              itemBuilder: (context, index) {
+                final theme = themes[index];
+                final code = codes[index];
+                return ListTile(
+                  title: Text(theme.name),
+                  subtitle: Text(theme.author ?? ""),
+                  trailing: IconButton(
+                    onPressed: () async {
+                      final result = await SimpleConfirmDialog.show(
+                        context: context,
+                        message: S.of(context).confirmDeleteTheme,
+                        primary: S.of(context).willDelete,
+                        secondary: S.of(context).cancel,
+                      );
+                      if (!context.mounted) return;
+                      if (result ?? false) {
+                        await ref
+                            .read(misskeyThemeCodesNotifierProvider.notifier)
+                            .uninstall(index);
+                      }
+                    },
+                    icon: const Icon(Icons.delete),
+                  ),
+                  onTap: () async {
+                    await showDialog<void>(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        scrollable: true,
+                        title: Text(S.of(context).themeCode),
+                        content: Text(code),
+                        actions: [
+                          TextButton(
+                            onPressed: () async {
+                              await Clipboard.setData(
+                                ClipboardData(text: code),
+                              );
+                              if (!context.mounted) return;
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(S.of(context).doneCopy)),
+                              );
+                              Navigator.of(context).pop();
+                            },
+                            child: Text(S.of(context).copy),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/view/themes/app_theme_scope.dart
+++ b/lib/view/themes/app_theme_scope.dart
@@ -7,6 +7,7 @@ import "package:miria/extensions/color_extension.dart";
 import "package:miria/model/color_theme.dart";
 import "package:miria/model/general_settings.dart";
 import "package:miria/providers.dart";
+import "package:miria/state_notifier/installed_themes_page/misskey_theme_codes_notifier.dart";
 import "package:miria/view/themes/app_theme.dart";
 import "package:miria/view/themes/built_in_color_themes.dart";
 
@@ -446,6 +447,10 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
         (value) => value.settings.languages,
       ),
     );
+    final colorThemes = [
+      ...builtInColorThemes,
+      ...ref.watch(installedColorThemesProvider),
+    ];
 
     final bool isDark;
     if (colorSystem == ThemeColorSystem.system) {
@@ -459,14 +464,12 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
     }
 
     final foundColorTheme =
-        builtInColorThemes.firstWhereOrNull(
+        colorThemes.firstWhereOrNull(
           (e) =>
               e.isDarkTheme == isDark &&
               e.id == (isDark ? darkTheme : lightTheme),
         ) ??
-        builtInColorThemes.firstWhere(
-          (element) => element.isDarkTheme == isDark,
-        );
+        colorThemes.firstWhere((element) => element.isDarkTheme == isDark);
 
     return Theme(
       data: buildTheme(


### PR DESCRIPTION
Resolve #383 

テーマのインストールと削除ができるようにしました

- shared preferencesにテーマコードを保存します
- 組み込みテーマと同様にidで指定します

| インストールダイアログ | インストールされたテーマ一覧 | テーマの選択 | テーマの適用後 |
|  ---- | ---- | ---- | ---- |
| ![image](https://github.com/shiosyakeyakini-info/miria/assets/63451158/4931091e-670c-4449-bfe8-4b8a400634ad) | ![image](https://github.com/shiosyakeyakini-info/miria/assets/63451158/ffaf1722-6b5e-45a7-9c09-faa42ee80fb0) | ![image](https://github.com/shiosyakeyakini-info/miria/assets/63451158/e449ee05-667a-4290-8251-06f050136efb) | ![image](https://github.com/shiosyakeyakini-info/miria/assets/63451158/8db44b2e-12fe-4307-96ab-5aed0517b633) |

