### PR TITLE
削除したノートの投票期間がないときvoteExpireTypeをunlimitedにする

### DIFF
--- a/lib/state_notifier/note_create_page/note_create_state_notifier.dart
+++ b/lib/state_notifier/note_create_page/note_create_state_notifier.dart
@@ -200,7 +200,9 @@ class NoteCreateNotifier extends StateNotifier<NoteCreate> {
         ],
         isVote: note.poll != null,
         isVoteMultiple: note.poll?.multiple ?? false,
-        voteExpireType: VoteExpireType.date,
+        voteExpireType: note.poll?.expiresAt == null
+            ? VoteExpireType.unlimited
+            : VoteExpireType.date,
         voteContentCount: note.poll?.choices.map((e) => e.text).length ?? 2,
         voteContent: note.poll?.choices.map((e) => e.text).toList() ?? [],
         voteDate: note.poll?.expiresAt,


### PR DESCRIPTION
Fix #432 