### PR TITLE
入力欄以外をタップしたときにフォーカスを外す

### DIFF
--- a/lib/view/time_line_page/timeline_note.dart
+++ b/lib/view/time_line_page/timeline_note.dart
@@ -33,6 +33,7 @@ class TimelineNoteFieldState extends ConsumerState<TimelineNoteField> {
         maxLines: null,
         controller: ref.watch(timelineNoteProvider),
         decoration: noteStyle,
+        onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
       ),
     );
   }


### PR DESCRIPTION
Fix #450