### PR TITLE
Misskeyのバージョンによってレジストリのドメインを変更する

### DIFF
--- a/lib/view/several_account_settings_page/reaction_deck_page/add_reactions_dialog.dart
+++ b/lib/view/several_account_settings_page/reaction_deck_page/add_reactions_dialog.dart
@@ -6,9 +6,14 @@ import 'package:miria/view/themes/app_theme.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class AddReactionsDialog extends StatefulWidget {
-  final Account account;
+  const AddReactionsDialog({
+    super.key,
+    required this.account,
+    this.domain = "system",
+  });
 
-  const AddReactionsDialog({super.key, required this.account});
+  final Account account;
+  final String domain;
 
   @override
   State<AddReactionsDialog> createState() => _AddReactionsDialogState();
@@ -33,7 +38,7 @@ class _AddReactionsDialogState extends State<AddReactionsDialog> {
       pathSegments: [
         "registry",
         "value",
-        "system",
+        widget.domain,
         "client",
         "base",
         "reactions",

--- a/lib/view/several_account_settings_page/reaction_deck_page/reaction_deck_page.dart
+++ b/lib/view/several_account_settings_page/reaction_deck_page/reaction_deck_page.dart
@@ -152,9 +152,17 @@ class ReactionDeckPageState extends ConsumerState<ReactionDeckPage> {
   }
 
   Future<void> showAddReactionsDialog({required BuildContext context}) async {
+    final endpoints =
+        await ref.read(misskeyProvider(widget.account)).endpoints();
+    final domain =
+        endpoints.contains("i/registry/scopes-with-domain") ? "@" : "system";
+    if (!mounted) return;
     final emojiNames = await showDialog<List<String>>(
       context: context,
-      builder: (context) => AddReactionsDialog(account: widget.account),
+      builder: (context) => AddReactionsDialog(
+        account: widget.account,
+        domain: domain,
+      ),
     );
     if (emojiNames == null) {
       return;


### PR DESCRIPTION
endpoints に `i/registry/scopes-with-domain` が含まれる場合、レジストリのURLのドメイン部分を `@` に、そうでない場合は `system` にするようにしました

Fix #434 