### PR TITLE
リアクションと投票の後にnotes/showを呼ばない

### DIFF
--- a/lib/const.dart
+++ b/lib/const.dart
@@ -1,5 +1,3 @@
-const misskeyIOReactionDelay = 1500;
-
 class Font {
   final String displayName;
   final String actualName;

--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -138,6 +138,85 @@ class NoteRepository extends ChangeNotifier {
     });
   }
 
+  void addReaction(String noteId, TimelineReacted reaction) {
+    final registeredNote = _notes[noteId];
+    if (registeredNote == null) return;
+
+    final reactions = Map.of(registeredNote.reactions);
+    reactions[reaction.reaction] = (reactions[reaction.reaction] ?? 0) + 1;
+    final emoji = reaction.emoji;
+    final reactionEmojis = Map.of(registeredNote.reactionEmojis);
+    if (emoji != null && !reaction.reaction.endsWith("@.:")) {
+      reactionEmojis[emoji.name] = emoji.url;
+    }
+
+    registerNote(
+      registeredNote.copyWith(
+        reactions: reactions,
+        reactionEmojis: reactionEmojis,
+        myReaction: reaction.userId == account.i.id
+            ? (emoji?.name != null ? ":${emoji?.name}:" : null)
+            : registeredNote.myReaction,
+      ),
+    );
+  }
+
+  void removeReaction(String noteId, TimelineReacted reaction) {
+    final registeredNote = _notes[noteId];
+    if (registeredNote == null) return;
+
+    final reactions = Map.of(registeredNote.reactions);
+    final reactionCount = reactions[reaction.reaction];
+    if (reactionCount == null) {
+      return;
+    }
+    if (reactionCount <= 1) {
+      reactions.remove(reaction.reaction);
+    } else {
+      reactions[reaction.reaction] = reactionCount - 1;
+    }
+
+    registerNote(
+      registeredNote.copyWith(
+        reactions: reactions,
+        myReaction:
+            reaction.userId == account.i.id ? "" : registeredNote.myReaction,
+      ),
+    );
+  }
+
+  void addVote(String noteId, TimelineVoted vote) {
+    final registeredNote = _notes[noteId];
+    if (registeredNote == null) return;
+
+    final poll = registeredNote.poll;
+    if (poll == null) return;
+
+    final choices = poll.choices.toList();
+    choices[vote.choice] = choices[vote.choice].copyWith(
+      votes: choices[vote.choice].votes + 1,
+    );
+
+    registerNote(
+      registeredNote.copyWith(
+        poll: poll.copyWith(choices: choices),
+      ),
+    );
+  }
+
+  void updateNote(String noteId, NoteEdited note) {
+    final registeredNote = _notes[noteId];
+    if (registeredNote == null) return;
+
+    registerNote(
+      registeredNote.copyWith(
+        text: note.text,
+        cw: note.cw,
+        updatedAt: DateTime.now(),
+      ),
+    );
+  }
+
   Future<void> refresh(String noteId) async {
     final note = await misskey.notes.show(NotesShowRequest(noteId: noteId));
     registerNote(note.copyWith(myReaction: note.myReaction ?? ""));

--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -225,9 +225,15 @@ class NoteRepository extends ChangeNotifier {
     final poll = registeredNote.poll;
     if (poll == null) return;
 
+    final isMyVote = vote.userId == account.i.id;
+    if (isMyVote && poll.choices[vote.choice].isVoted) {
+      return;
+    }
+
     final choices = poll.choices.toList();
     choices[vote.choice] = choices[vote.choice].copyWith(
       votes: choices[vote.choice].votes + 1,
+      isVoted: isMyVote,
     );
 
     registerNote(
@@ -235,6 +241,10 @@ class NoteRepository extends ChangeNotifier {
         poll: poll.copyWith(choices: choices),
       ),
     );
+  }
+
+  void addMyVote(String noteId, int choice) {
+    addVote(noteId, TimelineVoted(choice: choice, userId: account.i.id));
   }
 
   void updateNote(String noteId, NoteEdited note) {

--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -142,6 +142,11 @@ class NoteRepository extends ChangeNotifier {
     final registeredNote = _notes[noteId];
     if (registeredNote == null) return;
 
+    final isMyReaction = reaction.userId == account.i.id;
+    if (isMyReaction && registeredNote.myReaction == reaction.reaction) {
+      return;
+    }
+
     final reactions = Map.of(registeredNote.reactions);
     reactions[reaction.reaction] = (reactions[reaction.reaction] ?? 0) + 1;
     final emoji = reaction.emoji;
@@ -154,9 +159,8 @@ class NoteRepository extends ChangeNotifier {
       registeredNote.copyWith(
         reactions: reactions,
         reactionEmojis: reactionEmojis,
-        myReaction: reaction.userId == account.i.id
-            ? (emoji?.name != null ? ":${emoji?.name}:" : null)
-            : registeredNote.myReaction,
+        myReaction:
+            isMyReaction ? reaction.reaction : registeredNote.myReaction,
       ),
     );
   }
@@ -164,6 +168,11 @@ class NoteRepository extends ChangeNotifier {
   void removeReaction(String noteId, TimelineReacted reaction) {
     final registeredNote = _notes[noteId];
     if (registeredNote == null) return;
+
+    final isMyReaction = reaction.userId == account.i.id;
+    if (isMyReaction && registeredNote.myReaction == null) {
+      return;
+    }
 
     final reactions = Map.of(registeredNote.reactions);
     final reactionCount = reactions[reaction.reaction];
@@ -179,8 +188,7 @@ class NoteRepository extends ChangeNotifier {
     registerNote(
       registeredNote.copyWith(
         reactions: reactions,
-        myReaction:
-            reaction.userId == account.i.id ? "" : registeredNote.myReaction,
+        myReaction: isMyReaction ? "" : registeredNote.myReaction,
       ),
     );
   }

--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -165,6 +165,17 @@ class NoteRepository extends ChangeNotifier {
     );
   }
 
+  void addMyReaction(String noteId, String reaction) {
+    addReaction(
+      noteId,
+      TimelineReacted(
+        reaction: reaction,
+        emoji: null,
+        userId: account.i.id,
+      ),
+    );
+  }
+
   void removeReaction(String noteId, TimelineReacted reaction) {
     final registeredNote = _notes[noteId];
     if (registeredNote == null) return;
@@ -189,6 +200,20 @@ class NoteRepository extends ChangeNotifier {
       registeredNote.copyWith(
         reactions: reactions,
         myReaction: isMyReaction ? "" : registeredNote.myReaction,
+      ),
+    );
+  }
+
+  void removeMyReaction(String noteId) {
+    final myReaction = _notes[noteId]?.myReaction;
+    if (myReaction == null) return;
+
+    removeReaction(
+      noteId,
+      TimelineReacted(
+        reaction: myReaction,
+        emoji: null,
+        userId: account.i.id,
       ),
     );
   }

--- a/lib/view/common/misskey_notes/note_vote.dart
+++ b/lib/view/common/misskey_notes/note_vote.dart
@@ -76,7 +76,7 @@ class NoteVoteState extends ConsumerState<NoteVote> {
     if (dialogValue == true) {
       await ref.read(misskeyProvider(account)).notes.polls.vote(
           NotesPollsVoteRequest(noteId: widget.displayNote.id, choice: choice));
-      await ref.read(notesProvider(account)).refresh(widget.displayNote.id);
+      ref.read(notesProvider(account)).addMyVote(widget.displayNote.id, choice);
       if (!widget.poll.multiple) {
         if (!mounted) return;
         setState(() {

--- a/lib/view/common/misskey_notes/reaction_button.dart
+++ b/lib/view/common/misskey_notes/reaction_button.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:miria/const.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/model/misskey_emoji_data.dart';
 import 'package:miria/providers.dart';
@@ -84,12 +83,7 @@ class ReactionButtonState extends ConsumerState<ReactionButton> {
               .notes
               .reactions
               .delete(NotesReactionsDeleteRequest(noteId: widget.noteId));
-          if (account.host == "misskey.io") {
-            await Future.delayed(
-                const Duration(milliseconds: misskeyIOReactionDelay));
-          }
-
-          await ref.read(notesProvider(account)).refresh(widget.noteId);
+          ref.read(notesProvider(account)).removeMyReaction(widget.noteId);
 
           return;
         }
@@ -105,23 +99,21 @@ class ReactionButtonState extends ConsumerState<ReactionButton> {
             break;
           case CustomEmojiData():
             if (!emojiData.isCurrentServer) return;
-            reactionString = ":${emojiData.baseName}:";
+            reactionString = ":${emojiData.baseName}@.:";
             break;
           case NotEmojiData():
             return;
         }
 
         await ref.read(misskeyProvider(account)).notes.reactions.create(
-            NotesReactionsCreateRequest(
-                noteId: widget.noteId, reaction: reactionString));
-
-        // misskey.ioはただちにリアクションを反映してくれない
-        if (account.host == "misskey.io") {
-          await Future.delayed(
-              const Duration(milliseconds: misskeyIOReactionDelay));
-        }
-
-        await ref.read(notesProvider(account)).refresh(widget.noteId);
+              NotesReactionsCreateRequest(
+                noteId: widget.noteId,
+                reaction: reactionString,
+              ),
+            );
+        ref
+            .read(notesProvider(account))
+            .addMyReaction(widget.noteId, reactionString);
       },
       onLongPress: () {
         showDialog(


### PR DESCRIPTION
Fix #426 

リアクションを付けたり外したりするときにNoteRepositoryのリアクションの数や自分のリアクションを更新するようにしました
これによってリアクションの後に `notes/show` を呼んで情報を更新する必要がなくなったため、タイムラグがなくなりました

また、ストリーミングで二重に更新されることを防ぐために自分のリアクションであれば既に更新しているかどうかを確認してから更新するようにしました