### PR TITLE
Update dart setup

### DIFF
--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
+      - uses: dart-lang/setup-dart@v1
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
#456 の一環
#457 の続きです。
こちらはsetup-dartの更新です。現在はバージョン指定にコミットハッシュを使っていますが、今回はバージョン名で指定しています。