### PR TITLE
ブロックされているときにブロック中と表示されていたのを修正

### DIFF
--- a/lib/view/user_page/user_control_dialog.dart
+++ b/lib/view/user_page/user_control_dialog.dart
@@ -205,32 +205,32 @@ class UserControlDialogState extends ConsumerState<UserControlDialog> {
       if (!widget.isMe) ...[
         if (widget.response.isRenoteMuted ?? false)
           ListTile(
-            onTap: renoteMuteDelete,
+            onTap: renoteMuteDelete.expectFailure(context),
             title: const Text("Renoteのミュート解除する"),
           )
         else
           ListTile(
-            onTap: renoteMuteCreate,
+            onTap: renoteMuteCreate.expectFailure(context),
             title: const Text("Renoteをミュートする"),
           ),
         if (widget.response.isMuted ?? false)
           ListTile(
-            onTap: muteDelete,
+            onTap: muteDelete.expectFailure(context),
             title: const Text("ミュート解除する"),
           )
         else
           ListTile(
-            onTap: muteCreate,
+            onTap: muteCreate.expectFailure(context),
             title: const Text("ミュートする"),
           ),
         if (widget.response.isBlocking ?? false)
           ListTile(
-            onTap: blockingDelete,
+            onTap: blockingDelete.expectFailure(context),
             title: const Text("ブロックを解除する"),
           )
         else
           ListTile(
-            onTap: blockingCreate,
+            onTap: blockingCreate.expectFailure(context),
             title: const Text("ブロックする"),
           )
       ],

--- a/lib/view/user_page/user_control_dialog.dart
+++ b/lib/view/user_page/user_control_dialog.dart
@@ -223,7 +223,7 @@ class UserControlDialogState extends ConsumerState<UserControlDialog> {
             onTap: muteCreate,
             title: const Text("ミュートする"),
           ),
-        if (widget.response.isBlocked ?? false)
+        if (widget.response.isBlocking ?? false)
           ListTile(
             onTap: blockingDelete,
             title: const Text("ブロックを解除する"),

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -9,6 +9,7 @@ import 'package:miria/router/app_router.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/avatar_icon.dart';
 import 'package:miria/view/common/constants.dart';
+import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:miria/view/common/misskey_notes/mfm_text.dart';
 import 'package:miria/view/common/misskey_notes/misskey_note.dart';
 import 'package:miria/view/dialogs/simple_confirm_dialog.dart';
@@ -43,18 +44,26 @@ class UserDetailState extends ConsumerState<UserDetail> {
     setState(() {
       isFollowEditing = true;
     });
-    await ref
-        .read(misskeyProvider(AccountScope.of(context)))
-        .following
-        .create(FollowingCreateRequest(userId: response.id));
-    if (!mounted) return;
-    setState(() {
-      isFollowEditing = false;
-      response = response.copyWith(
-        isFollowing: !response.requiresFollowRequest,
-        hasPendingFollowRequestFromYou: response.requiresFollowRequest,
-      );
-    });
+    try {
+      await ref
+          .read(misskeyProvider(AccountScope.of(context)))
+          .following
+          .create(FollowingCreateRequest(userId: response.id));
+      if (!mounted) return;
+      setState(() {
+        isFollowEditing = false;
+        response = response.copyWith(
+          isFollowing: !response.requiresFollowRequest,
+          hasPendingFollowRequestFromYou: response.requiresFollowRequest,
+        );
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        isFollowEditing = false;
+      });
+      rethrow;
+    }
   }
 
   Future<void> followDelete() async {
@@ -71,15 +80,23 @@ class UserDetailState extends ConsumerState<UserDetail> {
     setState(() {
       isFollowEditing = true;
     });
-    await ref
-        .read(misskeyProvider(account))
-        .following
-        .delete(FollowingDeleteRequest(userId: response.id));
-    if (!mounted) return;
-    setState(() {
-      isFollowEditing = false;
-      response = response.copyWith(isFollowing: false);
-    });
+    try {
+      await ref
+          .read(misskeyProvider(account))
+          .following
+          .delete(FollowingDeleteRequest(userId: response.id));
+      if (!mounted) return;
+      setState(() {
+        isFollowEditing = false;
+        response = response.copyWith(isFollowing: false);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        isFollowEditing = false;
+      });
+      rethrow;
+    }
   }
 
   Future<void> followRequestCancel() async {
@@ -87,16 +104,24 @@ class UserDetailState extends ConsumerState<UserDetail> {
     setState(() {
       isFollowEditing = true;
     });
-    await ref
-        .read(misskeyProvider(AccountScope.of(context)))
-        .following
-        .requests
-        .cancel(FollowingRequestsCancelRequest(userId: response.id));
-    if (!mounted) return;
-    setState(() {
-      isFollowEditing = false;
-      response = response.copyWith(hasPendingFollowRequestFromYou: false);
-    });
+    try {
+      await ref
+          .read(misskeyProvider(AccountScope.of(context)))
+          .following
+          .requests
+          .cancel(FollowingRequestsCancelRequest(userId: response.id));
+      if (!mounted) return;
+      setState(() {
+        isFollowEditing = false;
+        response = response.copyWith(hasPendingFollowRequestFromYou: false);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        isFollowEditing = false;
+      });
+      rethrow;
+    }
   }
 
   Future<void> userControl(bool isMe) async {

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -132,12 +132,12 @@ class UserDetailState extends ConsumerState<UserDetail> {
         break;
       case UserControl.createBlock:
         setState(() {
-          response = response.copyWith(isBlocked: true);
+          response = response.copyWith(isBlocking: true);
         });
         break;
       case UserControl.deleteBlock:
         setState(() {
-          response = response.copyWith(isBlocked: false);
+          response = response.copyWith(isBlocking: false);
         });
         break;
     }
@@ -187,7 +187,7 @@ class UserDetailState extends ConsumerState<UserDetail> {
                                 padding: EdgeInsets.all(10),
                                 child: Text("ミュート中"),
                               )),
-                            if (response.isBlocked ?? false)
+                            if (response.isBlocking ?? false)
                               const Card(
                                   child: Padding(
                                 padding: EdgeInsets.all(10),

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -205,17 +205,20 @@ class UserDetailState extends ConsumerState<UserDetail> {
                             if (!isFollowEditing)
                               (response.isFollowing ?? false)
                                   ? ElevatedButton(
-                                      onPressed: followDelete,
+                                      onPressed:
+                                          followDelete.expectFailure(context),
                                       child: const Text("フォロー解除"),
                                     )
                                   : (response.hasPendingFollowRequestFromYou ??
                                           false)
                                       ? ElevatedButton(
-                                          onPressed: followRequestCancel,
+                                          onPressed: followRequestCancel
+                                              .expectFailure(context),
                                           child: const Text("フォロー許可待ち"),
                                         )
                                       : OutlinedButton(
-                                          onPressed: followCreate,
+                                          onPressed: followCreate
+                                              .expectFailure(context),
                                           child: Text(
                                             (response.requiresFollowRequest)
                                                 ? "フォロー申請"


### PR DESCRIPTION
対象のユーザーをブロックしているか判別するために `isBlocking` を見るべきところを `isBlocked` を見ていたので修正しました
Misskey Web ではブロックされているときに「あなたはブロックされています」みたいな表示はされないようなので `isBlocked` についての表示はしていません

また、フォロー、ミュート、ブロックなどの操作でエラーが発生した時の処理を追加しました