### PR TITLE
WillPopScopeをPopScopeに置き換え

### DIFF
--- a/lib/view/common/modal_indicator.dart
+++ b/lib/view/common/modal_indicator.dart
@@ -85,11 +85,9 @@ class ModalOverlay extends ModalRoute<void> {
   }
 
   Widget dialogContent(BuildContext context) {
-    return WillPopScope(
+    return PopScope(
+      canPop: isAndroidBackEnable,
       child: contents,
-      onWillPop: () {
-        return Future(() => isAndroidBackEnable);
-      },
     ); //
   }
 }

--- a/lib/view/photo_edit_page/photo_edit_page.dart
+++ b/lib/view/photo_edit_page/photo_edit_page.dart
@@ -45,8 +45,8 @@ class PhotoEditPageState extends ConsumerState<PhotoEditPage> {
   Widget build(BuildContext context) {
     return AccountScope(
       account: widget.account,
-      child: WillPopScope(
-        onWillPop: () async => false,
+      child: PopScope(
+        canPop: false,
         child: Scaffold(
           appBar: AppBar(
             title: const Text("写真編集"),


### PR DESCRIPTION
WillPopScopeがdeprecatedになったため、新しく導入されたPopScopeに置き換えました

https://docs.flutter.dev/release/breaking-changes/android-predictive-back