### PR TITLE
リアクションピッカーにoverlayColorを追加

### DIFF
--- a/lib/view/reaction_picker_dialog/reaction_picker_content.dart
+++ b/lib/view/reaction_picker_dialog/reaction_picker_content.dart
@@ -9,6 +9,7 @@ import 'package:miria/repository/emoji_repository.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/misskey_notes/custom_emoji.dart';
 import 'package:miria/view/dialogs/simple_message_dialog.dart';
+import 'package:miria/view/themes/app_theme.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 class ReactionPickerContent extends ConsumerStatefulWidget {
@@ -163,11 +164,12 @@ class EmojiButtonState extends ConsumerState<EmojiButton> {
             ? BoxDecoration(color: Theme.of(context).disabledColor)
             : const BoxDecoration(),
         child: ElevatedButton(
-          style: const ButtonStyle(
+          style: ButtonStyle(
             backgroundColor: MaterialStatePropertyAll(Colors.transparent),
             padding: MaterialStatePropertyAll(EdgeInsets.all(5)),
             elevation: MaterialStatePropertyAll(0),
             minimumSize: MaterialStatePropertyAll(Size.zero),
+            overlayColor: MaterialStatePropertyAll(AppTheme.of(context).colorTheme.accentedBackground),
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
           onPressed: () async {


### PR DESCRIPTION
リアクションピッカーに`overlayColor`として`accentedBackground`を設定する提案です。
この変更により、デスクトップなどでキーボードを用いてリアクションを選択するときの視認性が向上します。

![screenshot_231227224051](https://github.com/shiosyakeyakini-info/miria/assets/66727014/d8e298a3-882a-4263-9adb-4f73aa2313be)
