### PR TITLE
[Linux]ノートの共有をLinuxのみ削除する

### DIFF
--- a/lib/view/note_modal_sheet/note_modal_sheet.dart
+++ b/lib/view/note_modal_sheet/note_modal_sheet.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "dart:ui";
 
 import "package:auto_route/auto_route.dart";
+import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/services.dart";
@@ -366,26 +367,29 @@ class NoteModalSheet extends ConsumerWidget implements AutoRouteWrapper {
                 .read(misskeyNoteNotifierProvider.notifier)
                 .openNoteInOtherAccount(targetNote),
           ),
-        ListTile(
-          leading: const Icon(Icons.share),
-          title: Text(S.of(context).shareNotes),
-          onTap: () {
-            WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-              Future(() async {
-                if (!context.mounted) return;
-                final box = context.findRenderObject() as RenderBox?;
-                if (box == null) return;
-                final boundary = noteBoundaryKey.currentContext!
-                    .findRenderObject()! as RenderRepaintBoundary;
-                await ref.read(targetNoteNotifierProvider.notifier).copyAsImage(
-                      box,
-                      boundary,
-                      View.of(context).devicePixelRatio,
-                    );
+        if (defaultTargetPlatform != TargetPlatform.linux)
+          ListTile(
+            leading: const Icon(Icons.share),
+            title: Text(S.of(context).shareNotes),
+            onTap: () {
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                Future(() async {
+                  if (!context.mounted) return;
+                  final box = context.findRenderObject() as RenderBox?;
+                  if (box == null) return;
+                  final boundary = noteBoundaryKey.currentContext!
+                      .findRenderObject()! as RenderRepaintBoundary;
+                  await ref
+                      .read(targetNoteNotifierProvider.notifier)
+                      .copyAsImage(
+                        box,
+                        boundary,
+                        View.of(context).devicePixelRatio,
+                      );
+                });
               });
-            });
-          },
-        ),
+            },
+          ),
         if (accountContext.isSame)
           switch (noteStatus) {
             null => const SizedBox.shrink(),


### PR DESCRIPTION
Related #481
Linuxの場合のみ「ノートを共有」をリストから削除するようにしました（#481 の対応1に該当）。