### PR TITLE
絵文字名からEmojiRepositoryDataを取得する場合にHashMapを使用するように

### DIFF
--- a/lib/model/misskey_emoji_data.dart
+++ b/lib/model/misskey_emoji_data.dart
@@ -9,10 +9,6 @@ sealed class MisskeyEmojiData {
     this.isSensitive,
   );
 
-  static final customEmojiRegExp = RegExp(r":(.+?)@(.+?):");
-  static final hostIncludedRegExp = RegExp(r":(.+?):");
-  static final customEmojiRegExp2 = RegExp(r"^:(.+?):$");
-
   factory MisskeyEmojiData.fromEmojiName({
     required String emojiName,
     Map<String, String>? emojiInfo,
@@ -22,6 +18,9 @@ sealed class MisskeyEmojiData {
     if (!emojiName.startsWith(":")) {
       return UnicodeEmojiData(char: emojiName);
     }
+
+    final customEmojiRegExp = RegExp(r":(.+?)@(.+?):");
+    final hostIncludedRegExp = RegExp(r":(.+?):");
 
     // よそのサーバー
     if (emojiInfo != null && emojiInfo.isNotEmpty) {
@@ -53,6 +52,7 @@ sealed class MisskeyEmojiData {
     }
 
     // 自分のサーバー　:ai:
+    final customEmojiRegExp2 = RegExp(r"^:(.+?):$");
     if (customEmojiRegExp2.hasMatch(emojiName)) {
       assert(repository != null);
       final name =

--- a/lib/model/misskey_emoji_data.dart
+++ b/lib/model/misskey_emoji_data.dart
@@ -9,6 +9,10 @@ sealed class MisskeyEmojiData {
     this.isSensitive,
   );
 
+  static final customEmojiRegExp = RegExp(r":(.+?)@(.+?):");
+  static final hostIncludedRegExp = RegExp(r":(.+?):");
+  static final customEmojiRegExp2 = RegExp(r"^:(.+?):$");
+
   factory MisskeyEmojiData.fromEmojiName({
     required String emojiName,
     Map<String, String>? emojiInfo,
@@ -18,9 +22,6 @@ sealed class MisskeyEmojiData {
     if (!emojiName.startsWith(":")) {
       return UnicodeEmojiData(char: emojiName);
     }
-
-    final customEmojiRegExp = RegExp(r":(.+?)@(.+?):");
-    final hostIncludedRegExp = RegExp(r":(.+?):");
 
     // よそのサーバー
     if (emojiInfo != null && emojiInfo.isNotEmpty) {
@@ -44,32 +45,21 @@ sealed class MisskeyEmojiData {
     // 自分のサーバー :ai@.:
     if (customEmojiRegExp.hasMatch(emojiName)) {
       assert(repository != null);
-      final EmojiRepositoryData? found = repository!.emoji?.firstWhereOrNull(
-          (e) =>
-              e.emoji.baseName ==
-              (customEmojiRegExp.firstMatch(emojiName)?.group(1) ?? emojiName));
-      if (found != null) {
-        return found.emoji;
-      } else {
-        return NotEmojiData(name: emojiName);
-      }
+      final name =
+          (customEmojiRegExp.firstMatch(emojiName)?.group(1) ?? emojiName);
+      final EmojiRepositoryData? found = repository!.emojiMap?[name];
+
+      return found?.emoji ?? NotEmojiData(name: emojiName);
     }
 
     // 自分のサーバー　:ai:
-    final customEmojiRegExp2 = RegExp(r"^:(.+?):$");
     if (customEmojiRegExp2.hasMatch(emojiName)) {
       assert(repository != null);
-      final EmojiRepositoryData? found = repository!.emoji?.firstWhereOrNull(
-          (e) =>
-              e.emoji.baseName ==
-              (customEmojiRegExp2.firstMatch(emojiName)?.group(1) ??
-                  emojiName));
+      final name =
+          (customEmojiRegExp2.firstMatch(emojiName)?.group(1) ?? emojiName);
+      final EmojiRepositoryData? found = repository!.emojiMap?[name];
 
-      if (found != null) {
-        return found.emoji;
-      } else {
-        return NotEmojiData(name: emojiName);
-      }
+      return found?.emoji ?? NotEmojiData(name: emojiName);
     }
 
     return NotEmojiData(name: emojiName);

--- a/lib/repository/emoji_repository.dart
+++ b/lib/repository/emoji_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
@@ -13,6 +14,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 abstract class EmojiRepository {
   List<EmojiRepositoryData>? emoji;
+  Map<String, EmojiRepositoryData>? emojiMap;
   Future<void> loadFromSourceIfNeed();
   Future<void> loadFromSource();
 
@@ -143,6 +145,12 @@ class EmojiRepositoryImpl extends EmojiRepository {
             ))
         .toList();
     emoji!.addAll(unicodeEmojis);
+
+    emojiMap = HashMap();
+    for(var e in emoji!)
+    {
+      emojiMap![e.emoji.baseName] = e;
+    }
   }
 
   bool emojiSearchCondition(


### PR DESCRIPTION
TLをある程度読み込んだのち、タブの切り替え時に一時的に重たくなってしまう問題の修正提案です。
fromEmojiNameで絵文字を取得する際にHashMapを使用するように変更しました。