### PR TITLE
メタデータをエクスポートする

### DIFF
--- a/lib/view/settings_page/import_export_page/import_export_page.dart
+++ b/lib/view/settings_page/import_export_page/import_export_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:miria/model/account.dart';
 import 'package:miria/providers.dart';
+import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:miria/view/dialogs/simple_message_dialog.dart';
 
 @RoutePage()
@@ -66,7 +67,8 @@ class ImportExportPageState extends ConsumerState<ImportExportPage> {
                       }
                       await ref
                           .read(importExportRepository)
-                          .import(context, account);
+                          .import(context, account)
+                          .expectFailure(context);
                     },
                     child: const Text("選択"),
                   ),
@@ -113,7 +115,8 @@ class ImportExportPageState extends ConsumerState<ImportExportPage> {
                         }
                         ref
                             .read(importExportRepository)
-                            .export(context, account);
+                            .export(context, account)
+                            .expectFailure(context);
                       },
                       child: const Text("保存")),
                 ],


### PR DESCRIPTION
Resolve #496

設定ファイルのエクスポート時にファイルにメタデータを追加するようにしました
人間が読むことを想定しています

- エクスポート日時
- パッケージ情報 ([package_info_plus](https://pub.dev/packages/package_info_plus))
  - バージョンを含みます
- プラットフォーム