### PR TITLE
入力補完の外をタップしたときにフォーカスを外す

### DIFF
--- a/lib/view/common/note_create/input_completation.dart
+++ b/lib/view/common/note_create/input_completation.dart
@@ -46,54 +46,59 @@ class InputComplement extends HookConsumerWidget {
       return Container();
     }
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: Theme.of(context).primaryColor)),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: ConstrainedBox(
-                constraints: BoxConstraints(
-                  minWidth: MediaQuery.of(context).size.width,
+    return TextFieldTapRegion(
+      onTapOutside: (_) => primaryFocus?.unfocus(),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          border: Border(
+            top: BorderSide(color: Theme.of(context).primaryColor),
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minWidth: MediaQuery.of(context).size.width,
+                  ),
+                  child: switch (inputCompletionType) {
+                    Basic() => BasicKeyboard(
+                      controller: controller,
+                      focusNode: focusNode,
+                    ),
+                    Emoji() => EmojiKeyboard(
+                      controller: controller,
+                      focusNode: focusNode,
+                    ),
+                    MfmFn() => MfmFnKeyboard(
+                      controller: controller,
+                      focusNode: focusNode,
+                      parentContext: context,
+                    ),
+                    Hashtag() => HashtagKeyboard(
+                      controller: controller,
+                      focusNode: focusNode,
+                    ),
+                    _ => BasicKeyboard(
+                      controller: controller,
+                      focusNode: focusNode,
+                    ),
+                  },
                 ),
-                child: switch (inputCompletionType) {
-                  Basic() => BasicKeyboard(
-                    controller: controller,
-                    focusNode: focusNode,
-                  ),
-                  Emoji() => EmojiKeyboard(
-                    controller: controller,
-                    focusNode: focusNode,
-                  ),
-                  MfmFn() => MfmFnKeyboard(
-                    controller: controller,
-                    focusNode: focusNode,
-                    parentContext: context,
-                  ),
-                  Hashtag() => HashtagKeyboard(
-                    controller: controller,
-                    focusNode: focusNode,
-                  ),
-                  _ => BasicKeyboard(
-                    controller: controller,
-                    focusNode: focusNode,
-                  ),
-                },
               ),
             ),
-          ),
-          if (defaultTargetPlatform == TargetPlatform.android ||
-              defaultTargetPlatform == TargetPlatform.iOS)
-            IconButton(
-              onPressed: () {
-                FocusManager.instance.primaryFocus?.unfocus();
-              },
-              icon: const Icon(Icons.keyboard_arrow_down),
-            ),
-        ],
+            if (defaultTargetPlatform == TargetPlatform.android ||
+                defaultTargetPlatform == TargetPlatform.iOS)
+              IconButton(
+                onPressed: () {
+                  FocusManager.instance.primaryFocus?.unfocus();
+                },
+                icon: const Icon(Icons.keyboard_arrow_down),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/time_line_page/timeline_note.dart
+++ b/lib/view/time_line_page/timeline_note.dart
@@ -25,7 +25,6 @@ class TimelineNoteField extends ConsumerWidget {
         maxLines: null,
         controller: ref.watch(timelineNoteProvider),
         decoration: noteStyle,
-        // onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
       ),
     );
   }


### PR DESCRIPTION
Fix #450 

入力補完をTextFieldTapRegionで囲むことで入力欄と入力補完以外をタップしたときにフォーカスを外すようにしました