### PR TITLE
TabIconが正方形になるように

### DIFF
--- a/lib/view/common/misskey_notes/custom_emoji.dart
+++ b/lib/view/common/misskey_notes/custom_emoji.dart
@@ -14,6 +14,7 @@ class CustomEmoji extends ConsumerStatefulWidget {
   final bool isAttachTooltip;
   final double? size;
   final TextStyle? style;
+  final bool forceSquare;
 
   const CustomEmoji({
     super.key,
@@ -22,6 +23,7 @@ class CustomEmoji extends ConsumerStatefulWidget {
     this.isAttachTooltip = true,
     this.size,
     this.style,
+    this.forceSquare = false,
   });
 
   @override
@@ -95,6 +97,7 @@ class CustomEmojiState extends ConsumerState<CustomEmoji> {
               height: scopedFontSize,
               width: scopedFontSize,
             ),
+            width: widget.forceSquare ? scopedFontSize : null,
             height: scopedFontSize,
           ),
         );

--- a/lib/view/common/misskey_notes/network_image.dart
+++ b/lib/view/common/misskey_notes/network_image.dart
@@ -21,6 +21,7 @@ class NetworkImageView extends ConsumerWidget {
   final ImageType type;
   final ImageLoadingBuilder? loadingBuilder;
   final ImageErrorWidgetBuilder? errorBuilder;
+  final double? width;
   final double? height;
   final BoxFit? fit;
 
@@ -30,6 +31,7 @@ class NetworkImageView extends ConsumerWidget {
     required this.type,
     this.loadingBuilder,
     this.errorBuilder,
+    this.width,
     this.height,
     this.fit,
   });
@@ -39,6 +41,7 @@ class NetworkImageView extends ConsumerWidget {
     if (url.endsWith(".svg")) {
       return SvgPicture.network(
         url,
+        width: width,
         height: height,
         fit: fit ?? BoxFit.contain,
         placeholderBuilder: (context) =>
@@ -60,6 +63,7 @@ class NetworkImageView extends ConsumerWidget {
             errorBuilder?.call(context, error, StackTrace.current) ??
             Container(),
         cacheManager: ref.read(cacheManagerProvider),
+        width: width,
         height: height,
         placeholder: (context, url) =>
             loadingBuilder?.call(context, Container(), null) ??
@@ -72,6 +76,7 @@ class NetworkImageView extends ConsumerWidget {
         fit: fit,
         loadingBuilder: loadingBuilder,
         errorBuilder: errorBuilder,
+        width: width,
         height: height,
       );
     }

--- a/lib/view/common/tab_icon_view.dart
+++ b/lib/view/common/tab_icon_view.dart
@@ -39,6 +39,7 @@ class TabIconView extends ConsumerWidget {
               ref.read(emojiRepositoryProvider(AccountScope.of(context))),
         ),
         size: iconSize,
+        forceSquare: true,
       );
     }
     return const SizedBox.shrink();


### PR DESCRIPTION
タブのアイコンに不等幅のカスタム絵文字を使っている場合にタブ設定画面で横長に表示されていたのを他のアイコンと同じ幅で表示するように変更しました
同時にMaterial3でタイムラインのAppBarで不等幅のタブアイコンが横長になるのも修正されます