### PR TITLE
入力補完に＃と＠を追加

### DIFF
--- a/lib/view/common/note_create/basic_keyboard.dart
+++ b/lib/view/common/note_create/basic_keyboard.dart
@@ -26,6 +26,12 @@ class BasicKeyboard extends StatelessWidget {
           focusNode: focusNode,
         ),
         CustomKeyboardButton(
+          keyboard: "#",
+          displayText: "＃",
+          controller: controller,
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
           keyboard: r"$[",
           afterInsert: "]",
           controller: controller,
@@ -40,6 +46,12 @@ class BasicKeyboard extends StatelessWidget {
         CustomKeyboardButton(
           keyboard: "<small>",
           afterInsert: "</small>",
+          controller: controller,
+          focusNode: focusNode,
+        ),
+        CustomKeyboardButton(
+          keyboard: "@",
+          displayText: "＠",
           controller: controller,
           focusNode: focusNode,
         ),


### PR DESCRIPTION
ノートの入力補完に`#`と`@`を追加する提案です。
（`displayText`も追加しましたが、使っていないように見えます。）