### PR TITLE
MFMの関数の引数の入力補完を追加

### DIFF
--- a/lib/extensions/text_editing_controller_extension.dart
+++ b/lib/extensions/text_editing_controller_extension.dart
@@ -37,7 +37,7 @@ extension TextEditingControllerExtension on TextEditingController {
       return null;
     }
     final query = textBeforeSelection.substring(lastOpenTagIndex + 2);
-    if (RegExp(r"^[a-z234]*$").hasMatch(query)) {
+    if (RegExp(r"^[a-zA-Z0-9_.,-=]*$").hasMatch(query)) {
       return query;
     } else {
       return null;

--- a/lib/view/common/note_create/mfm_fn_keyboard.dart
+++ b/lib/view/common/note_create/mfm_fn_keyboard.dart
@@ -8,38 +8,130 @@ import 'package:miria/view/common/note_create/basic_keyboard.dart';
 import 'package:miria/view/common/note_create/custom_keyboard_button.dart';
 import 'package:miria/view/common/note_create/input_completation.dart';
 
-const mfmFn = [
-  "tada",
-  "jelly",
-  "twitch",
-  "shake",
-  "spin",
-  "jump",
-  "bounce",
-  "flip",
-  "x2",
-  "x3",
-  "x4",
-  "scale",
-  "position",
-  "fg",
-  "bg",
-  "font",
-  "blur",
-  "rainbow",
-  "sparkle",
-  "rotate",
-  "ruby",
-  "unixtime"
-];
+class MfmFnArg {
+  const MfmFnArg({
+    required this.name,
+    this.defaultValue,
+  });
 
-final _filteredMfmFnProvider = Provider.autoDispose<List<String>>((ref) {
+  final String name;
+  final String? defaultValue;
+}
+
+const Map<String, List<MfmFnArg>> mfmFn = {
+  "tada": [
+    MfmFnArg(name: "speed", defaultValue: "1s"),
+    MfmFnArg(name: "delay", defaultValue: "0s"),
+  ],
+  "jelly": [
+    MfmFnArg(name: "speed", defaultValue: "1s"),
+    MfmFnArg(name: "delay", defaultValue: "0s"),
+  ],
+  "twitch": [
+    MfmFnArg(name: "speed", defaultValue: "0.5s"),
+    MfmFnArg(name: "delay", defaultValue: "0s"),
+  ],
+  "shake": [
+    MfmFnArg(name: "speed", defaultValue: "0.5s"),
+    MfmFnArg(name: "delay", defaultValue: "0s"),
+  ],
+  "spin": [
+    MfmFnArg(name: "speed", defaultValue: "1.5s"),
+    MfmFnArg(name: "delay", defaultValue: "0s"),
+    MfmFnArg(name: "x"),
+    MfmFnArg(name: "y"),
+    MfmFnArg(name: "left"),
+    MfmFnArg(name: "alternate"),
+  ],
+  "jump": [
+    MfmFnArg(name: "speed", defaultValue: "0.75s"),
+    MfmFnArg(name: "delay", defaultValue: "0s"),
+  ],
+  "bounce": [
+    MfmFnArg(name: "speed", defaultValue: "0.75s"),
+    MfmFnArg(name: "delay", defaultValue: "0s"),
+  ],
+  "flip": [
+    MfmFnArg(name: "v"),
+    MfmFnArg(name: "h"),
+  ],
+  "x2": [],
+  "x3": [],
+  "x4": [],
+  "scale": [
+    MfmFnArg(name: "x", defaultValue: "1"),
+    MfmFnArg(name: "y", defaultValue: "1"),
+  ],
+  "position": [
+    MfmFnArg(name: "x", defaultValue: "0"),
+    MfmFnArg(name: "y", defaultValue: "0"),
+  ],
+  "fg": [
+    MfmFnArg(name: "color"),
+  ],
+  "bg": [
+    MfmFnArg(name: "color"),
+  ],
+  "font": [
+    MfmFnArg(name: "serif"),
+    MfmFnArg(name: "monospace"),
+    MfmFnArg(name: "cursive"),
+    MfmFnArg(name: "fantasy"),
+  ],
+  "blur": [],
+  "rainbow": [
+    MfmFnArg(name: "speed", defaultValue: "1s"),
+  ],
+  "sparkle": [
+    MfmFnArg(name: "speed", defaultValue: "1.5s"),
+  ],
+  "rotate": [
+    MfmFnArg(name: "deg", defaultValue: "90"),
+  ],
+  "ruby": [],
+  "unixtime": [],
+};
+
+final filteredMfmFnNamesProvider = Provider.autoDispose<List<String>>((ref) {
   final type = ref.watch(inputCompletionTypeProvider);
   if (type is MfmFn) {
-    return mfmFn.where((name) => name.startsWith(type.query)).toList();
+    return mfmFn.keys.where((name) => name.startsWith(type.query)).toList();
   } else {
-    return mfmFn;
+    return [];
   }
+});
+
+final filteredMfmFnArgsProvider = Provider.autoDispose<List<MfmFnArg>>((ref) {
+  final type = ref.watch(inputCompletionTypeProvider);
+  if (type is MfmFn) {
+    if (type.query.contains(".")) {
+      final firstPeriodIndex = type.query.indexOf(".");
+      final name = type.query.substring(0, firstPeriodIndex);
+      final allArgs = mfmFn[name];
+      if (allArgs != null && allArgs.isNotEmpty) {
+        final argNames = type.query
+            .substring(firstPeriodIndex + 1)
+            .split(",")
+            .map((s) => s.split("=").first);
+        if (argNames.isEmpty) {
+          return allArgs;
+        }
+        final head = argNames.take(argNames.length - 1);
+        final tail = argNames.last;
+        if (allArgs.any((arg) => arg.name == tail)) {
+          return allArgs.where((arg) => !argNames.contains(arg.name)).toList();
+        } else {
+          return allArgs
+              .where(
+                (arg) => !head.contains(arg.name) && arg.name.startsWith(tail),
+              )
+              .toList();
+        }
+      }
+    }
+    return mfmFn[type.query] ?? [];
+  }
+  return [];
 });
 
 class MfmFnKeyboard extends ConsumerWidget {
@@ -54,12 +146,12 @@ class MfmFnKeyboard extends ConsumerWidget {
   final FocusNode focusNode;
   final BuildContext parentContext;
 
-  Future<void> insertMfmFn(String mfmFn) async {
+  Future<void> insertMfmFnName(String mfmFnName) async {
     final textBeforeSelection = controller.textBeforeSelection;
     final lastOpenTagIndex = textBeforeSelection!.lastIndexOf(r"$[");
     final queryLength = textBeforeSelection.length - lastOpenTagIndex - 2;
-    controller.insert(mfmFn.substring(queryLength));
-    if (mfmFn == "unixtime") {
+    controller.insert(mfmFnName.substring(queryLength));
+    if (mfmFnName == "unixtime") {
       final resultDate = await showDateTimePicker(
         context: parentContext,
         firstDate: DateTime.utc(-271820, 12, 31),
@@ -71,7 +163,7 @@ class MfmFnKeyboard extends ConsumerWidget {
 
         controller.insert(" $unixtime");
       }
-    } else if (mfmFn == "fg" || mfmFn == "bg") {
+    } else if (mfmFnName == "fg" || mfmFnName == "bg") {
       final result = await showDialog<Color?>(
           context: parentContext,
           builder: (context) => const ColorPickerDialog());
@@ -86,30 +178,83 @@ class MfmFnKeyboard extends ConsumerWidget {
     focusNode.requestFocus();
   }
 
+  Future<void> insertMfmFnArg(MfmFnArg arg) async {
+    final textBeforeSelection = controller.textBeforeSelection!;
+    final lastOpenTagIndex = textBeforeSelection.lastIndexOf(r"$[");
+    final firstPeriodIndex = textBeforeSelection.indexOf(".", lastOpenTagIndex);
+    final mfmFnName = textBeforeSelection.substring(
+      lastOpenTagIndex + 2,
+      firstPeriodIndex < 0 ? null : firstPeriodIndex,
+    );
+    if (firstPeriodIndex < 0) {
+      controller.insert(".${arg.name}");
+    } else {
+      final lastArg =
+          textBeforeSelection.substring(firstPeriodIndex + 1).split(",").last;
+      final lastArgName = lastArg.split("=").first;
+      if (mfmFn[mfmFnName]?.any((arg) => arg.name == lastArgName) ?? false) {
+        controller.insert(",${arg.name}");
+      } else if (textBeforeSelection.contains(",", lastOpenTagIndex)) {
+        controller.insert(arg.name.substring(lastArg.length));
+      } else {
+        final queryLength = textBeforeSelection.length - firstPeriodIndex - 1;
+        controller.insert(arg.name.substring(queryLength));
+      }
+    }
+    if ((mfmFnName == "fg" || mfmFnName == "bg") && arg.name == "color") {
+      final result = await showDialog<Color?>(
+        context: parentContext,
+        builder: (context) => const ColorPickerDialog(),
+      );
+      if (result != null) {
+        controller.insert(
+          "=${result.red.toRadixString(16).padLeft(2, "0")}${result.green.toRadixString(16).padLeft(2, "0")}${result.blue.toRadixString(16).padLeft(2, "0")}",
+        );
+      } else {
+        controller.insert("=f00");
+      }
+    } else if (arg.defaultValue != null) {
+      controller.insert("=${arg.defaultValue}");
+    }
+    focusNode.requestFocus();
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final filteredMfmFn = ref.watch(_filteredMfmFnProvider);
+    final filteredNames = ref.watch(filteredMfmFnNamesProvider);
+    final filteredArgs = ref.watch(filteredMfmFnArgsProvider);
 
-    if (filteredMfmFn.isEmpty) {
+    if (filteredArgs.isNotEmpty) {
+      return Row(
+        children: filteredArgs
+            .map(
+              (arg) => CustomKeyboardButton(
+                keyboard: arg.name,
+                controller: controller,
+                focusNode: focusNode,
+                onTap: () => insertMfmFnArg(arg),
+              ),
+            )
+            .toList(),
+      );
+    } else if (filteredNames.isNotEmpty) {
+      return Row(
+        children: filteredNames
+            .map(
+              (name) => CustomKeyboardButton(
+                keyboard: name,
+                controller: controller,
+                focusNode: focusNode,
+                onTap: () => insertMfmFnName(name),
+              ),
+            )
+            .toList(),
+      );
+    } else {
       return BasicKeyboard(
         controller: controller,
         focusNode: focusNode,
       );
     }
-
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      mainAxisSize: MainAxisSize.max,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        for (final mfmFn in filteredMfmFn)
-          CustomKeyboardButton(
-            keyboard: mfmFn,
-            controller: controller,
-            focusNode: focusNode,
-            onTap: () => insertMfmFn(mfmFn),
-          ),
-      ],
-    );
   }
 }

--- a/test/view/common/note_create/mfm_fn_keyboard_test.dart
+++ b/test/view/common/note_create/mfm_fn_keyboard_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miria/model/input_completion_type.dart';
+import 'package:miria/view/common/note_create/input_completation.dart';
+import 'package:miria/view/common/note_create/mfm_fn_keyboard.dart';
+
+void main() {
+  test("入力が空文字列のとき全ての関数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider.overrideWith((ref) => const MfmFn("")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, orderedEquals(mfmFn.keys));
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(args, isEmpty);
+  });
+
+  test("入力された文字列で始まる関数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider.overrideWith((ref) => const MfmFn("s")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, orderedEquals(["shake", "spin", "scale", "sparkle"]));
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(args, isEmpty);
+  });
+
+  test("関数名が入力されたとき全ての引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider.overrideWith((ref) => const MfmFn("spin")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, orderedEquals(["spin"]));
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "speed", defaultValue: "1.5s"),
+        MfmFnArg(name: "delay", defaultValue: "0s"),
+        MfmFnArg(name: "x"),
+        MfmFnArg(name: "y"),
+        MfmFnArg(name: "left"),
+        MfmFnArg(name: "alternate"),
+      ]),
+    );
+  });
+
+  test("関数名とピリオドが入力されたとき全ての引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider.overrideWith((ref) => const MfmFn("spin.")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "speed", defaultValue: "1.5s"),
+        MfmFnArg(name: "delay", defaultValue: "0s"),
+        MfmFnArg(name: "x"),
+        MfmFnArg(name: "y"),
+        MfmFnArg(name: "left"),
+        MfmFnArg(name: "alternate"),
+      ]),
+    );
+  });
+
+  test("関数名と引数名の一部が入力されたとき入力された文字列で始まる引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider
+            .overrideWith((ref) => const MfmFn("spin.s")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "speed", defaultValue: "1.5s"),
+      ]),
+    );
+  });
+
+  test("関数名と引数名が入力されたとき入力されていない引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider
+            .overrideWith((ref) => const MfmFn("spin.x")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "speed", defaultValue: "1.5s"),
+        MfmFnArg(name: "delay", defaultValue: "0s"),
+        MfmFnArg(name: "y"),
+        MfmFnArg(name: "left"),
+        MfmFnArg(name: "alternate"),
+      ]),
+    );
+  });
+
+  test("関数名と引数名とコンマが入力されたとき入力されていない引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider
+            .overrideWith((ref) => const MfmFn("spin.x,")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "speed", defaultValue: "1.5s"),
+        MfmFnArg(name: "delay", defaultValue: "0s"),
+        MfmFnArg(name: "y"),
+        MfmFnArg(name: "left"),
+        MfmFnArg(name: "alternate"),
+      ]),
+    );
+  });
+
+  test("関数名と引数名と値が入力されたとき入力されていない引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider
+            .overrideWith((ref) => const MfmFn("spin.speed=1.5s")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "delay", defaultValue: "0s"),
+        MfmFnArg(name: "x"),
+        MfmFnArg(name: "y"),
+        MfmFnArg(name: "left"),
+        MfmFnArg(name: "alternate"),
+      ]),
+    );
+  });
+
+  test("関数名と引数名と値とコンマが入力されたとき入力されていない引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider
+            .overrideWith((ref) => const MfmFn("spin.speed=1.5s,")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "delay", defaultValue: "0s"),
+        MfmFnArg(name: "x"),
+        MfmFnArg(name: "y"),
+        MfmFnArg(name: "left"),
+        MfmFnArg(name: "alternate"),
+      ]),
+    );
+  });
+
+  test("引数名が正しくない場合空のリストを返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider
+            .overrideWith((ref) => const MfmFn("spin.xy")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(args, isEmpty);
+  });
+
+  test("2つ目の引数名の一部が入力されたとき入力された文字列で始まる引数を返す", () {
+    final container = ProviderContainer(
+      overrides: [
+        inputCompletionTypeProvider
+            .overrideWith((ref) => const MfmFn("spin.x,s")),
+      ],
+    );
+    addTearDown(container.dispose);
+    final names = container.read(filteredMfmFnNamesProvider);
+    expect(names, isEmpty);
+    final args = container.read(filteredMfmFnArgsProvider);
+    expect(
+      args,
+      orderedEquals(const [
+        MfmFnArg(name: "speed", defaultValue: "1.5s"),
+      ]),
+    );
+  });
+}

--- a/test/view/note_create_page/note_create_page_test.dart
+++ b/test/view/note_create_page/note_create_page_test.dart
@@ -1321,6 +1321,32 @@ void main() {
           );
         });
 
+        testWidgets("MFMの関数の引数の入力補完が可能なこと", (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              child: DefaultRootWidget(
+                initialRoute: NoteCreateRoute(initialAccount: TestData.account),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          await tester.enterText(
+            find.byType(TextField).hitTestable(),
+            r"$[spin.s",
+          );
+          await tester.pumpAndSettle();
+          await tester.tap(find.text("speed"));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text("x"));
+          await tester.pumpAndSettle();
+          expect(
+            tester
+                .textEditingController(find.byType(TextField).hitTestable())
+                .text,
+            r"$[spin.speed=1.5s,x",
+          );
+        });
+
         testWidgets("ハッシュタグの入力補完が可能なこと", (tester) async {
           final mockMisskey = MockMisskey();
           final mockHashtags = MockMisskeyHashtags();


### PR DESCRIPTION
入力補完でMFMの関数の引数を表示するようにしました

- 関数名の直後にカーソルがあるときに引数を表示します
  - 関数名の入力補完では最後に空白が追加されるため、関数名の入力補完をタップした状態では引数の入力補完は表示されません
    - 一つ左にカーソルを戻すことで表示されます
  - 入力された関数に対して存在する引数のうち、まだ入力されていないものを表示します
    - 引数名の一部が入力されている場合はそれで始まるもののみ表示します
- 引数名をタップした場合は引数名と、（あれば）デフォルトの値を挿入します
  - 空白は挿入しません
  - ピリオドやコンマが必要な場合は挿入します

ref: https://github.com/shiosyakeyakini-info/miria/pull/476#issuecomment-1839470713