### PR TITLE
[Windows]windows_deploy.ymlのDLLコピー操作を削除

### DIFF
--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -1,6 +1,6 @@
 name: デプロイ(windows zip)
 
-on: 
+on:
   workflow_dispatch:
   release:
     types: [published]
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -34,12 +34,6 @@ jobs:
         run: |
           flutter build windows --release
 
-      - name: Copy DLL
-        run: |
-          cp C:\Windows\System32\msvcp140.dll build\windows\x64\runner\Release\
-          cp C:\Windows\System32\vcruntime140.dll build\windows\x64\runner\Release\
-          cp C:\Windows\System32\vcruntime140_1.dll build\windows\x64\runner\Release\
-
       - name: Compile .ISS to .EXE Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.1.0
         with:
@@ -49,7 +43,7 @@ jobs:
       - name: Rename .EXE Installer
         run:  mv miria-installer.exe miria-installer_${env:version}_x64.exe
 
-      - name: Zip files
+      - name: Compress files
         run: |
           ren build\windows\x64\runner\Release Miria
           Compress-Archive -Path build\windows\x64\runner\Miria -DestinationPath miria_${env:version}_windows-x64.zip -Force


### PR DESCRIPTION
今までインストーラーやZipファイルの作成時に`msvcp140.dll, vcruntime140.dll, vcruntime140_1.dll`を含めるようコピーする操作を行っていたが、最近のリリースでは必要なライブラリが自動で`Release`ディレクトリ以下にコピーされるようになっていた（`api-ms-win-*.dll`まで含める必要があるのかは不明）ため、DLLをコピーする操作を`windows_deploy.yml`から削除しました。