### PR TITLE
Play、ページのタイトルをMFMの太字に変更

### DIFF
--- a/lib/view/explore_page/explore_pages.dart
+++ b/lib/view/explore_page/explore_pages.dart
@@ -33,7 +33,7 @@ class ExplorePagesState extends ConsumerState<ExplorePages> {
               MisskeyRouteRoute(account: AccountScope.of(context), page: item),
             );
           },
-          title: MfmText(mfmText: item.title),
+          title: MfmText(mfmText: item.title, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold)),
           subtitle: MfmText(mfmText: item.summary ?? ""),
         );
       }),

--- a/lib/view/explore_page/explore_plays.dart
+++ b/lib/view/explore_page/explore_plays.dart
@@ -32,7 +32,7 @@ class ExplorePagesState extends ConsumerState<ExplorePlay> {
                 host: AccountScope.of(context).host,
                 pathSegments: ["play", item.id]));
           },
-          title: MfmText(mfmText: item.title),
+          title: MfmText(mfmText: item.title, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold)),
           subtitle: MfmText(mfmText: item.summary),
         );
       }),

--- a/lib/view/user_page/user_plays.dart
+++ b/lib/view/user_page/user_plays.dart
@@ -3,6 +3,7 @@ import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/view/common/account_scope.dart';
+import 'package:miria/view/common/misskey_notes/mfm_text.dart';
 import 'package:miria/view/common/pushable_listview.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -31,8 +32,8 @@ class UserPlays extends ConsumerWidget {
       },
       itemBuilder: (context, play) {
         return ListTile(
-          title: Text(play.title),
-          subtitle: Text(play.summary),
+          title: MfmText(mfmText: play.title, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold)),
+          subtitle: MfmText(mfmText: play.summary),
           onTap: () {
             launchUrl(
                 Uri(


### PR DESCRIPTION
Resolve #416
Play・ページのリストにおいて、タイトルに太字を使うように変更しました。
|「みつける」のページリスト(修正前)|「みつける」のページリスト(修正後)|
|-|-|
|![Page修正前](https://github.com/shiosyakeyakini-info/miria/assets/66727014/03553d67-ae0f-428a-8acc-566e23c3fa7d)|![Page修正後](https://github.com/shiosyakeyakini-info/miria/assets/66727014/1eccec72-6e6a-4426-b782-b1bb96524af0)|

|「みつける」のPlayリスト(修正前)|「みつける」のPlayリスト(修正後)|
|-|-|
|![Play修正前](https://github.com/shiosyakeyakini-info/miria/assets/66727014/ea33dc4a-9242-412e-a022-25e156052b9f)|![Play修正後](https://github.com/shiosyakeyakini-info/miria/assets/66727014/644fdc3f-56a7-4bc4-9462-1b30e0ccbd18)|

・気になる点
ユーザーページから開くPlayリストは`MfmText()`ではなく`Text()`が使われています。
Misskey WebではPlayのタイトルなどでMFMの表示できるようになってないように見えますが、Misskey Webに寄せるのか、URLやカスタム絵文字が見えるようにするのか、どちらか一方に統一したほうがいいのではないかと思います（このPRでは、ユーザーページ側も`MfmText()`を使用するように変更しています）。
|「みつける」のPlayリスト(`Text()`にした場合)|
|-|
|![Playテキストへ変更後](https://github.com/shiosyakeyakini-info/miria/assets/66727014/c94c71ba-b997-4d28-908d-4579b9324e38)|
