### PR TITLE
フォロー・お気に入りしていないチャンネルのタブを作れるように

### DIFF
--- a/lib/view/channels_page/channel_favorited.dart
+++ b/lib/view/channels_page/channel_favorited.dart
@@ -7,16 +7,24 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 class ChannelFavorited extends ConsumerWidget {
-  const ChannelFavorited({super.key});
+  const ChannelFavorited({super.key, this.onChannelSelected});
+
+  final void Function(CommunityChannel channel)? onChannelSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final account = AccountScope.of(context);
     return FutureListView(
-        future: ref
-            .read(misskeyProvider(account))
-            .channels
-            .myFavorite(const ChannelsMyFavoriteRequest()),
-        builder: (context, item) => CommunityChannelView(channel: item));
+      future: ref
+          .read(misskeyProvider(account))
+          .channels
+          .myFavorite(const ChannelsMyFavoriteRequest()),
+      builder: (context, item) => CommunityChannelView(
+        channel: item,
+        onTap: onChannelSelected != null
+            ? () => onChannelSelected?.call(item)
+            : null,
+      ),
+    );
   }
 }

--- a/lib/view/channels_page/channel_followed.dart
+++ b/lib/view/channels_page/channel_followed.dart
@@ -7,26 +7,34 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 class ChannelFollowed extends ConsumerWidget {
-  const ChannelFollowed({super.key});
+  const ChannelFollowed({super.key, this.onChannelSelected});
+
+  final void Function(CommunityChannel channel)? onChannelSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final account = AccountScope.of(context);
     return PushableListView(
-        initializeFuture: () async {
-          final response = await ref
-              .read(misskeyProvider(account))
-              .channels
-              .followed(const ChannelsFollowedRequest());
-          return response.toList();
-        },
-        nextFuture: (lastItem, _) async {
-          final response = await ref
-              .read(misskeyProvider(account))
-              .channels
-              .followed(ChannelsFollowedRequest(untilId: lastItem.id));
-          return response.toList();
-        },
-        itemBuilder: (context, item) => CommunityChannelView(channel: item));
+      initializeFuture: () async {
+        final response = await ref
+            .read(misskeyProvider(account))
+            .channels
+            .followed(const ChannelsFollowedRequest());
+        return response.toList();
+      },
+      nextFuture: (lastItem, _) async {
+        final response = await ref
+            .read(misskeyProvider(account))
+            .channels
+            .followed(ChannelsFollowedRequest(untilId: lastItem.id));
+        return response.toList();
+      },
+      itemBuilder: (context, item) => CommunityChannelView(
+        channel: item,
+        onTap: onChannelSelected != null
+            ? () => onChannelSelected?.call(item)
+            : null,
+      ),
+    );
   }
 }

--- a/lib/view/channels_page/channel_trend.dart
+++ b/lib/view/channels_page/channel_trend.dart
@@ -5,17 +5,26 @@ import 'package:miria/view/channels_page/community_channel_view.dart';
 import 'package:miria/view/common/account_scope.dart';
 import 'package:miria/view/common/futable_list_builder.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:misskey_dart/misskey_dart.dart';
 
 class ChannelTrend extends ConsumerWidget {
-  const ChannelTrend({super.key});
+  const ChannelTrend({super.key, this.onChannelSelected});
+
+  final void Function(CommunityChannel channel)? onChannelSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return FutureListView(
-        future: ref
-            .read(misskeyProvider(AccountScope.of(context)))
-            .channels
-            .featured(),
-        builder: (context, item) => CommunityChannelView(channel: item));
+      future: ref
+          .read(misskeyProvider(AccountScope.of(context)))
+          .channels
+          .featured(),
+      builder: (context, item) => CommunityChannelView(
+        channel: item,
+        onTap: onChannelSelected != null
+            ? () => onChannelSelected?.call(item)
+            : null,
+      ),
+    );
   }
 }

--- a/lib/view/channels_page/community_channel_view.dart
+++ b/lib/view/channels_page/community_channel_view.dart
@@ -8,16 +8,22 @@ import 'package:misskey_dart/misskey_dart.dart';
 
 class CommunityChannelView extends StatelessWidget {
   final CommunityChannel channel;
+  final void Function()? onTap;
 
-  const CommunityChannelView({super.key, required this.channel});
+  const CommunityChannelView({
+    super.key,
+    required this.channel,
+    this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Padding(
         padding: const EdgeInsets.all(10),
         child: GestureDetector(
-          onTap: () => context.pushRoute(ChannelDetailRoute(
-              account: AccountScope.of(context), channelId: channel.id)),
+          onTap: onTap ??
+              () => context.pushRoute(ChannelDetailRoute(
+                  account: AccountScope.of(context), channelId: channel.id)),
           child: Container(
             decoration: BoxDecoration(
                 border: Border.all(color: Theme.of(context).dividerColor)),
@@ -33,6 +39,7 @@ class CommunityChannelView extends StatelessWidget {
                     child: Image.network(
                       channel.bannerUrl!.toString(),
                       fit: BoxFit.fitWidth,
+                      errorBuilder: (_, __, ___) => const SizedBox.shrink(),
                     ),
                   ),
                 Padding(

--- a/lib/view/settings_page/tab_settings_page/channel_select_dialog.dart
+++ b/lib/view/settings_page/tab_settings_page/channel_select_dialog.dart
@@ -1,94 +1,87 @@
 import 'package:flutter/material.dart';
 import 'package:miria/model/account.dart';
-import 'package:miria/providers.dart';
+import 'package:miria/view/channels_page/channel_favorited.dart';
+import 'package:miria/view/channels_page/channel_followed.dart';
+import 'package:miria/view/channels_page/channel_search.dart';
+import 'package:miria/view/channels_page/channel_trend.dart';
 import 'package:miria/view/common/account_scope.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:misskey_dart/misskey_dart.dart';
 
-class ChannelSelectDialog extends ConsumerStatefulWidget {
+class ChannelSelectDialog extends StatelessWidget {
   final Account account;
 
   const ChannelSelectDialog({super.key, required this.account});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      ChannelSelectDialogState();
-}
-
-class ChannelSelectDialogState extends ConsumerState<ChannelSelectDialog> {
-  final favoritedChannels = <CommunityChannel>[];
-  final followedChannels = <CommunityChannel>[];
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    Future(() async {
-      final myFavorites = await ref
-          .read(misskeyProvider(widget.account))
-          .channels
-          .myFavorite(const ChannelsMyFavoriteRequest(limit: 100));
-      favoritedChannels
-        ..clear()
-        ..addAll(myFavorites);
-
-      final followed = await ref
-          .read(misskeyProvider(widget.account))
-          .channels
-          .followed(const ChannelsFollowedRequest(limit: 100));
-      followedChannels
-        ..clear()
-        ..addAll(followed);
-      if (!mounted) return;
-      setState(() {});
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return AccountScope(
-      account: widget.account,
-      child: AlertDialog(
-        title: const Text("チャンネル選択"),
-        content: SizedBox(
-          width: MediaQuery.of(context).size.width * 0.8,
-          height: MediaQuery.of(context).size.height * 0.8,
-          child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  "フォロー中",
-                  style: Theme.of(context).textTheme.titleMedium,
+    return AlertDialog(
+      title: const Text("チャンネル選択"),
+      content: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.8,
+        height: MediaQuery.of(context).size.height * 0.8,
+        child: DefaultTabController(
+          length: 4,
+          initialIndex: 2,
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(bottom: 5),
+                child: Container(
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).primaryColor,
+                  ),
+                  child: const Align(
+                    child: TabBar(
+                      tabs: [
+                        Tab(text: "検索"),
+                        Tab(text: "トレンド"),
+                        Tab(text: "お気に入り"),
+                        Tab(text: "フォロー中"),
+                      ],
+                      isScrollable: true,
+                      tabAlignment: TabAlignment.center,
+                    ),
+                  ),
                 ),
-                ListView.builder(
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    itemCount: followedChannels.length,
-                    itemBuilder: (context, index) {
-                      return ListTile(
-                          onTap: () {
-                            Navigator.of(context).pop(followedChannels[index]);
-                          },
-                          title: Text(followedChannels[index].name));
-                    }),
-                const Padding(padding: EdgeInsets.only(top: 30)),
-                Text(
-                  "お気に入り",
-                  style: Theme.of(context).textTheme.titleMedium,
+              ),
+              Expanded(
+                child: AccountScope(
+                  account: account,
+                  child: TabBarView(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        child: ChannelSearch(
+                          onChannelSelected: (channel) =>
+                              Navigator.of(context).pop(channel),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        child: ChannelTrend(
+                          onChannelSelected: (channel) =>
+                              Navigator.of(context).pop(channel),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        child: ChannelFavorited(
+                          onChannelSelected: (channel) =>
+                              Navigator.of(context).pop(channel),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        child: ChannelFollowed(
+                          onChannelSelected: (channel) =>
+                              Navigator.of(context).pop(channel),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-                ListView.builder(
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    itemCount: favoritedChannels.length,
-                    itemBuilder: (context, index) {
-                      return ListTile(
-                          onTap: () {
-                            Navigator.of(context).pop(favoritedChannels[index]);
-                          },
-                          title: Text(favoritedChannels[index].name));
-                    }),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/test/view/search_page/search_page_test.dart
+++ b/test/view/search_page/search_page_test.dart
@@ -114,20 +114,21 @@ void main() {
       await tester.tap(find.byIcon(Icons.keyboard_arrow_right).at(1));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text(TestData.channel1.name));
+      await tester.tap(find.text(TestData.channel2.name));
       await tester.pumpAndSettle();
 
-      // 指定したユーザーが表示されていること
+      // 指定したチャンネルが表示されていること
       expect(
           find.descendant(
-              of: find.byType(Card),
-              matching: find.text(TestData.channel1.name)),
+            of: find.byType(Card),
+            matching: find.text(TestData.channel2.name),
+          ),
           findsOneWidget);
 
       // ノートが表示されていること
       expect(find.text(TestData.note1.text!), findsOneWidget);
       verify(mockNote.search(argThat(equals(
-              NotesSearchRequest(query: "", channelId: TestData.channel1.id)))))
+              NotesSearchRequest(query: "", channelId: TestData.channel2.id)))))
           .called(1);
     });
 


### PR DESCRIPTION
タブ設定ページでチャンネルを選択するときにフォロー中とお気に入りのチャンネルのみ選択可能でしたが、検索とトレンドからもチャンネルを選択できるようにしました