### PR TITLE
withRepliesとwithFilesを同時にtrueにしない

### DIFF
--- a/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
@@ -323,14 +323,24 @@ class TabSettingsAddDialogState extends ConsumerState<TabSettingsPage> {
                   title: const Text("返信も入れる"),
                   subtitle: const Text("Misskey v2023.10.1以降の機能です。"),
                   value: isIncludeReply,
-                  onChanged: (value) =>
-                      setState(() => isIncludeReply = !isIncludeReply),
+                  enabled: !isMediaOnly,
+                  onChanged: (value) => setState(() {
+                    isIncludeReply = !isIncludeReply;
+                    if (value ?? false) {
+                      isMediaOnly = false;
+                    }
+                  }),
                 ),
               CheckboxListTile(
                 title: const Text("ファイルのみにする"),
                 value: isMediaOnly,
-                onChanged: (value) =>
-                    setState(() => isMediaOnly = !isMediaOnly),
+                enabled: !isIncludeReply,
+                onChanged: (value) => setState(() {
+                  isMediaOnly = !isMediaOnly;
+                  if (value ?? false) {
+                    isIncludeReply = false;
+                  }
+                }),
               ),
               CheckboxListTile(
                 title: const Text("リアクションや投票数を自動更新する"),

--- a/lib/view/user_page/user_notes.dart
+++ b/lib/view/user_page/user_notes.dart
@@ -57,9 +57,15 @@ class UserNotesState extends ConsumerState<UserNotes> {
                           switch (value) {
                             case 0:
                               withReply = !withReply;
+                              if (withReply) {
+                                isFileOnly = false;
+                              }
                               highlight = false;
                             case 1:
                               isFileOnly = !isFileOnly;
+                              if (isFileOnly) {
+                                withReply = false;
+                              }
                               highlight = false;
                             case 2:
                               renote = !renote;


### PR DESCRIPTION
Fix #506

- ユーザーのノート一覧で「返信つき」と「ファイルつき」のどちらかをタップしたときにもう一方の選択を解除するようにしました
- タブ設定で「返信も入れる」と「ファイルのみにする」のどちらかをタップしたときにもう一方の選択を解除し、変更できなくするようにしました