### PR TITLE
リアクション一覧の絵文字の背景色を変更

### DIFF
--- a/lib/view/user_page/user_reactions.dart
+++ b/lib/view/user_page/user_reactions.dart
@@ -6,6 +6,7 @@ import 'package:miria/view/common/misskey_notes/custom_emoji.dart';
 import 'package:miria/view/common/misskey_notes/misskey_note.dart';
 import 'package:miria/view/common/pushable_listview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:miria/view/themes/app_theme.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 class UserReactions extends ConsumerWidget {
@@ -67,7 +68,7 @@ class UserReaction extends ConsumerWidget {
           children: [
             DecoratedBox(
               decoration: BoxDecoration(
-                  color: Theme.of(context).primaryColor,
+                  color: AppTheme.of(context).colorTheme.accentedBackground,
                   borderRadius: const BorderRadius.only(
                     topLeft: Radius.circular(10),
                     topRight: Radius.circular(10),

--- a/lib/view/user_page/user_reactions.dart
+++ b/lib/view/user_page/user_reactions.dart
@@ -55,7 +55,7 @@ class UserReaction extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 20),
+      padding: const EdgeInsets.symmetric(vertical: 10),
       child: DecoratedBox(
         decoration: BoxDecoration(
           border: Border.all(color: Theme.of(context).primaryColor),


### PR DESCRIPTION
Fix #298

ユーザーのリアクション一覧の絵文字の背景色をaccentedBgにしました
また、一つ目のノートがTabBarのすぐ下にあったのを間隔を空けるようにしました

| 変更前 | 変更後 |
| ---- | ---- |
| ![image](https://github.com/shiosyakeyakini-info/miria/assets/63451158/f5b7d463-92d7-49aa-9c09-3a75b8798d4e) | ![image](https://github.com/shiosyakeyakini-info/miria/assets/63451158/af3bde0a-e1fe-470a-a771-420d29bdad0c) |
