### PR TITLE
dividerColorを指定

### DIFF
--- a/lib/view/themes/app_theme_scope.dart
+++ b/lib/view/themes/app_theme_scope.dart
@@ -134,6 +134,7 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
       primaryColor: theme.primary,
       primaryColorDark: theme.primaryDarken,
       primaryColorLight: theme.primaryLighten,
+      dividerColor: theme.divider,
       appBarTheme: AppBarTheme(
         elevation: 0,
         titleSpacing: 0,


### PR DESCRIPTION
dividerColor は複数の箇所で参照されていますが、AppThemeScopeでは指定されていなかったため、ColorThemeのdividerが参照されるようにしました