### PR TITLE
TabBarを修正

### DIFF
--- a/lib/view/channels_page/channels_page.dart
+++ b/lib/view/channels_page/channels_page.dart
@@ -30,6 +30,7 @@ class ChannelsPage extends StatelessWidget {
               Tab(text: "管理中")
             ],
             isScrollable: true,
+            tabAlignment: TabAlignment.center,
           ),
         ),
         body: AccountScope(

--- a/lib/view/explore_page/explore_page.dart
+++ b/lib/view/explore_page/explore_page.dart
@@ -45,6 +45,7 @@ class ExplorePageState extends ConsumerState<ExplorePage> {
                   Tab(text: "ハッシュタグ"),
                   Tab(text: "よそのサーバー"),
                 ],
+                tabAlignment: TabAlignment.center,
               ),
             ),
             body: const TabBarView(

--- a/lib/view/federation_page/federation_page.dart
+++ b/lib/view/federation_page/federation_page.dart
@@ -59,6 +59,7 @@ class FederationPageState extends ConsumerState<FederationPage> {
                 if (isSupportedTimeline) const Tab(text: "カスタム絵文字"),
                 if (isSupportedTimeline) const Tab(text: "LTL")
               ],
+              tabAlignment: TabAlignment.center,
             ),
           ),
           body: TabBarView(

--- a/lib/view/themes/app_theme_scope.dart
+++ b/lib/view/themes/app_theme_scope.dart
@@ -130,6 +130,11 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
                 : theme.foreground.lighten(0.1)));
 
     final themeData = ThemeData(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: theme.primary,
+        brightness: theme.isDarkTheme ? Brightness.dark : Brightness.light,
+        primary: theme.primary,
+      ),
       brightness: theme.isDarkTheme ? Brightness.dark : Brightness.light,
       primaryColor: theme.primary,
       primaryColorDark: theme.primaryDarken,
@@ -151,7 +156,7 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
         labelColor: Colors.white,
         labelStyle: textTheme.titleSmall,
         unselectedLabelStyle:
-            textTheme.titleSmall?.copyWith(color: textTheme.bodySmall?.color),
+            textTheme.titleSmall?.copyWith(color: Colors.white60),
         indicator: UnderlineTabIndicator(
           borderSide: BorderSide(color: theme.primary),
         ),

--- a/lib/view/user_page/user_page.dart
+++ b/lib/view/user_page/user_page.dart
@@ -79,6 +79,7 @@ class UserPageState extends ConsumerState<UserPage> {
                 const Tab(text: "Play"),
               ],
               isScrollable: true,
+              tabAlignment: TabAlignment.center,
             ),
           ),
           body: Column(


### PR DESCRIPTION
Flutter 3.16でisScrollableなTabBarが左寄せで配置されるようになったのを中央寄せになるように修正しました
https://docs.flutter.dev/release/breaking-changes/tab-alignment

また、`https://github.com/flutter/flutter/pull/133989` によって unselectedLabelStyle に指定されていた色が反映されるようになったため、選択されていないタブのラベルの色が間違ったものになっていた問題を修正しました
もともとは `textTheme.bodySmall?.color` が指定されていましたが、この色は典型的に灰色で、ライトテーマのAppBarの上に表示した場合の視認性が悪くなっていました