### PR TITLE
お知らせのタイトルをTextからMfmTextに

### DIFF
--- a/lib/view/federation_page/federation_announcements.dart
+++ b/lib/view/federation_page/federation_announcements.dart
@@ -151,8 +151,8 @@ class AnnouncementState extends ConsumerState<Announcement> {
                   children: [
                     if (icon != null) AnnouncementIcon(iconType: icon),
                     Expanded(
-                      child: Text(
-                        data.title,
+                      child: MfmText(
+                        mfmText: data.title,
                         style: Theme.of(context).textTheme.titleMedium,
                       ),
                     ),


### PR DESCRIPTION
Fix #441 
お知らせのタイトルをMfmTextで表示するように変更しました。
![screenshot_231117214824](https://github.com/shiosyakeyakini-info/miria/assets/66727014/712d738e-d261-427d-90c6-d475fd018da1)
