### PR TITLE
アバターを非表示にできるように

### DIFF
--- a/lib/model/general_settings.dart
+++ b/lib/model/general_settings.dart
@@ -99,6 +99,9 @@ class GeneralSettings with _$GeneralSettings {
 
     /// `$[font.fantasy のフォント名
     @Default("") String fantasyFontName,
+
+    /// ユーザーのアバターを隠す
+    @Default(false) bool hideAvatar,
   }) = _GeneralSettings;
 
   factory GeneralSettings.fromJson(Map<String, dynamic> json) =>

--- a/lib/model/general_settings.freezed.dart
+++ b/lib/model/general_settings.freezed.dart
@@ -66,6 +66,9 @@ mixin _$GeneralSettings {
   /// `$[font.fantasy のフォント名
   String get fantasyFontName => throw _privateConstructorUsedError;
 
+  /// ユーザーのアバターを隠す
+  bool get hideAvatar => throw _privateConstructorUsedError;
+
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $GeneralSettingsCopyWith<GeneralSettings> get copyWith =>
@@ -95,7 +98,8 @@ abstract class $GeneralSettingsCopyWith<$Res> {
       String serifFontName,
       String monospaceFontName,
       String cursiveFontName,
-      String fantasyFontName});
+      String fantasyFontName,
+      bool hideAvatar});
 }
 
 /// @nodoc
@@ -128,6 +132,7 @@ class _$GeneralSettingsCopyWithImpl<$Res, $Val extends GeneralSettings>
     Object? monospaceFontName = null,
     Object? cursiveFontName = null,
     Object? fantasyFontName = null,
+    Object? hideAvatar = null,
   }) {
     return _then(_value.copyWith(
       lightColorThemeId: null == lightColorThemeId
@@ -198,6 +203,10 @@ class _$GeneralSettingsCopyWithImpl<$Res, $Val extends GeneralSettings>
           ? _value.fantasyFontName
           : fantasyFontName // ignore: cast_nullable_to_non_nullable
               as String,
+      hideAvatar: null == hideAvatar
+          ? _value.hideAvatar
+          : hideAvatar // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -227,7 +236,8 @@ abstract class _$$GeneralSettingsImplCopyWith<$Res>
       String serifFontName,
       String monospaceFontName,
       String cursiveFontName,
-      String fantasyFontName});
+      String fantasyFontName,
+      bool hideAvatar});
 }
 
 /// @nodoc
@@ -258,6 +268,7 @@ class __$$GeneralSettingsImplCopyWithImpl<$Res>
     Object? monospaceFontName = null,
     Object? cursiveFontName = null,
     Object? fantasyFontName = null,
+    Object? hideAvatar = null,
   }) {
     return _then(_$GeneralSettingsImpl(
       lightColorThemeId: null == lightColorThemeId
@@ -328,6 +339,10 @@ class __$$GeneralSettingsImplCopyWithImpl<$Res>
           ? _value.fantasyFontName
           : fantasyFontName // ignore: cast_nullable_to_non_nullable
               as String,
+      hideAvatar: null == hideAvatar
+          ? _value.hideAvatar
+          : hideAvatar // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -352,7 +367,8 @@ class _$GeneralSettingsImpl implements _GeneralSettings {
       this.serifFontName = "",
       this.monospaceFontName = "",
       this.cursiveFontName = "",
-      this.fantasyFontName = ""});
+      this.fantasyFontName = "",
+      this.hideAvatar = false});
 
   factory _$GeneralSettingsImpl.fromJson(Map<String, dynamic> json) =>
       _$$GeneralSettingsImplFromJson(json);
@@ -437,9 +453,14 @@ class _$GeneralSettingsImpl implements _GeneralSettings {
   @JsonKey()
   final String fantasyFontName;
 
+  /// ユーザーのアバターを隠す
+  @override
+  @JsonKey()
+  final bool hideAvatar;
+
   @override
   String toString() {
-    return 'GeneralSettings(lightColorThemeId: $lightColorThemeId, darkColorThemeId: $darkColorThemeId, themeColorSystem: $themeColorSystem, nsfwInherit: $nsfwInherit, enableDirectReaction: $enableDirectReaction, automaticPush: $automaticPush, enableAnimatedMFM: $enableAnimatedMFM, enableLongTextElipsed: $enableLongTextElipsed, enableFavoritedRenoteElipsed: $enableFavoritedRenoteElipsed, tabPosition: $tabPosition, textScaleFactor: $textScaleFactor, emojiType: $emojiType, defaultFontName: $defaultFontName, serifFontName: $serifFontName, monospaceFontName: $monospaceFontName, cursiveFontName: $cursiveFontName, fantasyFontName: $fantasyFontName)';
+    return 'GeneralSettings(lightColorThemeId: $lightColorThemeId, darkColorThemeId: $darkColorThemeId, themeColorSystem: $themeColorSystem, nsfwInherit: $nsfwInherit, enableDirectReaction: $enableDirectReaction, automaticPush: $automaticPush, enableAnimatedMFM: $enableAnimatedMFM, enableLongTextElipsed: $enableLongTextElipsed, enableFavoritedRenoteElipsed: $enableFavoritedRenoteElipsed, tabPosition: $tabPosition, textScaleFactor: $textScaleFactor, emojiType: $emojiType, defaultFontName: $defaultFontName, serifFontName: $serifFontName, monospaceFontName: $monospaceFontName, cursiveFontName: $cursiveFontName, fantasyFontName: $fantasyFontName, hideAvatar: $hideAvatar)';
   }
 
   @override
@@ -482,7 +503,9 @@ class _$GeneralSettingsImpl implements _GeneralSettings {
             (identical(other.cursiveFontName, cursiveFontName) ||
                 other.cursiveFontName == cursiveFontName) &&
             (identical(other.fantasyFontName, fantasyFontName) ||
-                other.fantasyFontName == fantasyFontName));
+                other.fantasyFontName == fantasyFontName) &&
+            (identical(other.hideAvatar, hideAvatar) ||
+                other.hideAvatar == hideAvatar));
   }
 
   @JsonKey(ignore: true)
@@ -505,7 +528,8 @@ class _$GeneralSettingsImpl implements _GeneralSettings {
       serifFontName,
       monospaceFontName,
       cursiveFontName,
-      fantasyFontName);
+      fantasyFontName,
+      hideAvatar);
 
   @JsonKey(ignore: true)
   @override
@@ -540,7 +564,8 @@ abstract class _GeneralSettings implements GeneralSettings {
       final String serifFontName,
       final String monospaceFontName,
       final String cursiveFontName,
-      final String fantasyFontName}) = _$GeneralSettingsImpl;
+      final String fantasyFontName,
+      final bool hideAvatar}) = _$GeneralSettingsImpl;
 
   factory _GeneralSettings.fromJson(Map<String, dynamic> json) =
       _$GeneralSettingsImpl.fromJson;
@@ -607,6 +632,10 @@ abstract class _GeneralSettings implements GeneralSettings {
 
   /// `$[font.fantasy のフォント名
   String get fantasyFontName;
+  @override
+
+  /// ユーザーのアバターを隠す
+  bool get hideAvatar;
   @override
   @JsonKey(ignore: true)
   _$$GeneralSettingsImplCopyWith<_$GeneralSettingsImpl> get copyWith =>

--- a/lib/model/general_settings.g.dart
+++ b/lib/model/general_settings.g.dart
@@ -36,6 +36,7 @@ _$GeneralSettingsImpl _$$GeneralSettingsImplFromJson(
       monospaceFontName: json['monospaceFontName'] as String? ?? "",
       cursiveFontName: json['cursiveFontName'] as String? ?? "",
       fantasyFontName: json['fantasyFontName'] as String? ?? "",
+      hideAvatar: json['hideAvatar'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$$GeneralSettingsImplToJson(
@@ -58,6 +59,7 @@ Map<String, dynamic> _$$GeneralSettingsImplToJson(
       'monospaceFontName': instance.monospaceFontName,
       'cursiveFontName': instance.cursiveFontName,
       'fantasyFontName': instance.fantasyFontName,
+      'hideAvatar': instance.hideAvatar,
     };
 
 const _$ThemeColorSystemEnumMap = {

--- a/lib/router/app_router.gr.dart
+++ b/lib/router/app_router.gr.dart
@@ -15,24 +15,13 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
-    NotesAfterRenoteRoute.name: (routeData) {
-      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
+    AnnouncementRoute.name: (routeData) {
+      final args = routeData.argsAs<AnnouncementRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotesAfterRenotePage(
+        child: AnnouncementPage(
           key: args.key,
-          note: args.note,
           account: args.account,
-        ),
-      );
-    },
-    AntennaRoute.name: (routeData) {
-      final args = routeData.argsAs<AntennaRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: AntennaPage(
-          account: args.account,
-          key: args.key,
         ),
       );
     },
@@ -47,20 +36,35 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    NotificationRoute.name: (routeData) {
-      final args = routeData.argsAs<NotificationRouteArgs>();
+    AntennaRoute.name: (routeData) {
+      final args = routeData.argsAs<AntennaRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: NotificationPage(
+        child: AntennaPage(
+          account: args.account,
+          key: args.key,
+        ),
+      );
+    },
+    ChannelsRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelsRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ChannelsPage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    LoginRoute.name: (routeData) {
+    ChannelDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<ChannelDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const LoginPage(),
+        child: ChannelDetailPage(
+          key: args.key,
+          account: args.account,
+          channelId: args.channelId,
+        ),
       );
     },
     ClipDetailRoute.name: (routeData) {
@@ -84,6 +88,87 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    ExploreRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExplorePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ExploreRoleUsersRoute.name: (routeData) {
+      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ExploreRoleUsersPage(
+          key: args.key,
+          item: args.item,
+          account: args.account,
+        ),
+      );
+    },
+    FavoritedNoteRoute.name: (routeData) {
+      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FavoritedNotePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    FederationRoute.name: (routeData) {
+      final args = routeData.argsAs<FederationRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: FederationPage(
+          key: args.key,
+          account: args.account,
+          host: args.host,
+        ),
+      );
+    },
+    HashtagRoute.name: (routeData) {
+      final args = routeData.argsAs<HashtagRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: HashtagPage(
+          key: args.key,
+          hashtag: args.hashtag,
+          account: args.account,
+        ),
+      );
+    },
+    LoginRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const LoginPage(),
+      );
+    },
+    MisskeyRouteRoute.name: (routeData) {
+      final args = routeData.argsAs<MisskeyRouteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: MisskeyPagePage(
+          key: args.key,
+          account: args.account,
+          page: args.page,
+        ),
+      );
+    },
+    NotesAfterRenoteRoute.name: (routeData) {
+      final args = routeData.argsAs<NotesAfterRenoteRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: NotesAfterRenotePage(
+          key: args.key,
+          note: args.note,
+          account: args.account,
+        ),
+      );
+    },
     NoteCreateRoute.name: (routeData) {
       final args = routeData.argsAs<NoteCreateRouteArgs>();
       return AutoRoutePage<dynamic>(
@@ -101,46 +186,23 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    HashtagRoute.name: (routeData) {
-      final args = routeData.argsAs<HashtagRouteArgs>();
+    NoteDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<NoteDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: HashtagPage(
+        child: NoteDetailPage(
           key: args.key,
-          hashtag: args.hashtag,
+          note: args.note,
           account: args.account,
         ),
       );
     },
-    UserFolloweeRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFolloweeRouteArgs>();
+    NotificationRoute.name: (routeData) {
+      final args = routeData.argsAs<NotificationRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: UserFolloweePage(
+        child: NotificationPage(
           key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserRoute.name: (routeData) {
-      final args = routeData.argsAs<UserRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserPage(
-          key: args.key,
-          userId: args.userId,
-          account: args.account,
-        ),
-      );
-    },
-    UserFollowerRoute.name: (routeData) {
-      final args = routeData.argsAs<UserFollowerRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UserFollowerPage(
-          key: args.key,
-          userId: args.userId,
           account: args.account,
         ),
       );
@@ -157,20 +219,92 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    AnnouncementRoute.name: (routeData) {
-      final args = routeData.argsAs<AnnouncementRouteArgs>();
+    SearchRoute.name: (routeData) {
+      final args = routeData.argsAs<SearchRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: AnnouncementPage(
+        child: SearchPage(
+          key: args.key,
+          initialSearchText: args.initialSearchText,
+          account: args.account,
+        ),
+      );
+    },
+    AccountListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AccountListPage(),
+      );
+    },
+    AppInfoRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const AppInfoPage(),
+      );
+    },
+    GeneralSettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const GeneralSettingsPage(),
+      );
+    },
+    ImportExportRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const ImportExportPage(),
+      );
+    },
+    SettingsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SettingsPage(),
+      );
+    },
+    TabSettingsListRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const TabSettingsListPage(),
+      );
+    },
+    TabSettingsRoute.name: (routeData) {
+      final args = routeData.argsAs<TabSettingsRouteArgs>(
+          orElse: () => const TabSettingsRouteArgs());
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: TabSettingsPage(
+          key: args.key,
+          tabIndex: args.tabIndex,
+        ),
+      );
+    },
+    CacheManagementRoute.name: (routeData) {
+      final args = routeData.argsAs<CacheManagementRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: CacheManagementPage(
           key: args.key,
           account: args.account,
         ),
       );
     },
-    SplashRoute.name: (routeData) {
+    InstanceMuteRoute.name: (routeData) {
+      final args = routeData.argsAs<InstanceMuteRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const SplashPage(),
+        child: InstanceMutePage(
+          key: args.key,
+          account: args.account,
+        ),
+      );
+    },
+    ReactionDeckRoute.name: (routeData) {
+      final args = routeData.argsAs<ReactionDeckRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ReactionDeckPage(
+          key: args.key,
+          account: args.account,
+        ),
       );
     },
     SeveralAccountGeneralSettingsRoute.name: (routeData) {
@@ -193,16 +327,6 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    InstanceMuteRoute.name: (routeData) {
-      final args = routeData.argsAs<InstanceMuteRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: InstanceMutePage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
     WordMuteRoute.name: (routeData) {
       final args = routeData.argsAs<WordMuteRouteArgs>();
       return AutoRoutePage<dynamic>(
@@ -211,112 +335,6 @@ abstract class _$AppRouter extends RootStackRouter {
           key: args.key,
           account: args.account,
           muteType: args.muteType,
-        ),
-      );
-    },
-    CacheManagementRoute.name: (routeData) {
-      final args = routeData.argsAs<CacheManagementRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: CacheManagementPage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    ReactionDeckRoute.name: (routeData) {
-      final args = routeData.argsAs<ReactionDeckRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ReactionDeckPage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    UsersListTimelineRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListTimelineRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UsersListTimelinePage(
-          args.account,
-          args.list,
-          key: args.key,
-        ),
-      );
-    },
-    UsersListRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UsersListPage(
-          args.account,
-          key: args.key,
-        ),
-      );
-    },
-    UsersListDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<UsersListDetailRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: UsersListDetailPage(
-          key: args.key,
-          account: args.account,
-          listId: args.listId,
-        ),
-      );
-    },
-    ChannelDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelDetailRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ChannelDetailPage(
-          key: args.key,
-          account: args.account,
-          channelId: args.channelId,
-        ),
-      );
-    },
-    ChannelsRoute.name: (routeData) {
-      final args = routeData.argsAs<ChannelsRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ChannelsPage(
-          key: args.key,
-          account: args.account,
-        ),
-      );
-    },
-    FederationRoute.name: (routeData) {
-      final args = routeData.argsAs<FederationRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: FederationPage(
-          key: args.key,
-          account: args.account,
-          host: args.host,
-        ),
-      );
-    },
-    NoteDetailRoute.name: (routeData) {
-      final args = routeData.argsAs<NoteDetailRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: NoteDetailPage(
-          key: args.key,
-          note: args.note,
-          account: args.account,
-        ),
-      );
-    },
-    SearchRoute.name: (routeData) {
-      final args = routeData.argsAs<SearchRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: SearchPage(
-          key: args.key,
-          initialSearchText: args.initialSearchText,
-          account: args.account,
         ),
       );
     },
@@ -332,83 +350,10 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    MisskeyRouteRoute.name: (routeData) {
-      final args = routeData.argsAs<MisskeyRouteRouteArgs>();
+    SplashRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: MisskeyPagePage(
-          key: args.key,
-          account: args.account,
-          page: args.page,
-        ),
-      );
-    },
-    ImportExportRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const ImportExportPage(),
-      );
-    },
-    GeneralSettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const GeneralSettingsPage(),
-      );
-    },
-    TabSettingsRoute.name: (routeData) {
-      final args = routeData.argsAs<TabSettingsRouteArgs>(
-          orElse: () => const TabSettingsRouteArgs());
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: TabSettingsPage(
-          key: args.key,
-          tabIndex: args.tabIndex,
-        ),
-      );
-    },
-    TabSettingsListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const TabSettingsListPage(),
-      );
-    },
-    AppInfoRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AppInfoPage(),
-      );
-    },
-    SettingsRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const SettingsPage(),
-      );
-    },
-    AccountListRoute.name: (routeData) {
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const AccountListPage(),
-      );
-    },
-    ExploreRoleUsersRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRoleUsersRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExploreRoleUsersPage(
-          key: args.key,
-          item: args.item,
-          account: args.account,
-        ),
-      );
-    },
-    ExploreRoute.name: (routeData) {
-      final args = routeData.argsAs<ExploreRouteArgs>();
-      return AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: ExplorePage(
-          key: args.key,
-          account: args.account,
-        ),
+        child: const SplashPage(),
       );
     },
     TimeLineRoute.name: (routeData) {
@@ -421,12 +366,67 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
-    FavoritedNoteRoute.name: (routeData) {
-      final args = routeData.argsAs<FavoritedNoteRouteArgs>();
+    UsersListDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListDetailRouteArgs>();
       return AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: FavoritedNotePage(
+        child: UsersListDetailPage(
           key: args.key,
+          account: args.account,
+          listId: args.listId,
+        ),
+      );
+    },
+    UsersListRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UsersListPage(
+          args.account,
+          key: args.key,
+        ),
+      );
+    },
+    UsersListTimelineRoute.name: (routeData) {
+      final args = routeData.argsAs<UsersListTimelineRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UsersListTimelinePage(
+          args.account,
+          args.list,
+          key: args.key,
+        ),
+      );
+    },
+    UserFolloweeRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFolloweeRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UserFolloweePage(
+          key: args.key,
+          userId: args.userId,
+          account: args.account,
+        ),
+      );
+    },
+    UserFollowerRoute.name: (routeData) {
+      final args = routeData.argsAs<UserFollowerRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UserFollowerPage(
+          key: args.key,
+          userId: args.userId,
+          account: args.account,
+        ),
+      );
+    },
+    UserRoute.name: (routeData) {
+      final args = routeData.argsAs<UserRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: UserPage(
+          key: args.key,
+          userId: args.userId,
           account: args.account,
         ),
       );
@@ -435,83 +435,40 @@ abstract class _$AppRouter extends RootStackRouter {
 }
 
 /// generated route for
-/// [NotesAfterRenotePage]
-class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
-  NotesAfterRenoteRoute({
+/// [AnnouncementPage]
+class AnnouncementRoute extends PageRouteInfo<AnnouncementRouteArgs> {
+  AnnouncementRoute({
     Key? key,
-    required Note note,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotesAfterRenoteRoute.name,
-          args: NotesAfterRenoteRouteArgs(
+          AnnouncementRoute.name,
+          args: AnnouncementRouteArgs(
             key: key,
-            note: note,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotesAfterRenoteRoute';
+  static const String name = 'AnnouncementRoute';
 
-  static const PageInfo<NotesAfterRenoteRouteArgs> page =
-      PageInfo<NotesAfterRenoteRouteArgs>(name);
+  static const PageInfo<AnnouncementRouteArgs> page =
+      PageInfo<AnnouncementRouteArgs>(name);
 }
 
-class NotesAfterRenoteRouteArgs {
-  const NotesAfterRenoteRouteArgs({
+class AnnouncementRouteArgs {
+  const AnnouncementRouteArgs({
     this.key,
-    required this.note,
     required this.account,
   });
 
   final Key? key;
 
-  final Note note;
-
   final Account account;
 
   @override
   String toString() {
-    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
-  }
-}
-
-/// generated route for
-/// [AntennaPage]
-class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
-  AntennaRoute({
-    required Account account,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          AntennaRoute.name,
-          args: AntennaRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'AntennaRoute';
-
-  static const PageInfo<AntennaRouteArgs> page =
-      PageInfo<AntennaRouteArgs>(name);
-}
-
-class AntennaRouteArgs {
-  const AntennaRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'AntennaRouteArgs{account: $account, key: $key}';
+    return 'AnnouncementRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -559,29 +516,67 @@ class AntennaNotesRouteArgs {
 }
 
 /// generated route for
-/// [NotificationPage]
-class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
-  NotificationRoute({
+/// [AntennaPage]
+class AntennaRoute extends PageRouteInfo<AntennaRouteArgs> {
+  AntennaRoute({
+    required Account account,
+    Key? key,
+    List<PageRouteInfo>? children,
+  }) : super(
+          AntennaRoute.name,
+          args: AntennaRouteArgs(
+            account: account,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'AntennaRoute';
+
+  static const PageInfo<AntennaRouteArgs> page =
+      PageInfo<AntennaRouteArgs>(name);
+}
+
+class AntennaRouteArgs {
+  const AntennaRouteArgs({
+    required this.account,
+    this.key,
+  });
+
+  final Account account;
+
+  final Key? key;
+
+  @override
+  String toString() {
+    return 'AntennaRouteArgs{account: $account, key: $key}';
+  }
+}
+
+/// generated route for
+/// [ChannelsPage]
+class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
+  ChannelsRoute({
     Key? key,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          NotificationRoute.name,
-          args: NotificationRouteArgs(
+          ChannelsRoute.name,
+          args: ChannelsRouteArgs(
             key: key,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'NotificationRoute';
+  static const String name = 'ChannelsRoute';
 
-  static const PageInfo<NotificationRouteArgs> page =
-      PageInfo<NotificationRouteArgs>(name);
+  static const PageInfo<ChannelsRouteArgs> page =
+      PageInfo<ChannelsRouteArgs>(name);
 }
 
-class NotificationRouteArgs {
-  const NotificationRouteArgs({
+class ChannelsRouteArgs {
+  const ChannelsRouteArgs({
     this.key,
     required this.account,
   });
@@ -592,22 +587,51 @@ class NotificationRouteArgs {
 
   @override
   String toString() {
-    return 'NotificationRouteArgs{key: $key, account: $account}';
+    return 'ChannelsRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [LoginPage]
-class LoginRoute extends PageRouteInfo<void> {
-  const LoginRoute({List<PageRouteInfo>? children})
-      : super(
-          LoginRoute.name,
+/// [ChannelDetailPage]
+class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
+  ChannelDetailRoute({
+    Key? key,
+    required Account account,
+    required String channelId,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ChannelDetailRoute.name,
+          args: ChannelDetailRouteArgs(
+            key: key,
+            account: account,
+            channelId: channelId,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'LoginRoute';
+  static const String name = 'ChannelDetailRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static const PageInfo<ChannelDetailRouteArgs> page =
+      PageInfo<ChannelDetailRouteArgs>(name);
+}
+
+class ChannelDetailRouteArgs {
+  const ChannelDetailRouteArgs({
+    this.key,
+    required this.account,
+    required this.channelId,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String channelId;
+
+  @override
+  String toString() {
+    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
+  }
 }
 
 /// generated route for
@@ -692,6 +716,311 @@ class ClipListRouteArgs {
 }
 
 /// generated route for
+/// [ExplorePage]
+class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
+  ExploreRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoute.name,
+          args: ExploreRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoute';
+
+  static const PageInfo<ExploreRouteArgs> page =
+      PageInfo<ExploreRouteArgs>(name);
+}
+
+class ExploreRouteArgs {
+  const ExploreRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ExploreRoleUsersPage]
+class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
+  ExploreRoleUsersRoute({
+    Key? key,
+    required RolesListResponse item,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ExploreRoleUsersRoute.name,
+          args: ExploreRoleUsersRouteArgs(
+            key: key,
+            item: item,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ExploreRoleUsersRoute';
+
+  static const PageInfo<ExploreRoleUsersRouteArgs> page =
+      PageInfo<ExploreRoleUsersRouteArgs>(name);
+}
+
+class ExploreRoleUsersRouteArgs {
+  const ExploreRoleUsersRouteArgs({
+    this.key,
+    required this.item,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final RolesListResponse item;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FavoritedNotePage]
+class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
+  FavoritedNoteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FavoritedNoteRoute.name,
+          args: FavoritedNoteRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FavoritedNoteRoute';
+
+  static const PageInfo<FavoritedNoteRouteArgs> page =
+      PageInfo<FavoritedNoteRouteArgs>(name);
+}
+
+class FavoritedNoteRouteArgs {
+  const FavoritedNoteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [FederationPage]
+class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
+  FederationRoute({
+    Key? key,
+    required Account account,
+    required String host,
+    List<PageRouteInfo>? children,
+  }) : super(
+          FederationRoute.name,
+          args: FederationRouteArgs(
+            key: key,
+            account: account,
+            host: host,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'FederationRoute';
+
+  static const PageInfo<FederationRouteArgs> page =
+      PageInfo<FederationRouteArgs>(name);
+}
+
+class FederationRouteArgs {
+  const FederationRouteArgs({
+    this.key,
+    required this.account,
+    required this.host,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final String host;
+
+  @override
+  String toString() {
+    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
+  }
+}
+
+/// generated route for
+/// [HashtagPage]
+class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
+  HashtagRoute({
+    Key? key,
+    required String hashtag,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          HashtagRoute.name,
+          args: HashtagRouteArgs(
+            key: key,
+            hashtag: hashtag,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'HashtagRoute';
+
+  static const PageInfo<HashtagRouteArgs> page =
+      PageInfo<HashtagRouteArgs>(name);
+}
+
+class HashtagRouteArgs {
+  const HashtagRouteArgs({
+    this.key,
+    required this.hashtag,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String hashtag;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+  }
+}
+
+/// generated route for
+/// [LoginPage]
+class LoginRoute extends PageRouteInfo<void> {
+  const LoginRoute({List<PageRouteInfo>? children})
+      : super(
+          LoginRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'LoginRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [MisskeyPagePage]
+class MisskeyRouteRoute extends PageRouteInfo<MisskeyRouteRouteArgs> {
+  MisskeyRouteRoute({
+    Key? key,
+    required Account account,
+    required Page page,
+    List<PageRouteInfo>? children,
+  }) : super(
+          MisskeyRouteRoute.name,
+          args: MisskeyRouteRouteArgs(
+            key: key,
+            account: account,
+            page: page,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'MisskeyRouteRoute';
+
+  static const PageInfo<MisskeyRouteRouteArgs> page =
+      PageInfo<MisskeyRouteRouteArgs>(name);
+}
+
+class MisskeyRouteRouteArgs {
+  const MisskeyRouteRouteArgs({
+    this.key,
+    required this.account,
+    required this.page,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  final Page page;
+
+  @override
+  String toString() {
+    return 'MisskeyRouteRouteArgs{key: $key, account: $account, page: $page}';
+  }
+}
+
+/// generated route for
+/// [NotesAfterRenotePage]
+class NotesAfterRenoteRoute extends PageRouteInfo<NotesAfterRenoteRouteArgs> {
+  NotesAfterRenoteRoute({
+    Key? key,
+    required Note note,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          NotesAfterRenoteRoute.name,
+          args: NotesAfterRenoteRouteArgs(
+            key: key,
+            note: note,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'NotesAfterRenoteRoute';
+
+  static const PageInfo<NotesAfterRenoteRouteArgs> page =
+      PageInfo<NotesAfterRenoteRouteArgs>(name);
+}
+
+class NotesAfterRenoteRouteArgs {
+  const NotesAfterRenoteRouteArgs({
+    this.key,
+    required this.note,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Note note;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'NotesAfterRenoteRouteArgs{key: $key, note: $note, account: $account}';
+  }
+}
+
+/// generated route for
 /// [NoteCreatePage]
 class NoteCreateRoute extends PageRouteInfo<NoteCreateRouteArgs> {
   NoteCreateRoute({
@@ -765,173 +1094,83 @@ class NoteCreateRouteArgs {
 }
 
 /// generated route for
-/// [HashtagPage]
-class HashtagRoute extends PageRouteInfo<HashtagRouteArgs> {
-  HashtagRoute({
+/// [NoteDetailPage]
+class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
+  NoteDetailRoute({
     Key? key,
-    required String hashtag,
+    required Note note,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          HashtagRoute.name,
-          args: HashtagRouteArgs(
+          NoteDetailRoute.name,
+          args: NoteDetailRouteArgs(
             key: key,
-            hashtag: hashtag,
+            note: note,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'HashtagRoute';
+  static const String name = 'NoteDetailRoute';
 
-  static const PageInfo<HashtagRouteArgs> page =
-      PageInfo<HashtagRouteArgs>(name);
+  static const PageInfo<NoteDetailRouteArgs> page =
+      PageInfo<NoteDetailRouteArgs>(name);
 }
 
-class HashtagRouteArgs {
-  const HashtagRouteArgs({
+class NoteDetailRouteArgs {
+  const NoteDetailRouteArgs({
     this.key,
-    required this.hashtag,
+    required this.note,
     required this.account,
   });
 
   final Key? key;
 
-  final String hashtag;
+  final Note note;
 
   final Account account;
 
   @override
   String toString() {
-    return 'HashtagRouteArgs{key: $key, hashtag: $hashtag, account: $account}';
+    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
   }
 }
 
 /// generated route for
-/// [UserFolloweePage]
-class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
-  UserFolloweeRoute({
+/// [NotificationPage]
+class NotificationRoute extends PageRouteInfo<NotificationRouteArgs> {
+  NotificationRoute({
     Key? key,
-    required String userId,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          UserFolloweeRoute.name,
-          args: UserFolloweeRouteArgs(
+          NotificationRoute.name,
+          args: NotificationRouteArgs(
             key: key,
-            userId: userId,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'UserFolloweeRoute';
+  static const String name = 'NotificationRoute';
 
-  static const PageInfo<UserFolloweeRouteArgs> page =
-      PageInfo<UserFolloweeRouteArgs>(name);
+  static const PageInfo<NotificationRouteArgs> page =
+      PageInfo<NotificationRouteArgs>(name);
 }
 
-class UserFolloweeRouteArgs {
-  const UserFolloweeRouteArgs({
+class NotificationRouteArgs {
+  const NotificationRouteArgs({
     this.key,
-    required this.userId,
     required this.account,
   });
 
   final Key? key;
 
-  final String userId;
-
   final Account account;
 
   @override
   String toString() {
-    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserPage]
-class UserRoute extends PageRouteInfo<UserRouteArgs> {
-  UserRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserRoute.name,
-          args: UserRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserRoute';
-
-  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
-}
-
-class UserRouteArgs {
-  const UserRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UserFollowerPage]
-class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
-  UserFollowerRoute({
-    Key? key,
-    required String userId,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UserFollowerRoute.name,
-          args: UserFollowerRouteArgs(
-            key: key,
-            userId: userId,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UserFollowerRoute';
-
-  static const PageInfo<UserFollowerRouteArgs> page =
-      PageInfo<UserFollowerRouteArgs>(name);
-}
-
-class UserFollowerRouteArgs {
-  const UserFollowerRouteArgs({
-    this.key,
-    required this.userId,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String userId;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
+    return 'NotificationRouteArgs{key: $key, account: $account}';
   }
 }
 
@@ -984,29 +1223,193 @@ class PhotoEditRouteArgs {
 }
 
 /// generated route for
-/// [AnnouncementPage]
-class AnnouncementRoute extends PageRouteInfo<AnnouncementRouteArgs> {
-  AnnouncementRoute({
+/// [SearchPage]
+class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
+  SearchRoute({
+    Key? key,
+    String? initialSearchText,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          SearchRoute.name,
+          args: SearchRouteArgs(
+            key: key,
+            initialSearchText: initialSearchText,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'SearchRoute';
+
+  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
+}
+
+class SearchRouteArgs {
+  const SearchRouteArgs({
+    this.key,
+    this.initialSearchText,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String? initialSearchText;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
+  }
+}
+
+/// generated route for
+/// [AccountListPage]
+class AccountListRoute extends PageRouteInfo<void> {
+  const AccountListRoute({List<PageRouteInfo>? children})
+      : super(
+          AccountListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AccountListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [AppInfoPage]
+class AppInfoRoute extends PageRouteInfo<void> {
+  const AppInfoRoute({List<PageRouteInfo>? children})
+      : super(
+          AppInfoRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AppInfoRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [GeneralSettingsPage]
+class GeneralSettingsRoute extends PageRouteInfo<void> {
+  const GeneralSettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          GeneralSettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'GeneralSettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [ImportExportPage]
+class ImportExportRoute extends PageRouteInfo<void> {
+  const ImportExportRoute({List<PageRouteInfo>? children})
+      : super(
+          ImportExportRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'ImportExportRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [SettingsPage]
+class SettingsRoute extends PageRouteInfo<void> {
+  const SettingsRoute({List<PageRouteInfo>? children})
+      : super(
+          SettingsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SettingsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsListPage]
+class TabSettingsListRoute extends PageRouteInfo<void> {
+  const TabSettingsListRoute({List<PageRouteInfo>? children})
+      : super(
+          TabSettingsListRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsListRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TabSettingsPage]
+class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
+  TabSettingsRoute({
+    Key? key,
+    int? tabIndex,
+    List<PageRouteInfo>? children,
+  }) : super(
+          TabSettingsRoute.name,
+          args: TabSettingsRouteArgs(
+            key: key,
+            tabIndex: tabIndex,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'TabSettingsRoute';
+
+  static const PageInfo<TabSettingsRouteArgs> page =
+      PageInfo<TabSettingsRouteArgs>(name);
+}
+
+class TabSettingsRouteArgs {
+  const TabSettingsRouteArgs({
+    this.key,
+    this.tabIndex,
+  });
+
+  final Key? key;
+
+  final int? tabIndex;
+
+  @override
+  String toString() {
+    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
+  }
+}
+
+/// generated route for
+/// [CacheManagementPage]
+class CacheManagementRoute extends PageRouteInfo<CacheManagementRouteArgs> {
+  CacheManagementRoute({
     Key? key,
     required Account account,
     List<PageRouteInfo>? children,
   }) : super(
-          AnnouncementRoute.name,
-          args: AnnouncementRouteArgs(
+          CacheManagementRoute.name,
+          args: CacheManagementRouteArgs(
             key: key,
             account: account,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'AnnouncementRoute';
+  static const String name = 'CacheManagementRoute';
 
-  static const PageInfo<AnnouncementRouteArgs> page =
-      PageInfo<AnnouncementRouteArgs>(name);
+  static const PageInfo<CacheManagementRouteArgs> page =
+      PageInfo<CacheManagementRouteArgs>(name);
 }
 
-class AnnouncementRouteArgs {
-  const AnnouncementRouteArgs({
+class CacheManagementRouteArgs {
+  const CacheManagementRouteArgs({
     this.key,
     required this.account,
   });
@@ -1017,22 +1420,84 @@ class AnnouncementRouteArgs {
 
   @override
   String toString() {
-    return 'AnnouncementRouteArgs{key: $key, account: $account}';
+    return 'CacheManagementRouteArgs{key: $key, account: $account}';
   }
 }
 
 /// generated route for
-/// [SplashPage]
-class SplashRoute extends PageRouteInfo<void> {
-  const SplashRoute({List<PageRouteInfo>? children})
-      : super(
-          SplashRoute.name,
+/// [InstanceMutePage]
+class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
+  InstanceMuteRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          InstanceMuteRoute.name,
+          args: InstanceMuteRouteArgs(
+            key: key,
+            account: account,
+          ),
           initialChildren: children,
         );
 
-  static const String name = 'SplashRoute';
+  static const String name = 'InstanceMuteRoute';
 
-  static const PageInfo<void> page = PageInfo<void>(name);
+  static const PageInfo<InstanceMuteRouteArgs> page =
+      PageInfo<InstanceMuteRouteArgs>(name);
+}
+
+class InstanceMuteRouteArgs {
+  const InstanceMuteRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
+  }
+}
+
+/// generated route for
+/// [ReactionDeckPage]
+class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
+  ReactionDeckRoute({
+    Key? key,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ReactionDeckRoute.name,
+          args: ReactionDeckRouteArgs(
+            key: key,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ReactionDeckRoute';
+
+  static const PageInfo<ReactionDeckRouteArgs> page =
+      PageInfo<ReactionDeckRouteArgs>(name);
+}
+
+class ReactionDeckRouteArgs {
+  const ReactionDeckRouteArgs({
+    this.key,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
+  }
 }
 
 /// generated route for
@@ -1114,44 +1579,6 @@ class SeveralAccountSettingsRouteArgs {
 }
 
 /// generated route for
-/// [InstanceMutePage]
-class InstanceMuteRoute extends PageRouteInfo<InstanceMuteRouteArgs> {
-  InstanceMuteRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          InstanceMuteRoute.name,
-          args: InstanceMuteRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'InstanceMuteRoute';
-
-  static const PageInfo<InstanceMuteRouteArgs> page =
-      PageInfo<InstanceMuteRouteArgs>(name);
-}
-
-class InstanceMuteRouteArgs {
-  const InstanceMuteRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'InstanceMuteRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
 /// [WordMutePage]
 class WordMuteRoute extends PageRouteInfo<WordMuteRouteArgs> {
   WordMuteRoute({
@@ -1191,415 +1618,6 @@ class WordMuteRouteArgs {
   @override
   String toString() {
     return 'WordMuteRouteArgs{key: $key, account: $account, muteType: $muteType}';
-  }
-}
-
-/// generated route for
-/// [CacheManagementPage]
-class CacheManagementRoute extends PageRouteInfo<CacheManagementRouteArgs> {
-  CacheManagementRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          CacheManagementRoute.name,
-          args: CacheManagementRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'CacheManagementRoute';
-
-  static const PageInfo<CacheManagementRouteArgs> page =
-      PageInfo<CacheManagementRouteArgs>(name);
-}
-
-class CacheManagementRouteArgs {
-  const CacheManagementRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'CacheManagementRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ReactionDeckPage]
-class ReactionDeckRoute extends PageRouteInfo<ReactionDeckRouteArgs> {
-  ReactionDeckRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ReactionDeckRoute.name,
-          args: ReactionDeckRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ReactionDeckRoute';
-
-  static const PageInfo<ReactionDeckRouteArgs> page =
-      PageInfo<ReactionDeckRouteArgs>(name);
-}
-
-class ReactionDeckRouteArgs {
-  const ReactionDeckRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ReactionDeckRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [UsersListTimelinePage]
-class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
-  UsersListTimelineRoute({
-    required Account account,
-    required UsersList list,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListTimelineRoute.name,
-          args: UsersListTimelineRouteArgs(
-            account: account,
-            list: list,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListTimelineRoute';
-
-  static const PageInfo<UsersListTimelineRouteArgs> page =
-      PageInfo<UsersListTimelineRouteArgs>(name);
-}
-
-class UsersListTimelineRouteArgs {
-  const UsersListTimelineRouteArgs({
-    required this.account,
-    required this.list,
-    this.key,
-  });
-
-  final Account account;
-
-  final UsersList list;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'UsersListTimelineRouteArgs{account: $account, list: $list, key: $key}';
-  }
-}
-
-/// generated route for
-/// [UsersListPage]
-class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
-  UsersListRoute({
-    required Account account,
-    Key? key,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListRoute.name,
-          args: UsersListRouteArgs(
-            account: account,
-            key: key,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListRoute';
-
-  static const PageInfo<UsersListRouteArgs> page =
-      PageInfo<UsersListRouteArgs>(name);
-}
-
-class UsersListRouteArgs {
-  const UsersListRouteArgs({
-    required this.account,
-    this.key,
-  });
-
-  final Account account;
-
-  final Key? key;
-
-  @override
-  String toString() {
-    return 'UsersListRouteArgs{account: $account, key: $key}';
-  }
-}
-
-/// generated route for
-/// [UsersListDetailPage]
-class UsersListDetailRoute extends PageRouteInfo<UsersListDetailRouteArgs> {
-  UsersListDetailRoute({
-    Key? key,
-    required Account account,
-    required String listId,
-    List<PageRouteInfo>? children,
-  }) : super(
-          UsersListDetailRoute.name,
-          args: UsersListDetailRouteArgs(
-            key: key,
-            account: account,
-            listId: listId,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'UsersListDetailRoute';
-
-  static const PageInfo<UsersListDetailRouteArgs> page =
-      PageInfo<UsersListDetailRouteArgs>(name);
-}
-
-class UsersListDetailRouteArgs {
-  const UsersListDetailRouteArgs({
-    this.key,
-    required this.account,
-    required this.listId,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String listId;
-
-  @override
-  String toString() {
-    return 'UsersListDetailRouteArgs{key: $key, account: $account, listId: $listId}';
-  }
-}
-
-/// generated route for
-/// [ChannelDetailPage]
-class ChannelDetailRoute extends PageRouteInfo<ChannelDetailRouteArgs> {
-  ChannelDetailRoute({
-    Key? key,
-    required Account account,
-    required String channelId,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ChannelDetailRoute.name,
-          args: ChannelDetailRouteArgs(
-            key: key,
-            account: account,
-            channelId: channelId,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ChannelDetailRoute';
-
-  static const PageInfo<ChannelDetailRouteArgs> page =
-      PageInfo<ChannelDetailRouteArgs>(name);
-}
-
-class ChannelDetailRouteArgs {
-  const ChannelDetailRouteArgs({
-    this.key,
-    required this.account,
-    required this.channelId,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String channelId;
-
-  @override
-  String toString() {
-    return 'ChannelDetailRouteArgs{key: $key, account: $account, channelId: $channelId}';
-  }
-}
-
-/// generated route for
-/// [ChannelsPage]
-class ChannelsRoute extends PageRouteInfo<ChannelsRouteArgs> {
-  ChannelsRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ChannelsRoute.name,
-          args: ChannelsRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ChannelsRoute';
-
-  static const PageInfo<ChannelsRouteArgs> page =
-      PageInfo<ChannelsRouteArgs>(name);
-}
-
-class ChannelsRouteArgs {
-  const ChannelsRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ChannelsRouteArgs{key: $key, account: $account}';
-  }
-}
-
-/// generated route for
-/// [FederationPage]
-class FederationRoute extends PageRouteInfo<FederationRouteArgs> {
-  FederationRoute({
-    Key? key,
-    required Account account,
-    required String host,
-    List<PageRouteInfo>? children,
-  }) : super(
-          FederationRoute.name,
-          args: FederationRouteArgs(
-            key: key,
-            account: account,
-            host: host,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'FederationRoute';
-
-  static const PageInfo<FederationRouteArgs> page =
-      PageInfo<FederationRouteArgs>(name);
-}
-
-class FederationRouteArgs {
-  const FederationRouteArgs({
-    this.key,
-    required this.account,
-    required this.host,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final String host;
-
-  @override
-  String toString() {
-    return 'FederationRouteArgs{key: $key, account: $account, host: $host}';
-  }
-}
-
-/// generated route for
-/// [NoteDetailPage]
-class NoteDetailRoute extends PageRouteInfo<NoteDetailRouteArgs> {
-  NoteDetailRoute({
-    Key? key,
-    required Note note,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          NoteDetailRoute.name,
-          args: NoteDetailRouteArgs(
-            key: key,
-            note: note,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'NoteDetailRoute';
-
-  static const PageInfo<NoteDetailRouteArgs> page =
-      PageInfo<NoteDetailRouteArgs>(name);
-}
-
-class NoteDetailRouteArgs {
-  const NoteDetailRouteArgs({
-    this.key,
-    required this.note,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Note note;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'NoteDetailRouteArgs{key: $key, note: $note, account: $account}';
-  }
-}
-
-/// generated route for
-/// [SearchPage]
-class SearchRoute extends PageRouteInfo<SearchRouteArgs> {
-  SearchRoute({
-    Key? key,
-    String? initialSearchText,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          SearchRoute.name,
-          args: SearchRouteArgs(
-            key: key,
-            initialSearchText: initialSearchText,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'SearchRoute';
-
-  static const PageInfo<SearchRouteArgs> page = PageInfo<SearchRouteArgs>(name);
-}
-
-class SearchRouteArgs {
-  const SearchRouteArgs({
-    this.key,
-    this.initialSearchText,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final String? initialSearchText;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'SearchRouteArgs{key: $key, initialSearchText: $initialSearchText, account: $account}';
   }
 }
 
@@ -1648,249 +1666,17 @@ class SharingAccountSelectRouteArgs {
 }
 
 /// generated route for
-/// [MisskeyPagePage]
-class MisskeyRouteRoute extends PageRouteInfo<MisskeyRouteRouteArgs> {
-  MisskeyRouteRoute({
-    Key? key,
-    required Account account,
-    required Page page,
-    List<PageRouteInfo>? children,
-  }) : super(
-          MisskeyRouteRoute.name,
-          args: MisskeyRouteRouteArgs(
-            key: key,
-            account: account,
-            page: page,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'MisskeyRouteRoute';
-
-  static const PageInfo<MisskeyRouteRouteArgs> page =
-      PageInfo<MisskeyRouteRouteArgs>(name);
-}
-
-class MisskeyRouteRouteArgs {
-  const MisskeyRouteRouteArgs({
-    this.key,
-    required this.account,
-    required this.page,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  final Page page;
-
-  @override
-  String toString() {
-    return 'MisskeyRouteRouteArgs{key: $key, account: $account, page: $page}';
-  }
-}
-
-/// generated route for
-/// [ImportExportPage]
-class ImportExportRoute extends PageRouteInfo<void> {
-  const ImportExportRoute({List<PageRouteInfo>? children})
+/// [SplashPage]
+class SplashRoute extends PageRouteInfo<void> {
+  const SplashRoute({List<PageRouteInfo>? children})
       : super(
-          ImportExportRoute.name,
+          SplashRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'ImportExportRoute';
+  static const String name = 'SplashRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [GeneralSettingsPage]
-class GeneralSettingsRoute extends PageRouteInfo<void> {
-  const GeneralSettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          GeneralSettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'GeneralSettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [TabSettingsPage]
-class TabSettingsRoute extends PageRouteInfo<TabSettingsRouteArgs> {
-  TabSettingsRoute({
-    Key? key,
-    int? tabIndex,
-    List<PageRouteInfo>? children,
-  }) : super(
-          TabSettingsRoute.name,
-          args: TabSettingsRouteArgs(
-            key: key,
-            tabIndex: tabIndex,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsRoute';
-
-  static const PageInfo<TabSettingsRouteArgs> page =
-      PageInfo<TabSettingsRouteArgs>(name);
-}
-
-class TabSettingsRouteArgs {
-  const TabSettingsRouteArgs({
-    this.key,
-    this.tabIndex,
-  });
-
-  final Key? key;
-
-  final int? tabIndex;
-
-  @override
-  String toString() {
-    return 'TabSettingsRouteArgs{key: $key, tabIndex: $tabIndex}';
-  }
-}
-
-/// generated route for
-/// [TabSettingsListPage]
-class TabSettingsListRoute extends PageRouteInfo<void> {
-  const TabSettingsListRoute({List<PageRouteInfo>? children})
-      : super(
-          TabSettingsListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'TabSettingsListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AppInfoPage]
-class AppInfoRoute extends PageRouteInfo<void> {
-  const AppInfoRoute({List<PageRouteInfo>? children})
-      : super(
-          AppInfoRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AppInfoRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [SettingsPage]
-class SettingsRoute extends PageRouteInfo<void> {
-  const SettingsRoute({List<PageRouteInfo>? children})
-      : super(
-          SettingsRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'SettingsRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [AccountListPage]
-class AccountListRoute extends PageRouteInfo<void> {
-  const AccountListRoute({List<PageRouteInfo>? children})
-      : super(
-          AccountListRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'AccountListRoute';
-
-  static const PageInfo<void> page = PageInfo<void>(name);
-}
-
-/// generated route for
-/// [ExploreRoleUsersPage]
-class ExploreRoleUsersRoute extends PageRouteInfo<ExploreRoleUsersRouteArgs> {
-  ExploreRoleUsersRoute({
-    Key? key,
-    required RolesListResponse item,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoleUsersRoute.name,
-          args: ExploreRoleUsersRouteArgs(
-            key: key,
-            item: item,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoleUsersRoute';
-
-  static const PageInfo<ExploreRoleUsersRouteArgs> page =
-      PageInfo<ExploreRoleUsersRouteArgs>(name);
-}
-
-class ExploreRoleUsersRouteArgs {
-  const ExploreRoleUsersRouteArgs({
-    this.key,
-    required this.item,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final RolesListResponse item;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRoleUsersRouteArgs{key: $key, item: $item, account: $account}';
-  }
-}
-
-/// generated route for
-/// [ExplorePage]
-class ExploreRoute extends PageRouteInfo<ExploreRouteArgs> {
-  ExploreRoute({
-    Key? key,
-    required Account account,
-    List<PageRouteInfo>? children,
-  }) : super(
-          ExploreRoute.name,
-          args: ExploreRouteArgs(
-            key: key,
-            account: account,
-          ),
-          initialChildren: children,
-        );
-
-  static const String name = 'ExploreRoute';
-
-  static const PageInfo<ExploreRouteArgs> page =
-      PageInfo<ExploreRouteArgs>(name);
-}
-
-class ExploreRouteArgs {
-  const ExploreRouteArgs({
-    this.key,
-    required this.account,
-  });
-
-  final Key? key;
-
-  final Account account;
-
-  @override
-  String toString() {
-    return 'ExploreRouteArgs{key: $key, account: $account}';
-  }
 }
 
 /// generated route for
@@ -1932,39 +1718,253 @@ class TimeLineRouteArgs {
 }
 
 /// generated route for
-/// [FavoritedNotePage]
-class FavoritedNoteRoute extends PageRouteInfo<FavoritedNoteRouteArgs> {
-  FavoritedNoteRoute({
+/// [UsersListDetailPage]
+class UsersListDetailRoute extends PageRouteInfo<UsersListDetailRouteArgs> {
+  UsersListDetailRoute({
     Key? key,
     required Account account,
+    required String listId,
     List<PageRouteInfo>? children,
   }) : super(
-          FavoritedNoteRoute.name,
-          args: FavoritedNoteRouteArgs(
+          UsersListDetailRoute.name,
+          args: UsersListDetailRouteArgs(
             key: key,
             account: account,
+            listId: listId,
           ),
           initialChildren: children,
         );
 
-  static const String name = 'FavoritedNoteRoute';
+  static const String name = 'UsersListDetailRoute';
 
-  static const PageInfo<FavoritedNoteRouteArgs> page =
-      PageInfo<FavoritedNoteRouteArgs>(name);
+  static const PageInfo<UsersListDetailRouteArgs> page =
+      PageInfo<UsersListDetailRouteArgs>(name);
 }
 
-class FavoritedNoteRouteArgs {
-  const FavoritedNoteRouteArgs({
+class UsersListDetailRouteArgs {
+  const UsersListDetailRouteArgs({
     this.key,
     required this.account,
+    required this.listId,
   });
 
   final Key? key;
 
   final Account account;
 
+  final String listId;
+
   @override
   String toString() {
-    return 'FavoritedNoteRouteArgs{key: $key, account: $account}';
+    return 'UsersListDetailRouteArgs{key: $key, account: $account, listId: $listId}';
+  }
+}
+
+/// generated route for
+/// [UsersListPage]
+class UsersListRoute extends PageRouteInfo<UsersListRouteArgs> {
+  UsersListRoute({
+    required Account account,
+    Key? key,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UsersListRoute.name,
+          args: UsersListRouteArgs(
+            account: account,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UsersListRoute';
+
+  static const PageInfo<UsersListRouteArgs> page =
+      PageInfo<UsersListRouteArgs>(name);
+}
+
+class UsersListRouteArgs {
+  const UsersListRouteArgs({
+    required this.account,
+    this.key,
+  });
+
+  final Account account;
+
+  final Key? key;
+
+  @override
+  String toString() {
+    return 'UsersListRouteArgs{account: $account, key: $key}';
+  }
+}
+
+/// generated route for
+/// [UsersListTimelinePage]
+class UsersListTimelineRoute extends PageRouteInfo<UsersListTimelineRouteArgs> {
+  UsersListTimelineRoute({
+    required Account account,
+    required UsersList list,
+    Key? key,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UsersListTimelineRoute.name,
+          args: UsersListTimelineRouteArgs(
+            account: account,
+            list: list,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UsersListTimelineRoute';
+
+  static const PageInfo<UsersListTimelineRouteArgs> page =
+      PageInfo<UsersListTimelineRouteArgs>(name);
+}
+
+class UsersListTimelineRouteArgs {
+  const UsersListTimelineRouteArgs({
+    required this.account,
+    required this.list,
+    this.key,
+  });
+
+  final Account account;
+
+  final UsersList list;
+
+  final Key? key;
+
+  @override
+  String toString() {
+    return 'UsersListTimelineRouteArgs{account: $account, list: $list, key: $key}';
+  }
+}
+
+/// generated route for
+/// [UserFolloweePage]
+class UserFolloweeRoute extends PageRouteInfo<UserFolloweeRouteArgs> {
+  UserFolloweeRoute({
+    Key? key,
+    required String userId,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UserFolloweeRoute.name,
+          args: UserFolloweeRouteArgs(
+            key: key,
+            userId: userId,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UserFolloweeRoute';
+
+  static const PageInfo<UserFolloweeRouteArgs> page =
+      PageInfo<UserFolloweeRouteArgs>(name);
+}
+
+class UserFolloweeRouteArgs {
+  const UserFolloweeRouteArgs({
+    this.key,
+    required this.userId,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String userId;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'UserFolloweeRouteArgs{key: $key, userId: $userId, account: $account}';
+  }
+}
+
+/// generated route for
+/// [UserFollowerPage]
+class UserFollowerRoute extends PageRouteInfo<UserFollowerRouteArgs> {
+  UserFollowerRoute({
+    Key? key,
+    required String userId,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UserFollowerRoute.name,
+          args: UserFollowerRouteArgs(
+            key: key,
+            userId: userId,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UserFollowerRoute';
+
+  static const PageInfo<UserFollowerRouteArgs> page =
+      PageInfo<UserFollowerRouteArgs>(name);
+}
+
+class UserFollowerRouteArgs {
+  const UserFollowerRouteArgs({
+    this.key,
+    required this.userId,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String userId;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'UserFollowerRouteArgs{key: $key, userId: $userId, account: $account}';
+  }
+}
+
+/// generated route for
+/// [UserPage]
+class UserRoute extends PageRouteInfo<UserRouteArgs> {
+  UserRoute({
+    Key? key,
+    required String userId,
+    required Account account,
+    List<PageRouteInfo>? children,
+  }) : super(
+          UserRoute.name,
+          args: UserRouteArgs(
+            key: key,
+            userId: userId,
+            account: account,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'UserRoute';
+
+  static const PageInfo<UserRouteArgs> page = PageInfo<UserRouteArgs>(name);
+}
+
+class UserRouteArgs {
+  const UserRouteArgs({
+    this.key,
+    required this.userId,
+    required this.account,
+  });
+
+  final Key? key;
+
+  final String userId;
+
+  final Account account;
+
+  @override
+  String toString() {
+    return 'UserRouteArgs{key: $key, userId: $userId, account: $account}';
   }
 }

--- a/lib/view/note_detail_page/note_detail_page.dart
+++ b/lib/view/note_detail_page/note_detail_page.dart
@@ -82,6 +82,7 @@ class NoteDetailPageState extends ConsumerState<NoteDetailPage> {
                               note: conversations[index],
                               isForceUnvisibleRenote: true,
                               isForceUnvisibleReply: true,
+                              hideAvatar: false,
                             );
                           }),
                       MisskeyNote(
@@ -90,6 +91,7 @@ class NoteDetailPageState extends ConsumerState<NoteDetailPage> {
                         isForceUnvisibleReply: true,
                         isDisplayBorder: false,
                         isForceVisibleLong: true,
+                        hideAvatar: false,
                       ),
                       const Padding(padding: EdgeInsets.only(top: 5)),
                       Text(
@@ -131,6 +133,7 @@ class NoteDetailPageState extends ConsumerState<NoteDetailPage> {
                                 recursive: 1,
                                 isForceUnvisibleRenote: true,
                                 isForceUnvisibleReply: true,
+                                hideAvatar: false,
                               );
                             }),
                       ),

--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -36,6 +36,7 @@ class GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
   String monospaceFontName = "";
   String cursiveFontName = "";
   String fantasyFontName = "";
+  bool hideAvatar = false;
 
   @override
   void initState() {
@@ -76,6 +77,7 @@ class GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
       monospaceFontName = settings.monospaceFontName;
       cursiveFontName = settings.cursiveFontName;
       fantasyFontName = settings.fantasyFontName;
+      hideAvatar = settings.hideAvatar;
     });
   }
 
@@ -99,6 +101,7 @@ class GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
             monospaceFontName: monospaceFontName,
             cursiveFontName: cursiveFontName,
             fantasyFontName: fantasyFontName,
+            hideAvatar: hideAvatar,
           ),
         );
   }
@@ -189,6 +192,14 @@ class GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
                           save();
                         }),
                         title: const Text("長いノートを省略します。"),
+                      ),
+                      CheckboxListTile(
+                        value: hideAvatar,
+                        onChanged: (value) => setState(() {
+                          hideAvatar = value ?? true;
+                          save();
+                        }),
+                        title: const Text("ユーザーのアバターを非表示にします。"),
                       ),
                       const Padding(padding: EdgeInsets.only(top: 10)),
                       const Text("タブの位置"),

--- a/test/test_util/mock.mocks.dart
+++ b/test/test_util/mock.mocks.dart
@@ -3,45 +3,46 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i17;
-import 'dart:collection' as _i30;
+import 'dart:async' as _i18;
+import 'dart:collection' as _i31;
 import 'dart:io' as _i12;
-import 'dart:typed_data' as _i27;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i28;
+import 'dart:ui' as _i19;
 
 import 'package:dio/dio.dart' as _i11;
-import 'package:file/file.dart' as _i13;
-import 'package:file_picker/file_picker.dart' as _i35;
-import 'package:flutter_cache_manager/flutter_cache_manager.dart' as _i14;
+import 'package:file/file.dart' as _i14;
+import 'package:file_picker/file_picker.dart' as _i36;
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' as _i15;
 import 'package:flutter_riverpod/flutter_riverpod.dart' as _i4;
 import 'package:miria/model/account.dart' as _i6;
 import 'package:miria/model/account_settings.dart' as _i2;
-import 'package:miria/model/acct.dart' as _i20;
+import 'package:miria/model/acct.dart' as _i21;
 import 'package:miria/model/general_settings.dart' as _i3;
-import 'package:miria/model/misskey_emoji_data.dart' as _i22;
-import 'package:miria/model/tab_setting.dart' as _i16;
-import 'package:miria/repository/account_repository.dart' as _i24;
-import 'package:miria/repository/account_settings_repository.dart' as _i19;
-import 'package:miria/repository/emoji_repository.dart' as _i21;
-import 'package:miria/repository/general_settings_repository.dart' as _i23;
-import 'package:miria/repository/note_repository.dart' as _i25;
-import 'package:miria/repository/tab_settings_repository.dart' as _i15;
+import 'package:miria/model/misskey_emoji_data.dart' as _i23;
+import 'package:miria/model/tab_setting.dart' as _i17;
+import 'package:miria/repository/account_repository.dart' as _i25;
+import 'package:miria/repository/account_settings_repository.dart' as _i20;
+import 'package:miria/repository/emoji_repository.dart' as _i22;
+import 'package:miria/repository/general_settings_repository.dart' as _i24;
+import 'package:miria/repository/note_repository.dart' as _i26;
+import 'package:miria/repository/tab_settings_repository.dart' as _i16;
 import 'package:misskey_dart/misskey_dart.dart' as _i5;
 import 'package:misskey_dart/src/data/ping_response.dart' as _i10;
 import 'package:misskey_dart/src/data/stats_response.dart' as _i9;
-import 'package:misskey_dart/src/data/streaming/streaming_request.dart' as _i29;
-import 'package:misskey_dart/src/enums/broadcast_event_type.dart' as _i33;
-import 'package:misskey_dart/src/enums/channel.dart' as _i28;
-import 'package:misskey_dart/src/enums/channel_event_type.dart' as _i31;
-import 'package:misskey_dart/src/enums/note_updated_event_type.dart' as _i32;
+import 'package:misskey_dart/src/data/streaming/streaming_request.dart' as _i30;
+import 'package:misskey_dart/src/enums/broadcast_event_type.dart' as _i34;
+import 'package:misskey_dart/src/enums/channel.dart' as _i29;
+import 'package:misskey_dart/src/enums/channel_event_type.dart' as _i32;
+import 'package:misskey_dart/src/enums/note_updated_event_type.dart' as _i33;
 import 'package:misskey_dart/src/misskey_flash.dart' as _i8;
 import 'package:misskey_dart/src/services/api_service.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i26;
+import 'package:mockito/src/dummies.dart' as _i27;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart'
-    as _i36;
+    as _i37;
+import 'package:web_socket_channel/web_socket_channel.dart' as _i13;
 
-import 'mock.dart' as _i34;
+import 'mock.dart' as _i35;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -697,8 +698,9 @@ class _FakeHttpClientRequest_60 extends _i1.SmartFake
         );
 }
 
-class _FakeFile_61 extends _i1.SmartFake implements _i13.File {
-  _FakeFile_61(
+class _FakeWebSocketChannel_61 extends _i1.SmartFake
+    implements _i13.WebSocketChannel {
+  _FakeWebSocketChannel_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -707,8 +709,18 @@ class _FakeFile_61 extends _i1.SmartFake implements _i13.File {
         );
 }
 
-class _FakeFileInfo_62 extends _i1.SmartFake implements _i14.FileInfo {
-  _FakeFileInfo_62(
+class _FakeFile_62 extends _i1.SmartFake implements _i14.File {
+  _FakeFile_62(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFileInfo_63 extends _i1.SmartFake implements _i15.FileInfo {
+  _FakeFileInfo_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,13 +733,13 @@ class _FakeFileInfo_62 extends _i1.SmartFake implements _i14.FileInfo {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTabSettingsRepository extends _i1.Mock
-    implements _i15.TabSettingsRepository {
+    implements _i16.TabSettingsRepository {
   @override
-  Iterable<_i16.TabSetting> get tabSettings => (super.noSuchMethod(
+  Iterable<_i17.TabSetting> get tabSettings => (super.noSuchMethod(
         Invocation.getter(#tabSettings),
-        returnValue: <_i16.TabSetting>[],
-        returnValueForMissingStub: <_i16.TabSetting>[],
-      ) as Iterable<_i16.TabSetting>);
+        returnValue: <_i17.TabSetting>[],
+        returnValueForMissingStub: <_i17.TabSetting>[],
+      ) as Iterable<_i17.TabSetting>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -737,49 +749,49 @@ class MockTabSettingsRepository extends _i1.Mock
       ) as bool);
 
   @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i18.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> save(List<_i16.TabSetting>? tabSettings) =>
+  _i18.Future<void> save(List<_i17.TabSetting>? tabSettings) =>
       (super.noSuchMethod(
         Invocation.method(
           #save,
           [tabSettings],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> removeAccount(_i6.Account? account) => (super.noSuchMethod(
+  _i18.Future<void> removeAccount(_i6.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #removeAccount,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> initializeTabSettings(_i6.Account? account) =>
+  _i18.Future<void> initializeTabSettings(_i6.Account? account) =>
       (super.noSuchMethod(
         Invocation.method(
           #initializeTabSettings,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -788,7 +800,7 @@ class MockTabSettingsRepository extends _i1.Mock
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -819,7 +831,7 @@ class MockTabSettingsRepository extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockAccountSettingsRepository extends _i1.Mock
-    implements _i19.AccountSettingsRepository {
+    implements _i20.AccountSettingsRepository {
   @override
   Iterable<_i2.AccountSettings> get accountSettings => (super.noSuchMethod(
         Invocation.getter(#accountSettings),
@@ -835,37 +847,37 @@ class MockAccountSettingsRepository extends _i1.Mock
       ) as bool);
 
   @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i18.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> save(_i2.AccountSettings? settings) => (super.noSuchMethod(
+  _i18.Future<void> save(_i2.AccountSettings? settings) => (super.noSuchMethod(
         Invocation.method(
           #save,
           [settings],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> removeAccount(_i6.Account? account) => (super.noSuchMethod(
+  _i18.Future<void> removeAccount(_i6.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #removeAccount,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i2.AccountSettings fromAcct(_i20.Acct? acct) => (super.noSuchMethod(
+  _i2.AccountSettings fromAcct(_i21.Acct? acct) => (super.noSuchMethod(
         Invocation.method(
           #fromAcct,
           [acct],
@@ -909,7 +921,7 @@ class MockAccountSettingsRepository extends _i1.Mock
       ) as _i2.AccountSettings);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -918,7 +930,7 @@ class MockAccountSettingsRepository extends _i1.Mock
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -948,9 +960,9 @@ class MockAccountSettingsRepository extends _i1.Mock
 /// A class which mocks [EmojiRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEmojiRepository extends _i1.Mock implements _i21.EmojiRepository {
+class MockEmojiRepository extends _i1.Mock implements _i22.EmojiRepository {
   @override
-  set emoji(List<_i21.EmojiRepositoryData>? _emoji) => super.noSuchMethod(
+  set emoji(List<_i22.EmojiRepositoryData>? _emoji) => super.noSuchMethod(
         Invocation.setter(
           #emoji,
           _emoji,
@@ -959,37 +971,37 @@ class MockEmojiRepository extends _i1.Mock implements _i21.EmojiRepository {
       );
 
   @override
-  _i17.Future<void> loadFromSourceIfNeed() => (super.noSuchMethod(
+  _i18.Future<void> loadFromSourceIfNeed() => (super.noSuchMethod(
         Invocation.method(
           #loadFromSourceIfNeed,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> loadFromSource() => (super.noSuchMethod(
+  _i18.Future<void> loadFromSource() => (super.noSuchMethod(
         Invocation.method(
           #loadFromSource,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> loadFromLocalCache() => (super.noSuchMethod(
+  _i18.Future<void> loadFromLocalCache() => (super.noSuchMethod(
         Invocation.method(
           #loadFromLocalCache,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<List<_i22.MisskeyEmojiData>> searchEmojis(
+  _i18.Future<List<_i23.MisskeyEmojiData>> searchEmojis(
     String? name, {
     int? limit = 30,
   }) =>
@@ -999,31 +1011,31 @@ class MockEmojiRepository extends _i1.Mock implements _i21.EmojiRepository {
           [name],
           {#limit: limit},
         ),
-        returnValue: _i17.Future<List<_i22.MisskeyEmojiData>>.value(
-            <_i22.MisskeyEmojiData>[]),
+        returnValue: _i18.Future<List<_i23.MisskeyEmojiData>>.value(
+            <_i23.MisskeyEmojiData>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i22.MisskeyEmojiData>>.value(
-                <_i22.MisskeyEmojiData>[]),
-      ) as _i17.Future<List<_i22.MisskeyEmojiData>>);
+            _i18.Future<List<_i23.MisskeyEmojiData>>.value(
+                <_i23.MisskeyEmojiData>[]),
+      ) as _i18.Future<List<_i23.MisskeyEmojiData>>);
 
   @override
-  List<_i22.MisskeyEmojiData> defaultEmojis({int? limit}) =>
+  List<_i23.MisskeyEmojiData> defaultEmojis({int? limit}) =>
       (super.noSuchMethod(
         Invocation.method(
           #defaultEmojis,
           [],
           {#limit: limit},
         ),
-        returnValue: <_i22.MisskeyEmojiData>[],
-        returnValueForMissingStub: <_i22.MisskeyEmojiData>[],
-      ) as List<_i22.MisskeyEmojiData>);
+        returnValue: <_i23.MisskeyEmojiData>[],
+        returnValueForMissingStub: <_i23.MisskeyEmojiData>[],
+      ) as List<_i23.MisskeyEmojiData>);
 }
 
 /// A class which mocks [GeneralSettingsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGeneralSettingsRepository extends _i1.Mock
-    implements _i23.GeneralSettingsRepository {
+    implements _i24.GeneralSettingsRepository {
   @override
   _i3.GeneralSettings get settings => (super.noSuchMethod(
         Invocation.getter(#settings),
@@ -1045,28 +1057,28 @@ class MockGeneralSettingsRepository extends _i1.Mock
       ) as bool);
 
   @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i18.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> update(_i3.GeneralSettings? settings) =>
+  _i18.Future<void> update(_i3.GeneralSettings? settings) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [settings],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1075,7 +1087,7 @@ class MockGeneralSettingsRepository extends _i1.Mock
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1105,7 +1117,7 @@ class MockGeneralSettingsRepository extends _i1.Mock
 /// A class which mocks [AccountRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
+class MockAccountRepository extends _i1.Mock implements _i25.AccountRepository {
   @override
   _i4.NotifierProviderRef<List<_i6.Account>> get ref => (super.noSuchMethod(
         Invocation.getter(#ref),
@@ -1147,48 +1159,48 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
       ) as List<_i6.Account>);
 
   @override
-  _i17.Future<void> load() => (super.noSuchMethod(
+  _i18.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> updateI(_i6.Account? account) => (super.noSuchMethod(
+  _i18.Future<void> updateI(_i6.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #updateI,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> updateMeta(_i6.Account? account) => (super.noSuchMethod(
+  _i18.Future<void> updateMeta(_i6.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #updateMeta,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> loadFromSourceIfNeed(_i20.Acct? acct) =>
+  _i18.Future<void> loadFromSourceIfNeed(_i21.Acct? acct) =>
       (super.noSuchMethod(
         Invocation.method(
           #loadFromSourceIfNeed,
           [acct],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> createUnreadAnnouncement(
+  _i18.Future<void> createUnreadAnnouncement(
     _i6.Account? account,
     _i5.AnnouncementsResponse? announcement,
   ) =>
@@ -1200,55 +1212,55 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
             announcement,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> removeUnreadAnnouncement(_i6.Account? account) =>
+  _i18.Future<void> removeUnreadAnnouncement(_i6.Account? account) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeUnreadAnnouncement,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> addUnreadNotification(_i6.Account? account) =>
+  _i18.Future<void> addUnreadNotification(_i6.Account? account) =>
       (super.noSuchMethod(
         Invocation.method(
           #addUnreadNotification,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> readAllNotification(_i6.Account? account) =>
+  _i18.Future<void> readAllNotification(_i6.Account? account) =>
       (super.noSuchMethod(
         Invocation.method(
           #readAllNotification,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> remove(_i6.Account? account) => (super.noSuchMethod(
+  _i18.Future<void> remove(_i6.Account? account) => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [account],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> loginAsPassword(
+  _i18.Future<void> loginAsPassword(
     String? server,
     String? userId,
     String? password,
@@ -1262,12 +1274,12 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
             password,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> loginAsToken(
+  _i18.Future<void> loginAsToken(
     String? server,
     String? token,
   ) =>
@@ -1279,32 +1291,32 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
             token,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> openMiAuth(String? server) => (super.noSuchMethod(
+  _i18.Future<void> openMiAuth(String? server) => (super.noSuchMethod(
         Invocation.method(
           #openMiAuth,
           [server],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> validateMiAuth(String? server) => (super.noSuchMethod(
+  _i18.Future<void> validateMiAuth(String? server) => (super.noSuchMethod(
         Invocation.method(
           #validateMiAuth,
           [server],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> reorder(
+  _i18.Future<void> reorder(
     int? oldIndex,
     int? newIndex,
   ) =>
@@ -1316,9 +1328,9 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
             newIndex,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   bool updateShouldNotify(
@@ -1341,7 +1353,7 @@ class MockAccountRepository extends _i1.Mock implements _i24.AccountRepository {
 /// A class which mocks [NoteRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockNoteRepository extends _i1.Mock implements _i25.NoteRepository {
+class MockNoteRepository extends _i1.Mock implements _i26.NoteRepository {
   @override
   _i5.Misskey get misskey => (super.noSuchMethod(
         Invocation.getter(#misskey),
@@ -1404,11 +1416,11 @@ class MockNoteRepository extends _i1.Mock implements _i25.NoteRepository {
       ) as Map<String, _i5.Note>);
 
   @override
-  Map<String, _i25.NoteStatus> get noteStatuses => (super.noSuchMethod(
+  Map<String, _i26.NoteStatus> get noteStatuses => (super.noSuchMethod(
         Invocation.getter(#noteStatuses),
-        returnValue: <String, _i25.NoteStatus>{},
-        returnValueForMissingStub: <String, _i25.NoteStatus>{},
-      ) as Map<String, _i25.NoteStatus>);
+        returnValue: <String, _i26.NoteStatus>{},
+        returnValueForMissingStub: <String, _i26.NoteStatus>{},
+      ) as Map<String, _i26.NoteStatus>);
 
   @override
   bool get hasListeners => (super.noSuchMethod(
@@ -1436,7 +1448,7 @@ class MockNoteRepository extends _i1.Mock implements _i25.NoteRepository {
   @override
   void updateNoteStatus(
     String? id,
-    _i25.NoteStatus Function(_i25.NoteStatus)? statusPredicate, {
+    _i26.NoteStatus Function(_i26.NoteStatus)? statusPredicate, {
     bool? isNotify = true,
   }) =>
       super.noSuchMethod(
@@ -1470,14 +1482,14 @@ class MockNoteRepository extends _i1.Mock implements _i25.NoteRepository {
       );
 
   @override
-  _i17.Future<void> refresh(String? noteId) => (super.noSuchMethod(
+  _i18.Future<void> refresh(String? noteId) => (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [noteId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void delete(String? noteId) => super.noSuchMethod(
@@ -1489,7 +1501,7 @@ class MockNoteRepository extends _i1.Mock implements _i25.NoteRepository {
       );
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1498,7 +1510,7 @@ class MockNoteRepository extends _i1.Mock implements _i25.NoteRepository {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1532,11 +1544,11 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   String get host => (super.noSuchMethod(
         Invocation.getter(#host),
-        returnValue: _i26.dummyValue<String>(
+        returnValue: _i27.dummyValue<String>(
           this,
           Invocation.getter(#host),
         ),
-        returnValueForMissingStub: _i26.dummyValue<String>(
+        returnValueForMissingStub: _i27.dummyValue<String>(
           this,
           Invocation.getter(#host),
         ),
@@ -1962,38 +1974,38 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
       );
 
   @override
-  _i17.Future<Iterable<_i5.AnnouncementsResponse>> announcements(
+  _i18.Future<Iterable<_i5.AnnouncementsResponse>> announcements(
           _i5.AnnouncementsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #announcements,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.AnnouncementsResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.AnnouncementsResponse>>.value(
             <_i5.AnnouncementsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.AnnouncementsResponse>>.value(
+            _i18.Future<Iterable<_i5.AnnouncementsResponse>>.value(
                 <_i5.AnnouncementsResponse>[]),
-      ) as _i17.Future<Iterable<_i5.AnnouncementsResponse>>);
+      ) as _i18.Future<Iterable<_i5.AnnouncementsResponse>>);
 
   @override
-  _i17.Future<List<String>> endpoints() => (super.noSuchMethod(
+  _i18.Future<List<String>> endpoints() => (super.noSuchMethod(
         Invocation.method(
           #endpoints,
           [],
         ),
-        returnValue: _i17.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
-      ) as _i17.Future<List<String>>);
+        returnValue: _i18.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i18.Future<List<String>>.value(<String>[]),
+      ) as _i18.Future<List<String>>);
 
   @override
-  _i17.Future<_i5.EmojisResponse> emojis() => (super.noSuchMethod(
+  _i18.Future<_i5.EmojisResponse> emojis() => (super.noSuchMethod(
         Invocation.method(
           #emojis,
           [],
         ),
         returnValue:
-            _i17.Future<_i5.EmojisResponse>.value(_FakeEmojisResponse_24(
+            _i18.Future<_i5.EmojisResponse>.value(_FakeEmojisResponse_24(
           this,
           Invocation.method(
             #emojis,
@@ -2001,23 +2013,23 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.EmojisResponse>.value(_FakeEmojisResponse_24(
+            _i18.Future<_i5.EmojisResponse>.value(_FakeEmojisResponse_24(
           this,
           Invocation.method(
             #emojis,
             [],
           ),
         )),
-      ) as _i17.Future<_i5.EmojisResponse>);
+      ) as _i18.Future<_i5.EmojisResponse>);
 
   @override
-  _i17.Future<_i5.EmojiResponse> emoji(_i5.EmojiRequest? request) =>
+  _i18.Future<_i5.EmojiResponse> emoji(_i5.EmojiRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #emoji,
           [request],
         ),
-        returnValue: _i17.Future<_i5.EmojiResponse>.value(_FakeEmojiResponse_25(
+        returnValue: _i18.Future<_i5.EmojiResponse>.value(_FakeEmojiResponse_25(
           this,
           Invocation.method(
             #emoji,
@@ -2025,22 +2037,22 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.EmojiResponse>.value(_FakeEmojiResponse_25(
+            _i18.Future<_i5.EmojiResponse>.value(_FakeEmojiResponse_25(
           this,
           Invocation.method(
             #emoji,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.EmojiResponse>);
+      ) as _i18.Future<_i5.EmojiResponse>);
 
   @override
-  _i17.Future<_i5.MetaResponse> meta() => (super.noSuchMethod(
+  _i18.Future<_i5.MetaResponse> meta() => (super.noSuchMethod(
         Invocation.method(
           #meta,
           [],
         ),
-        returnValue: _i17.Future<_i5.MetaResponse>.value(_FakeMetaResponse_26(
+        returnValue: _i18.Future<_i5.MetaResponse>.value(_FakeMetaResponse_26(
           this,
           Invocation.method(
             #meta,
@@ -2048,22 +2060,22 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.MetaResponse>.value(_FakeMetaResponse_26(
+            _i18.Future<_i5.MetaResponse>.value(_FakeMetaResponse_26(
           this,
           Invocation.method(
             #meta,
             [],
           ),
         )),
-      ) as _i17.Future<_i5.MetaResponse>);
+      ) as _i18.Future<_i5.MetaResponse>);
 
   @override
-  _i17.Future<_i9.StatsResponse> stats() => (super.noSuchMethod(
+  _i18.Future<_i9.StatsResponse> stats() => (super.noSuchMethod(
         Invocation.method(
           #stats,
           [],
         ),
-        returnValue: _i17.Future<_i9.StatsResponse>.value(_FakeStatsResponse_27(
+        returnValue: _i18.Future<_i9.StatsResponse>.value(_FakeStatsResponse_27(
           this,
           Invocation.method(
             #stats,
@@ -2071,22 +2083,22 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i9.StatsResponse>.value(_FakeStatsResponse_27(
+            _i18.Future<_i9.StatsResponse>.value(_FakeStatsResponse_27(
           this,
           Invocation.method(
             #stats,
             [],
           ),
         )),
-      ) as _i17.Future<_i9.StatsResponse>);
+      ) as _i18.Future<_i9.StatsResponse>);
 
   @override
-  _i17.Future<_i10.PingResponse> ping() => (super.noSuchMethod(
+  _i18.Future<_i10.PingResponse> ping() => (super.noSuchMethod(
         Invocation.method(
           #ping,
           [],
         ),
-        returnValue: _i17.Future<_i10.PingResponse>.value(_FakePingResponse_28(
+        returnValue: _i18.Future<_i10.PingResponse>.value(_FakePingResponse_28(
           this,
           Invocation.method(
             #ping,
@@ -2094,22 +2106,22 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i10.PingResponse>.value(_FakePingResponse_28(
+            _i18.Future<_i10.PingResponse>.value(_FakePingResponse_28(
           this,
           Invocation.method(
             #ping,
             [],
           ),
         )),
-      ) as _i17.Future<_i10.PingResponse>);
+      ) as _i18.Future<_i10.PingResponse>);
 
   @override
-  _i17.Future<_i5.ServerInfoResponse> serverInfo() => (super.noSuchMethod(
+  _i18.Future<_i5.ServerInfoResponse> serverInfo() => (super.noSuchMethod(
         Invocation.method(
           #serverInfo,
           [],
         ),
-        returnValue: _i17.Future<_i5.ServerInfoResponse>.value(
+        returnValue: _i18.Future<_i5.ServerInfoResponse>.value(
             _FakeServerInfoResponse_29(
           this,
           Invocation.method(
@@ -2117,7 +2129,7 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
             [],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.ServerInfoResponse>.value(
+        returnValueForMissingStub: _i18.Future<_i5.ServerInfoResponse>.value(
             _FakeServerInfoResponse_29(
           this,
           Invocation.method(
@@ -2125,16 +2137,16 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
             [],
           ),
         )),
-      ) as _i17.Future<_i5.ServerInfoResponse>);
+      ) as _i18.Future<_i5.ServerInfoResponse>);
 
   @override
-  _i17.Future<_i5.GetOnlineUsersCountResponse> getOnlineUsersCount() =>
+  _i18.Future<_i5.GetOnlineUsersCountResponse> getOnlineUsersCount() =>
       (super.noSuchMethod(
         Invocation.method(
           #getOnlineUsersCount,
           [],
         ),
-        returnValue: _i17.Future<_i5.GetOnlineUsersCountResponse>.value(
+        returnValue: _i18.Future<_i5.GetOnlineUsersCountResponse>.value(
             _FakeGetOnlineUsersCountResponse_30(
           this,
           Invocation.method(
@@ -2143,7 +2155,7 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.GetOnlineUsersCountResponse>.value(
+            _i18.Future<_i5.GetOnlineUsersCountResponse>.value(
                 _FakeGetOnlineUsersCountResponse_30(
           this,
           Invocation.method(
@@ -2151,55 +2163,55 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
             [],
           ),
         )),
-      ) as _i17.Future<_i5.GetOnlineUsersCountResponse>);
+      ) as _i18.Future<_i5.GetOnlineUsersCountResponse>);
 
   @override
-  _i17.Future<Iterable<_i5.GetAvatarDecorationsResponse>>
+  _i18.Future<Iterable<_i5.GetAvatarDecorationsResponse>>
       getAvatarDecorations() => (super.noSuchMethod(
             Invocation.method(
               #getAvatarDecorations,
               [],
             ),
             returnValue:
-                _i17.Future<Iterable<_i5.GetAvatarDecorationsResponse>>.value(
+                _i18.Future<Iterable<_i5.GetAvatarDecorationsResponse>>.value(
                     <_i5.GetAvatarDecorationsResponse>[]),
             returnValueForMissingStub:
-                _i17.Future<Iterable<_i5.GetAvatarDecorationsResponse>>.value(
+                _i18.Future<Iterable<_i5.GetAvatarDecorationsResponse>>.value(
                     <_i5.GetAvatarDecorationsResponse>[]),
-          ) as _i17.Future<Iterable<_i5.GetAvatarDecorationsResponse>>);
+          ) as _i18.Future<Iterable<_i5.GetAvatarDecorationsResponse>>);
 
   @override
-  _i17.Future<Iterable<_i5.User>> pinnedUsers() => (super.noSuchMethod(
+  _i18.Future<Iterable<_i5.User>> pinnedUsers() => (super.noSuchMethod(
         Invocation.method(
           #pinnedUsers,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+        returnValue: _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
-      ) as _i17.Future<Iterable<_i5.User>>);
+            _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i18.Future<Iterable<_i5.User>>);
 
   @override
   _i5.SocketController homeTimelineStream({
     required _i5.HomeTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
@@ -2255,24 +2267,24 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   _i5.SocketController localTimelineStream({
     required _i5.LocalTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
@@ -2328,24 +2340,24 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   _i5.SocketController globalTimelineStream({
     required _i5.GlobalTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
@@ -2401,24 +2413,24 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   _i5.SocketController hybridTimelineStream({
     required _i5.HybridTimelineParameter? parameter,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
@@ -2474,24 +2486,24 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   _i5.SocketController roleTimelineStream({
     required String? roleId,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
@@ -2547,24 +2559,24 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   _i5.SocketController channelStream({
     required String? channelId,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
@@ -2620,23 +2632,23 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   _i5.SocketController userListStream({
     required String? listId,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(_i5.User)? onUserAdded,
-    _i17.FutureOr<void> Function(_i5.User)? onUserRemoved,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(_i5.User)? onUserAdded,
+    _i18.FutureOr<void> Function(_i5.User)? onUserRemoved,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
-    _i17.FutureOr<void> Function(DateTime)? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(DateTime)? onDeleted,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
@@ -2698,24 +2710,24 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
   @override
   _i5.SocketController antennaStream({
     required String? antennaId,
-    _i17.FutureOr<void> Function(_i5.Note)? onNoteReceived,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(_i5.Note)? onNoteReceived,
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onReacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineReacted,
     )? onUnreacted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       DateTime,
     )? onDeleted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.TimelineVoted,
     )? onVoted,
-    _i17.FutureOr<void> Function(
+    _i18.FutureOr<void> Function(
       String,
       _i5.NoteEdited,
     )? onUpdated,
@@ -2770,8 +2782,8 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
 
   @override
   _i5.SocketController serverStatsLogStream(
-    _i17.FutureOr<void> Function(List<_i5.StatsLogResponse>)? onLogReceived,
-    _i17.FutureOr<void> Function(_i5.StatsLogResponse)? onEventReceived,
+    _i18.FutureOr<void> Function(List<_i5.StatsLogResponse>)? onLogReceived,
+    _i18.FutureOr<void> Function(_i5.StatsLogResponse)? onEventReceived,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2805,9 +2817,9 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
 
   @override
   _i5.SocketController queueStatsLogStream(
-    _i17.FutureOr<void> Function(List<_i5.QueueStatsLogResponse>)?
+    _i18.FutureOr<void> Function(List<_i5.QueueStatsLogResponse>)?
         onLogReceived,
-    _i17.FutureOr<void> Function(_i5.QueueStatsLogResponse)? onEventReceived,
+    _i18.FutureOr<void> Function(_i5.QueueStatsLogResponse)? onEventReceived,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2841,28 +2853,28 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
 
   @override
   _i5.SocketController mainStream({
-    _i17.FutureOr<void> Function(_i5.Emoji)? onEmojiAdded,
-    _i17.FutureOr<void> Function(Iterable<_i5.Emoji>)? onEmojiUpdated,
-    _i17.FutureOr<void> Function(Iterable<_i5.Emoji>)? onEmojiDeleted,
-    _i17.FutureOr<void> Function(_i5.AnnouncementsResponse)?
+    _i18.FutureOr<void> Function(_i5.Emoji)? onEmojiAdded,
+    _i18.FutureOr<void> Function(Iterable<_i5.Emoji>)? onEmojiUpdated,
+    _i18.FutureOr<void> Function(Iterable<_i5.Emoji>)? onEmojiDeleted,
+    _i18.FutureOr<void> Function(_i5.AnnouncementsResponse)?
         onAnnouncementCreated,
-    _i17.FutureOr<void> Function(_i5.INotificationsResponse)? onNotification,
-    _i17.FutureOr<void> Function(_i5.Note)? onMention,
-    _i17.FutureOr<void> Function(_i5.Note)? onReply,
-    _i17.FutureOr<void> Function(_i5.Note)? onRenote,
-    _i17.FutureOr<void> Function(_i5.User)? onFollow,
-    _i17.FutureOr<void> Function(_i5.User)? onFollowed,
-    _i17.FutureOr<void> Function(_i5.User)? onUnfollow,
-    _i17.FutureOr<void> Function(_i5.User)? onMeUpdated,
-    _i17.FutureOr<void> Function()? onReadAllNotifications,
-    _i17.FutureOr<void> Function(_i5.INotificationsResponse)?
+    _i18.FutureOr<void> Function(_i5.INotificationsResponse)? onNotification,
+    _i18.FutureOr<void> Function(_i5.Note)? onMention,
+    _i18.FutureOr<void> Function(_i5.Note)? onReply,
+    _i18.FutureOr<void> Function(_i5.Note)? onRenote,
+    _i18.FutureOr<void> Function(_i5.User)? onFollow,
+    _i18.FutureOr<void> Function(_i5.User)? onFollowed,
+    _i18.FutureOr<void> Function(_i5.User)? onUnfollow,
+    _i18.FutureOr<void> Function(_i5.User)? onMeUpdated,
+    _i18.FutureOr<void> Function()? onReadAllNotifications,
+    _i18.FutureOr<void> Function(_i5.INotificationsResponse)?
         onUnreadNotification,
-    _i17.FutureOr<void> Function(String)? onUnreadMention,
-    _i17.FutureOr<void> Function()? onReadAllUnreadMentions,
-    _i17.FutureOr<void> Function(String)? onUnreadSpecifiedNote,
-    _i17.FutureOr<void> Function()? onReadAllUnreadSpecifiedNotes,
-    _i17.FutureOr<void> Function(_i5.User)? onReceiveFollowRequest,
-    _i17.FutureOr<void> Function()? onReadAllAnnouncements,
+    _i18.FutureOr<void> Function(String)? onUnreadMention,
+    _i18.FutureOr<void> Function()? onReadAllUnreadMentions,
+    _i18.FutureOr<void> Function(String)? onUnreadSpecifiedNote,
+    _i18.FutureOr<void> Function()? onReadAllUnreadSpecifiedNotes,
+    _i18.FutureOr<void> Function(_i5.User)? onReceiveFollowRequest,
+    _i18.FutureOr<void> Function()? onReadAllAnnouncements,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2952,14 +2964,14 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
       ) as _i5.SocketController);
 
   @override
-  _i17.Future<void> startStreaming() => (super.noSuchMethod(
+  _i18.Future<void> startStreaming() => (super.noSuchMethod(
         Invocation.method(
           #startStreaming,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyAntenna].
@@ -2967,13 +2979,13 @@ class MockMisskey extends _i1.Mock implements _i5.Misskey {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyAntenna extends _i1.Mock implements _i5.MisskeyAntenna {
   @override
-  _i17.Future<_i5.Antenna> create(_i5.AntennasCreateRequest? request) =>
+  _i18.Future<_i5.Antenna> create(_i5.AntennasCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<_i5.Antenna>.value(_FakeAntenna_32(
+        returnValue: _i18.Future<_i5.Antenna>.value(_FakeAntenna_32(
           this,
           Invocation.method(
             #create,
@@ -2981,57 +2993,57 @@ class MockMisskeyAntenna extends _i1.Mock implements _i5.MisskeyAntenna {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.Antenna>.value(_FakeAntenna_32(
+            _i18.Future<_i5.Antenna>.value(_FakeAntenna_32(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.Antenna>);
+      ) as _i18.Future<_i5.Antenna>);
 
   @override
-  _i17.Future<void> delete(_i5.AntennasDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.AntennasDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.Antenna>> list() => (super.noSuchMethod(
+  _i18.Future<Iterable<_i5.Antenna>> list() => (super.noSuchMethod(
         Invocation.method(
           #list,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Antenna>>.value(<_i5.Antenna>[]),
+        returnValue: _i18.Future<Iterable<_i5.Antenna>>.value(<_i5.Antenna>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Antenna>>.value(<_i5.Antenna>[]),
-      ) as _i17.Future<Iterable<_i5.Antenna>>);
+            _i18.Future<Iterable<_i5.Antenna>>.value(<_i5.Antenna>[]),
+      ) as _i18.Future<Iterable<_i5.Antenna>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> notes(_i5.AntennasNotesRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> notes(_i5.AntennasNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i5.Antenna> show(_i5.AntennasShowRequest? request) =>
+  _i18.Future<_i5.Antenna> show(_i5.AntennasShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i5.Antenna>.value(_FakeAntenna_32(
+        returnValue: _i18.Future<_i5.Antenna>.value(_FakeAntenna_32(
           this,
           Invocation.method(
             #show,
@@ -3039,25 +3051,25 @@ class MockMisskeyAntenna extends _i1.Mock implements _i5.MisskeyAntenna {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.Antenna>.value(_FakeAntenna_32(
+            _i18.Future<_i5.Antenna>.value(_FakeAntenna_32(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.Antenna>);
+      ) as _i18.Future<_i5.Antenna>);
 
   @override
-  _i17.Future<void> update(_i5.AntennasUpdateRequest? request) =>
+  _i18.Future<void> update(_i5.AntennasUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyAp].
@@ -3065,14 +3077,14 @@ class MockMisskeyAntenna extends _i1.Mock implements _i5.MisskeyAntenna {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyAp extends _i1.Mock implements _i5.MisskeyAp {
   @override
-  _i17.Future<_i5.ApShowResponse> show(_i5.ApShowRequest? request) =>
+  _i18.Future<_i5.ApShowResponse> show(_i5.ApShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i5.ApShowResponse>.value(_FakeApShowResponse_33(
+            _i18.Future<_i5.ApShowResponse>.value(_FakeApShowResponse_33(
           this,
           Invocation.method(
             #show,
@@ -3080,14 +3092,14 @@ class MockMisskeyAp extends _i1.Mock implements _i5.MisskeyAp {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.ApShowResponse>.value(_FakeApShowResponse_33(
+            _i18.Future<_i5.ApShowResponse>.value(_FakeApShowResponse_33(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.ApShowResponse>);
+      ) as _i18.Future<_i5.ApShowResponse>);
 }
 
 /// A class which mocks [MisskeyBlocking].
@@ -3095,26 +3107,26 @@ class MockMisskeyAp extends _i1.Mock implements _i5.MisskeyAp {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyBlocking extends _i1.Mock implements _i5.MisskeyBlocking {
   @override
-  _i17.Future<void> create(_i5.BlockCreateRequest? request) =>
+  _i18.Future<void> create(_i5.BlockCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i5.BlockDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.BlockDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyChannels].
@@ -3122,27 +3134,27 @@ class MockMisskeyBlocking extends _i1.Mock implements _i5.MisskeyBlocking {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyChannels extends _i1.Mock implements _i5.MisskeyChannels {
   @override
-  _i17.Future<Iterable<_i5.Note>> timeline(
+  _i18.Future<Iterable<_i5.Note>> timeline(
           _i5.ChannelsTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #timeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i5.CommunityChannel> show(_i5.ChannelsShowRequest? request) =>
+  _i18.Future<_i5.CommunityChannel> show(_i5.ChannelsShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i18.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
           this,
           Invocation.method(
             #show,
@@ -3150,90 +3162,90 @@ class MockMisskeyChannels extends _i1.Mock implements _i5.MisskeyChannels {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i18.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.CommunityChannel>);
+      ) as _i18.Future<_i5.CommunityChannel>);
 
   @override
-  _i17.Future<Iterable<_i5.CommunityChannel>> followed(
+  _i18.Future<Iterable<_i5.CommunityChannel>> followed(
           _i5.ChannelsFollowedRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #followed,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+        returnValue: _i18.Future<Iterable<_i5.CommunityChannel>>.value(
             <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+            _i18.Future<Iterable<_i5.CommunityChannel>>.value(
                 <_i5.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i5.CommunityChannel>>);
+      ) as _i18.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i5.CommunityChannel>> myFavorite(
+  _i18.Future<Iterable<_i5.CommunityChannel>> myFavorite(
           _i5.ChannelsMyFavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #myFavorite,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+        returnValue: _i18.Future<Iterable<_i5.CommunityChannel>>.value(
             <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+            _i18.Future<Iterable<_i5.CommunityChannel>>.value(
                 <_i5.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i5.CommunityChannel>>);
+      ) as _i18.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i5.CommunityChannel>> featured() => (super.noSuchMethod(
+  _i18.Future<Iterable<_i5.CommunityChannel>> featured() => (super.noSuchMethod(
         Invocation.method(
           #featured,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+        returnValue: _i18.Future<Iterable<_i5.CommunityChannel>>.value(
             <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+            _i18.Future<Iterable<_i5.CommunityChannel>>.value(
                 <_i5.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i5.CommunityChannel>>);
+      ) as _i18.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i5.CommunityChannel>> owned(
+  _i18.Future<Iterable<_i5.CommunityChannel>> owned(
           _i5.ChannelsOwnedRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #owned,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+        returnValue: _i18.Future<Iterable<_i5.CommunityChannel>>.value(
             <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+            _i18.Future<Iterable<_i5.CommunityChannel>>.value(
                 <_i5.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i5.CommunityChannel>>);
+      ) as _i18.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<Iterable<_i5.CommunityChannel>> search(
+  _i18.Future<Iterable<_i5.CommunityChannel>> search(
           _i5.ChannelsSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+        returnValue: _i18.Future<Iterable<_i5.CommunityChannel>>.value(
             <_i5.CommunityChannel>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.CommunityChannel>>.value(
+            _i18.Future<Iterable<_i5.CommunityChannel>>.value(
                 <_i5.CommunityChannel>[]),
-      ) as _i17.Future<Iterable<_i5.CommunityChannel>>);
+      ) as _i18.Future<Iterable<_i5.CommunityChannel>>);
 
   @override
-  _i17.Future<_i5.CommunityChannel> create(
+  _i18.Future<_i5.CommunityChannel> create(
           _i5.ChannelsCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3241,7 +3253,7 @@ class MockMisskeyChannels extends _i1.Mock implements _i5.MisskeyChannels {
           [request],
         ),
         returnValue:
-            _i17.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i18.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
           this,
           Invocation.method(
             #create,
@@ -3249,69 +3261,69 @@ class MockMisskeyChannels extends _i1.Mock implements _i5.MisskeyChannels {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
+            _i18.Future<_i5.CommunityChannel>.value(_FakeCommunityChannel_34(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.CommunityChannel>);
+      ) as _i18.Future<_i5.CommunityChannel>);
 
   @override
-  _i17.Future<void> update(_i5.ChannelsUpdateRequest? request) =>
+  _i18.Future<void> update(_i5.ChannelsUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> favorite(_i5.ChannelsFavoriteRequest? request) =>
+  _i18.Future<void> favorite(_i5.ChannelsFavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #favorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> unfavorite(_i5.ChannelsUnfavoriteRequest? request) =>
+  _i18.Future<void> unfavorite(_i5.ChannelsUnfavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unfavorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> follow(_i5.ChannelsFollowRequest? request) =>
+  _i18.Future<void> follow(_i5.ChannelsFollowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #follow,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> unfollow(_i5.ChannelsUnfollowRequest? request) =>
+  _i18.Future<void> unfollow(_i5.ChannelsUnfollowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unfollow,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyClips].
@@ -3319,162 +3331,162 @@ class MockMisskeyChannels extends _i1.Mock implements _i5.MisskeyChannels {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyClips extends _i1.Mock implements _i5.MisskeyClips {
   @override
-  _i17.Future<Iterable<_i5.Clip>> list() => (super.noSuchMethod(
+  _i18.Future<Iterable<_i5.Clip>> list() => (super.noSuchMethod(
         Invocation.method(
           #list,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+        returnValue: _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
-      ) as _i17.Future<Iterable<_i5.Clip>>);
+            _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i18.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<Iterable<_i5.Clip>> myFavorites() => (super.noSuchMethod(
+  _i18.Future<Iterable<_i5.Clip>> myFavorites() => (super.noSuchMethod(
         Invocation.method(
           #myFavorites,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+        returnValue: _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
-      ) as _i17.Future<Iterable<_i5.Clip>>);
+            _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i18.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> notes(_i5.ClipsNotesRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> notes(_i5.ClipsNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<void> addNote(_i5.ClipsAddNoteRequest? request) =>
+  _i18.Future<void> addNote(_i5.ClipsAddNoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #addNote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> removeNote(_i5.ClipsRemoveNoteRequest? request) =>
+  _i18.Future<void> removeNote(_i5.ClipsRemoveNoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeNote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i5.Clip> create(_i5.ClipsCreateRequest? request) =>
+  _i18.Future<_i5.Clip> create(_i5.ClipsCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<_i5.Clip>.value(_FakeClip_35(
+        returnValue: _i18.Future<_i5.Clip>.value(_FakeClip_35(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.Clip>.value(_FakeClip_35(
+        returnValueForMissingStub: _i18.Future<_i5.Clip>.value(_FakeClip_35(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.Clip>);
+      ) as _i18.Future<_i5.Clip>);
 
   @override
-  _i17.Future<void> delete(_i5.ClipsDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.ClipsDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i5.Clip> update(_i5.ClipsUpdateRequest? request) =>
+  _i18.Future<_i5.Clip> update(_i5.ClipsUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<_i5.Clip>.value(_FakeClip_35(
+        returnValue: _i18.Future<_i5.Clip>.value(_FakeClip_35(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.Clip>.value(_FakeClip_35(
+        returnValueForMissingStub: _i18.Future<_i5.Clip>.value(_FakeClip_35(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.Clip>);
+      ) as _i18.Future<_i5.Clip>);
 
   @override
-  _i17.Future<_i5.Clip> show(_i5.ClipsShowRequest? request) =>
+  _i18.Future<_i5.Clip> show(_i5.ClipsShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i5.Clip>.value(_FakeClip_35(
+        returnValue: _i18.Future<_i5.Clip>.value(_FakeClip_35(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.Clip>.value(_FakeClip_35(
+        returnValueForMissingStub: _i18.Future<_i5.Clip>.value(_FakeClip_35(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.Clip>);
+      ) as _i18.Future<_i5.Clip>);
 
   @override
-  _i17.Future<void> favorite(_i5.ClipsFavoriteRequest? request) =>
+  _i18.Future<void> favorite(_i5.ClipsFavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #favorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> unfavorite(_i5.ClipsUnfavoriteRequest? request) =>
+  _i18.Future<void> unfavorite(_i5.ClipsUnfavoriteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unfavorite,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyDrive].
@@ -3508,7 +3520,7 @@ class MockMisskeyDrive extends _i1.Mock implements _i5.MisskeyDrive {
       ) as _i5.MisskeyDriveFolders);
 
   @override
-  _i17.Future<Iterable<_i5.DriveFile>> stream(
+  _i18.Future<Iterable<_i5.DriveFile>> stream(
           _i5.DriveStreamRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3516,10 +3528,10 @@ class MockMisskeyDrive extends _i1.Mock implements _i5.MisskeyDrive {
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
-      ) as _i17.Future<Iterable<_i5.DriveFile>>);
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+      ) as _i18.Future<Iterable<_i5.DriveFile>>);
 }
 
 /// A class which mocks [MisskeyDriveFolders].
@@ -3528,7 +3540,7 @@ class MockMisskeyDrive extends _i1.Mock implements _i5.MisskeyDrive {
 class MockMisskeyDriveFolders extends _i1.Mock
     implements _i5.MisskeyDriveFolders {
   @override
-  _i17.Future<Iterable<_i5.DriveFolder>> folders(
+  _i18.Future<Iterable<_i5.DriveFolder>> folders(
           _i5.DriveFoldersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3536,19 +3548,19 @@ class MockMisskeyDriveFolders extends _i1.Mock
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
+            _i18.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
-      ) as _i17.Future<Iterable<_i5.DriveFolder>>);
+            _i18.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
+      ) as _i18.Future<Iterable<_i5.DriveFolder>>);
 
   @override
-  _i17.Future<_i5.DriveFolder> create(_i5.DriveFoldersCreateRequest? request) =>
+  _i18.Future<_i5.DriveFolder> create(_i5.DriveFoldersCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
+        returnValue: _i18.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
           this,
           Invocation.method(
             #create,
@@ -3556,28 +3568,28 @@ class MockMisskeyDriveFolders extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
+            _i18.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.DriveFolder>);
+      ) as _i18.Future<_i5.DriveFolder>);
 
   @override
-  _i17.Future<void> delete(_i5.DriveFoldersDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.DriveFoldersDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.DriveFolder>> find(
+  _i18.Future<Iterable<_i5.DriveFolder>> find(
           _i5.DriveFoldersFindRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3585,19 +3597,19 @@ class MockMisskeyDriveFolders extends _i1.Mock
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
+            _i18.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
-      ) as _i17.Future<Iterable<_i5.DriveFolder>>);
+            _i18.Future<Iterable<_i5.DriveFolder>>.value(<_i5.DriveFolder>[]),
+      ) as _i18.Future<Iterable<_i5.DriveFolder>>);
 
   @override
-  _i17.Future<_i5.DriveFolder> show(_i5.DriveFoldersShowRequest? request) =>
+  _i18.Future<_i5.DriveFolder> show(_i5.DriveFoldersShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
+        returnValue: _i18.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
           this,
           Invocation.method(
             #show,
@@ -3605,23 +3617,23 @@ class MockMisskeyDriveFolders extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
+            _i18.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.DriveFolder>);
+      ) as _i18.Future<_i5.DriveFolder>);
 
   @override
-  _i17.Future<_i5.DriveFolder> update(_i5.DriveFoldersUpdateRequest? request) =>
+  _i18.Future<_i5.DriveFolder> update(_i5.DriveFoldersUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
+        returnValue: _i18.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
           this,
           Invocation.method(
             #update,
@@ -3629,14 +3641,14 @@ class MockMisskeyDriveFolders extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
+            _i18.Future<_i5.DriveFolder>.value(_FakeDriveFolder_38(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.DriveFolder>);
+      ) as _i18.Future<_i5.DriveFolder>);
 }
 
 /// A class which mocks [MisskeyDriveFiles].
@@ -3644,7 +3656,7 @@ class MockMisskeyDriveFolders extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
   @override
-  _i17.Future<_i5.DriveFile> create(
+  _i18.Future<_i5.DriveFile> create(
     _i5.DriveFilesCreateRequest? request,
     _i12.File? fileContent,
   ) =>
@@ -3656,7 +3668,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
             fileContent,
           ],
         ),
-        returnValue: _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+        returnValue: _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #create,
@@ -3667,7 +3679,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+            _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #create,
@@ -3677,12 +3689,12 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
             ],
           ),
         )),
-      ) as _i17.Future<_i5.DriveFile>);
+      ) as _i18.Future<_i5.DriveFile>);
 
   @override
-  _i17.Future<_i5.DriveFile> createAsBinary(
+  _i18.Future<_i5.DriveFile> createAsBinary(
     _i5.DriveFilesCreateRequest? request,
-    _i27.Uint8List? fileContent,
+    _i28.Uint8List? fileContent,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3692,7 +3704,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
             fileContent,
           ],
         ),
-        returnValue: _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+        returnValue: _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #createAsBinary,
@@ -3703,7 +3715,7 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+            _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #createAsBinary,
@@ -3713,16 +3725,16 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
             ],
           ),
         )),
-      ) as _i17.Future<_i5.DriveFile>);
+      ) as _i18.Future<_i5.DriveFile>);
 
   @override
-  _i17.Future<_i5.DriveFile> update(_i5.DriveFilesUpdateRequest? request) =>
+  _i18.Future<_i5.DriveFile> update(_i5.DriveFilesUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+        returnValue: _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #update,
@@ -3730,41 +3742,41 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+            _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.DriveFile>);
+      ) as _i18.Future<_i5.DriveFile>);
 
   @override
-  _i17.Future<void> delete(_i5.DriveFilesDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.DriveFilesDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.DriveFile>> files(_i5.DriveFilesRequest? request) =>
+  _i18.Future<Iterable<_i5.DriveFile>> files(_i5.DriveFilesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #files,
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
-      ) as _i17.Future<Iterable<_i5.DriveFile>>);
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+      ) as _i18.Future<Iterable<_i5.DriveFile>>);
 
   @override
-  _i17.Future<Iterable<_i5.DriveFile>> find(
+  _i18.Future<Iterable<_i5.DriveFile>> find(
           _i5.DriveFilesFindRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3772,38 +3784,38 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
-      ) as _i17.Future<Iterable<_i5.DriveFile>>);
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+      ) as _i18.Future<Iterable<_i5.DriveFile>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> attachedNotes(
+  _i18.Future<Iterable<_i5.Note>> attachedNotes(
           _i5.DriveFilesAttachedNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #attachedNotes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<bool> checkExistence(
+  _i18.Future<bool> checkExistence(
           _i5.DriveFilesCheckExistenceRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkExistence,
           [request],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<Iterable<_i5.DriveFile>> findByHash(
+  _i18.Future<Iterable<_i5.DriveFile>> findByHash(
           _i5.DriveFilesFindByHashRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3811,19 +3823,19 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
-      ) as _i17.Future<Iterable<_i5.DriveFile>>);
+            _i18.Future<Iterable<_i5.DriveFile>>.value(<_i5.DriveFile>[]),
+      ) as _i18.Future<Iterable<_i5.DriveFile>>);
 
   @override
-  _i17.Future<_i5.DriveFile> show(_i5.DriveFilesShowRequest? request) =>
+  _i18.Future<_i5.DriveFile> show(_i5.DriveFilesShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+        returnValue: _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #show,
@@ -3831,26 +3843,26 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
+            _i18.Future<_i5.DriveFile>.value(_FakeDriveFile_39(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.DriveFile>);
+      ) as _i18.Future<_i5.DriveFile>);
 
   @override
-  _i17.Future<void> uploadFromUrl(
+  _i18.Future<void> uploadFromUrl(
           _i5.DriveFilesUploadFromUrlRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uploadFromUrl,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyFederation].
@@ -3858,14 +3870,14 @@ class MockMisskeyDriveFiles extends _i1.Mock implements _i5.MisskeyDriveFiles {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyFederation extends _i1.Mock implements _i5.MisskeyFederation {
   @override
-  _i17.Future<_i5.FederationShowInstanceResponse> showInstance(
+  _i18.Future<_i5.FederationShowInstanceResponse> showInstance(
           _i5.FederationShowInstanceRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #showInstance,
           [request],
         ),
-        returnValue: _i17.Future<_i5.FederationShowInstanceResponse>.value(
+        returnValue: _i18.Future<_i5.FederationShowInstanceResponse>.value(
             _FakeFederationShowInstanceResponse_40(
           this,
           Invocation.method(
@@ -3874,7 +3886,7 @@ class MockMisskeyFederation extends _i1.Mock implements _i5.MisskeyFederation {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.FederationShowInstanceResponse>.value(
+            _i18.Future<_i5.FederationShowInstanceResponse>.value(
                 _FakeFederationShowInstanceResponse_40(
           this,
           Invocation.method(
@@ -3882,19 +3894,19 @@ class MockMisskeyFederation extends _i1.Mock implements _i5.MisskeyFederation {
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.FederationShowInstanceResponse>);
+      ) as _i18.Future<_i5.FederationShowInstanceResponse>);
 
   @override
-  _i17.Future<Iterable<_i5.User>> users(_i5.FederationUsersRequest? request) =>
+  _i18.Future<Iterable<_i5.User>> users(_i5.FederationUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+        returnValue: _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
-      ) as _i17.Future<Iterable<_i5.User>>);
+            _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i18.Future<Iterable<_i5.User>>);
 }
 
 /// A class which mocks [MisskeyFollowing].
@@ -3915,84 +3927,84 @@ class MockMisskeyFollowing extends _i1.Mock implements _i5.MisskeyFollowing {
       ) as _i5.MisskeyFollowingRequests);
 
   @override
-  _i17.Future<_i5.User> create(_i5.FollowingCreateRequest? request) =>
+  _i18.Future<_i5.User> create(_i5.FollowingCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<_i5.User>.value(_FakeUser_42(
+        returnValue: _i18.Future<_i5.User>.value(_FakeUser_42(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.User>.value(_FakeUser_42(
+        returnValueForMissingStub: _i18.Future<_i5.User>.value(_FakeUser_42(
           this,
           Invocation.method(
             #create,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.User>);
+      ) as _i18.Future<_i5.User>);
 
   @override
-  _i17.Future<_i5.User> delete(_i5.FollowingDeleteRequest? request) =>
+  _i18.Future<_i5.User> delete(_i5.FollowingDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<_i5.User>.value(_FakeUser_42(
+        returnValue: _i18.Future<_i5.User>.value(_FakeUser_42(
           this,
           Invocation.method(
             #delete,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.User>.value(_FakeUser_42(
+        returnValueForMissingStub: _i18.Future<_i5.User>.value(_FakeUser_42(
           this,
           Invocation.method(
             #delete,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.User>);
+      ) as _i18.Future<_i5.User>);
 
   @override
-  _i17.Future<_i5.User> invalidate(_i5.FollowingInvalidateRequest? request) =>
+  _i18.Future<_i5.User> invalidate(_i5.FollowingInvalidateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #invalidate,
           [request],
         ),
-        returnValue: _i17.Future<_i5.User>.value(_FakeUser_42(
+        returnValue: _i18.Future<_i5.User>.value(_FakeUser_42(
           this,
           Invocation.method(
             #invalidate,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.User>.value(_FakeUser_42(
+        returnValueForMissingStub: _i18.Future<_i5.User>.value(_FakeUser_42(
           this,
           Invocation.method(
             #invalidate,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.User>);
+      ) as _i18.Future<_i5.User>);
 
   @override
-  _i17.Future<void> updateAll(_i5.FollowingUpdateAllRequest? request) =>
+  _i18.Future<void> updateAll(_i5.FollowingUpdateAllRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateAll,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyHashtags].
@@ -4000,37 +4012,37 @@ class MockMisskeyFollowing extends _i1.Mock implements _i5.MisskeyFollowing {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyHashtags extends _i1.Mock implements _i5.MisskeyHashtags {
   @override
-  _i17.Future<Iterable<_i5.Hashtag>> list(_i5.HashtagsListRequest? request) =>
+  _i18.Future<Iterable<_i5.Hashtag>> list(_i5.HashtagsListRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #list,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Hashtag>>.value(<_i5.Hashtag>[]),
+        returnValue: _i18.Future<Iterable<_i5.Hashtag>>.value(<_i5.Hashtag>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Hashtag>>.value(<_i5.Hashtag>[]),
-      ) as _i17.Future<Iterable<_i5.Hashtag>>);
+            _i18.Future<Iterable<_i5.Hashtag>>.value(<_i5.Hashtag>[]),
+      ) as _i18.Future<Iterable<_i5.Hashtag>>);
 
   @override
-  _i17.Future<Iterable<String>> search(_i5.HashtagsSearchRequest? request) =>
+  _i18.Future<Iterable<String>> search(_i5.HashtagsSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<String>>.value(<String>[]),
+        returnValue: _i18.Future<Iterable<String>>.value(<String>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<String>>.value(<String>[]),
-      ) as _i17.Future<Iterable<String>>);
+            _i18.Future<Iterable<String>>.value(<String>[]),
+      ) as _i18.Future<Iterable<String>>);
 
   @override
-  _i17.Future<_i5.Hashtag> show(_i5.HashtagsShowRequest? request) =>
+  _i18.Future<_i5.Hashtag> show(_i5.HashtagsShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i5.Hashtag>.value(_FakeHashtag_43(
+        returnValue: _i18.Future<_i5.Hashtag>.value(_FakeHashtag_43(
           this,
           Invocation.method(
             #show,
@@ -4038,40 +4050,40 @@ class MockMisskeyHashtags extends _i1.Mock implements _i5.MisskeyHashtags {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.Hashtag>.value(_FakeHashtag_43(
+            _i18.Future<_i5.Hashtag>.value(_FakeHashtag_43(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.Hashtag>);
+      ) as _i18.Future<_i5.Hashtag>);
 
   @override
-  _i17.Future<Iterable<_i5.HashtagsTrendResponse>> trend() =>
+  _i18.Future<Iterable<_i5.HashtagsTrendResponse>> trend() =>
       (super.noSuchMethod(
         Invocation.method(
           #trend,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i5.HashtagsTrendResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.HashtagsTrendResponse>>.value(
             <_i5.HashtagsTrendResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.HashtagsTrendResponse>>.value(
+            _i18.Future<Iterable<_i5.HashtagsTrendResponse>>.value(
                 <_i5.HashtagsTrendResponse>[]),
-      ) as _i17.Future<Iterable<_i5.HashtagsTrendResponse>>);
+      ) as _i18.Future<Iterable<_i5.HashtagsTrendResponse>>);
 
   @override
-  _i17.Future<Iterable<_i5.User>> users(_i5.HashtagsUsersRequest? request) =>
+  _i18.Future<Iterable<_i5.User>> users(_i5.HashtagsUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+        returnValue: _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
-      ) as _i17.Future<Iterable<_i5.User>>);
+            _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i18.Future<Iterable<_i5.User>>);
 }
 
 /// A class which mocks [MisskeyI].
@@ -4079,12 +4091,12 @@ class MockMisskeyHashtags extends _i1.Mock implements _i5.MisskeyHashtags {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyI extends _i1.Mock implements _i5.MisskeyI {
   @override
-  _i17.Future<_i5.IResponse> i() => (super.noSuchMethod(
+  _i18.Future<_i5.IResponse> i() => (super.noSuchMethod(
         Invocation.method(
           #i,
           [],
         ),
-        returnValue: _i17.Future<_i5.IResponse>.value(_FakeIResponse_44(
+        returnValue: _i18.Future<_i5.IResponse>.value(_FakeIResponse_44(
           this,
           Invocation.method(
             #i,
@@ -4092,64 +4104,64 @@ class MockMisskeyI extends _i1.Mock implements _i5.MisskeyI {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.IResponse>.value(_FakeIResponse_44(
+            _i18.Future<_i5.IResponse>.value(_FakeIResponse_44(
           this,
           Invocation.method(
             #i,
             [],
           ),
         )),
-      ) as _i17.Future<_i5.IResponse>);
+      ) as _i18.Future<_i5.IResponse>);
 
   @override
-  _i17.Future<Iterable<_i5.INotificationsResponse>> notifications(
+  _i18.Future<Iterable<_i5.INotificationsResponse>> notifications(
           _i5.INotificationsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notifications,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.INotificationsResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.INotificationsResponse>>.value(
             <_i5.INotificationsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.INotificationsResponse>>.value(
+            _i18.Future<Iterable<_i5.INotificationsResponse>>.value(
                 <_i5.INotificationsResponse>[]),
-      ) as _i17.Future<Iterable<_i5.INotificationsResponse>>);
+      ) as _i18.Future<Iterable<_i5.INotificationsResponse>>);
 
   @override
-  _i17.Future<void> readAnnouncement(_i5.IReadAnnouncementRequest? request) =>
+  _i18.Future<void> readAnnouncement(_i5.IReadAnnouncementRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #readAnnouncement,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.IFavoritesResponse>> favorites(
+  _i18.Future<Iterable<_i5.IFavoritesResponse>> favorites(
           _i5.IFavoritesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #favorites,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.IFavoritesResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.IFavoritesResponse>>.value(
             <_i5.IFavoritesResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.IFavoritesResponse>>.value(
+            _i18.Future<Iterable<_i5.IFavoritesResponse>>.value(
                 <_i5.IFavoritesResponse>[]),
-      ) as _i17.Future<Iterable<_i5.IFavoritesResponse>>);
+      ) as _i18.Future<Iterable<_i5.IFavoritesResponse>>);
 
   @override
-  _i17.Future<_i5.IResponse> update(_i5.IUpdateRequest? request) =>
+  _i18.Future<_i5.IResponse> update(_i5.IUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<_i5.IResponse>.value(_FakeIResponse_44(
+        returnValue: _i18.Future<_i5.IResponse>.value(_FakeIResponse_44(
           this,
           Invocation.method(
             #update,
@@ -4157,14 +4169,14 @@ class MockMisskeyI extends _i1.Mock implements _i5.MisskeyI {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.IResponse>.value(_FakeIResponse_44(
+            _i18.Future<_i5.IResponse>.value(_FakeIResponse_44(
           this,
           Invocation.method(
             #update,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.IResponse>);
+      ) as _i18.Future<_i5.IResponse>);
 }
 
 /// A class which mocks [MisskeyNotes].
@@ -4224,146 +4236,146 @@ class MockMisskeyNotes extends _i1.Mock implements _i5.MisskeyNotes {
       ) as _i5.MisskeyNotesThreadMuting);
 
   @override
-  _i17.Future<void> create(_i5.NotesCreateRequest? request) =>
+  _i18.Future<void> create(_i5.NotesCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> update(_i5.NotesUpdateRequest? request) =>
+  _i18.Future<void> update(_i5.NotesUpdateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #update,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i5.NotesDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.NotesDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> notes(_i5.NotesRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> notes(_i5.NotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i5.Note> show(_i5.NotesShowRequest? request) =>
+  _i18.Future<_i5.Note> show(_i5.NotesShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
-        returnValue: _i17.Future<_i5.Note>.value(_FakeNote_49(
+        returnValue: _i18.Future<_i5.Note>.value(_FakeNote_49(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.Note>.value(_FakeNote_49(
+        returnValueForMissingStub: _i18.Future<_i5.Note>.value(_FakeNote_49(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.Note>);
+      ) as _i18.Future<_i5.Note>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> homeTimeline(
+  _i18.Future<Iterable<_i5.Note>> homeTimeline(
           _i5.NotesTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #homeTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> localTimeline(
+  _i18.Future<Iterable<_i5.Note>> localTimeline(
           _i5.NotesLocalTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #localTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> hybridTimeline(
+  _i18.Future<Iterable<_i5.Note>> hybridTimeline(
           _i5.NotesHybridTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #hybridTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> globalTimeline(
+  _i18.Future<Iterable<_i5.Note>> globalTimeline(
           _i5.NotesGlobalTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #globalTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> userListTimeline(
+  _i18.Future<Iterable<_i5.Note>> userListTimeline(
           _i5.UserListTimelineRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #userListTimeline,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<_i5.NotesStateResponse> state(_i5.NotesStateRequest? request) =>
+  _i18.Future<_i5.NotesStateResponse> state(_i5.NotesStateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #state,
           [request],
         ),
-        returnValue: _i17.Future<_i5.NotesStateResponse>.value(
+        returnValue: _i18.Future<_i5.NotesStateResponse>.value(
             _FakeNotesStateResponse_50(
           this,
           Invocation.method(
@@ -4371,7 +4383,7 @@ class MockMisskeyNotes extends _i1.Mock implements _i5.MisskeyNotes {
             [request],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i5.NotesStateResponse>.value(
+        returnValueForMissingStub: _i18.Future<_i5.NotesStateResponse>.value(
             _FakeNotesStateResponse_50(
           this,
           Invocation.method(
@@ -4379,128 +4391,128 @@ class MockMisskeyNotes extends _i1.Mock implements _i5.MisskeyNotes {
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.NotesStateResponse>);
+      ) as _i18.Future<_i5.NotesStateResponse>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> search(_i5.NotesSearchRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> search(_i5.NotesSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> searchByTag(
+  _i18.Future<Iterable<_i5.Note>> searchByTag(
           _i5.NotesSearchByTagRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchByTag,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> renotes(_i5.NotesRenoteRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> renotes(_i5.NotesRenoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #renotes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> replies(_i5.NotesRepliesRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> replies(_i5.NotesRepliesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #replies,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> children(_i5.NotesChildrenRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> children(_i5.NotesChildrenRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #children,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> conversation(
+  _i18.Future<Iterable<_i5.Note>> conversation(
           _i5.NotesConversationRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #conversation,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> featured(_i5.NotesFeaturedRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> featured(_i5.NotesFeaturedRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #featured,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> mentions(_i5.NotesMentionsRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> mentions(_i5.NotesMentionsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #mentions,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Clip>> clips(_i5.NotesClipsRequest? request) =>
+  _i18.Future<Iterable<_i5.Clip>> clips(_i5.NotesClipsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #clips,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+        returnValue: _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
-      ) as _i17.Future<Iterable<_i5.Clip>>);
+            _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i18.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<void> unrenote(_i5.NotesUnrenoteRequest? request) =>
+  _i18.Future<void> unrenote(_i5.NotesUnrenoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #unrenote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyNotesFavorites].
@@ -4509,26 +4521,26 @@ class MockMisskeyNotes extends _i1.Mock implements _i5.MisskeyNotes {
 class MockMisskeyNotesFavorites extends _i1.Mock
     implements _i5.MisskeyNotesFavorites {
   @override
-  _i17.Future<void> create(_i5.NotesFavoritesCreateRequest? request) =>
+  _i18.Future<void> create(_i5.NotesFavoritesCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i5.NotesFavoritesDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.NotesFavoritesDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyNotesReactions].
@@ -4537,41 +4549,41 @@ class MockMisskeyNotesFavorites extends _i1.Mock
 class MockMisskeyNotesReactions extends _i1.Mock
     implements _i5.MisskeyNotesReactions {
   @override
-  _i17.Future<void> create(_i5.NotesReactionsCreateRequest? request) =>
+  _i18.Future<void> create(_i5.NotesReactionsCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i5.NotesReactionsDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.NotesReactionsDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.NotesReactionsResponse>> reactions(
+  _i18.Future<Iterable<_i5.NotesReactionsResponse>> reactions(
           _i5.NotesReactionsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #reactions,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.NotesReactionsResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.NotesReactionsResponse>>.value(
             <_i5.NotesReactionsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.NotesReactionsResponse>>.value(
+            _i18.Future<Iterable<_i5.NotesReactionsResponse>>.value(
                 <_i5.NotesReactionsResponse>[]),
-      ) as _i17.Future<Iterable<_i5.NotesReactionsResponse>>);
+      ) as _i18.Future<Iterable<_i5.NotesReactionsResponse>>);
 }
 
 /// A class which mocks [MisskeyNotesPolls].
@@ -4579,28 +4591,28 @@ class MockMisskeyNotesReactions extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyNotesPolls extends _i1.Mock implements _i5.MisskeyNotesPolls {
   @override
-  _i17.Future<void> vote(_i5.NotesPollsVoteRequest? request) =>
+  _i18.Future<void> vote(_i5.NotesPollsVoteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #vote,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> recommendation(
+  _i18.Future<Iterable<_i5.Note>> recommendation(
           _i5.NotesPollsRecommendationRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #recommendation,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 }
 
 /// A class which mocks [MisskeyRenoteMute].
@@ -4608,26 +4620,26 @@ class MockMisskeyNotesPolls extends _i1.Mock implements _i5.MisskeyNotesPolls {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyRenoteMute extends _i1.Mock implements _i5.MisskeyRenoteMute {
   @override
-  _i17.Future<void> create(_i5.RenoteMuteCreateRequest? request) =>
+  _i18.Future<void> create(_i5.RenoteMuteCreateRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> delete(_i5.RenoteMuteDeleteRequest? request) =>
+  _i18.Future<void> delete(_i5.RenoteMuteDeleteRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #delete,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [MisskeyRoles].
@@ -4635,42 +4647,42 @@ class MockMisskeyRenoteMute extends _i1.Mock implements _i5.MisskeyRenoteMute {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyRoles extends _i1.Mock implements _i5.MisskeyRoles {
   @override
-  _i17.Future<Iterable<_i5.RolesListResponse>> list() => (super.noSuchMethod(
+  _i18.Future<Iterable<_i5.RolesListResponse>> list() => (super.noSuchMethod(
         Invocation.method(
           #list,
           [],
         ),
-        returnValue: _i17.Future<Iterable<_i5.RolesListResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.RolesListResponse>>.value(
             <_i5.RolesListResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.RolesListResponse>>.value(
+            _i18.Future<Iterable<_i5.RolesListResponse>>.value(
                 <_i5.RolesListResponse>[]),
-      ) as _i17.Future<Iterable<_i5.RolesListResponse>>);
+      ) as _i18.Future<Iterable<_i5.RolesListResponse>>);
 
   @override
-  _i17.Future<Iterable<_i5.RolesUsersResponse>> users(
+  _i18.Future<Iterable<_i5.RolesUsersResponse>> users(
           _i5.RolesUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.RolesUsersResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.RolesUsersResponse>>.value(
             <_i5.RolesUsersResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.RolesUsersResponse>>.value(
+            _i18.Future<Iterable<_i5.RolesUsersResponse>>.value(
                 <_i5.RolesUsersResponse>[]),
-      ) as _i17.Future<Iterable<_i5.RolesUsersResponse>>);
+      ) as _i18.Future<Iterable<_i5.RolesUsersResponse>>);
 
   @override
-  _i17.Future<_i5.RolesListResponse> show(_i5.RolesShowRequest? request) =>
+  _i18.Future<_i5.RolesListResponse> show(_i5.RolesShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i5.RolesListResponse>.value(_FakeRolesListResponse_51(
+            _i18.Future<_i5.RolesListResponse>.value(_FakeRolesListResponse_51(
           this,
           Invocation.method(
             #show,
@@ -4678,26 +4690,26 @@ class MockMisskeyRoles extends _i1.Mock implements _i5.MisskeyRoles {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.RolesListResponse>.value(_FakeRolesListResponse_51(
+            _i18.Future<_i5.RolesListResponse>.value(_FakeRolesListResponse_51(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.RolesListResponse>);
+      ) as _i18.Future<_i5.RolesListResponse>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> notes(_i5.RolesNotesRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> notes(_i5.RolesNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 }
 
 /// A class which mocks [MisskeyUsers].
@@ -4718,14 +4730,14 @@ class MockMisskeyUsers extends _i1.Mock implements _i5.MisskeyUsers {
       ) as _i5.MisskeyUsersLists);
 
   @override
-  _i17.Future<_i5.UsersShowResponse> show(_i5.UsersShowRequest? request) =>
+  _i18.Future<_i5.UsersShowResponse> show(_i5.UsersShowRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
           [request],
         ),
         returnValue:
-            _i17.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
+            _i18.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
           this,
           Invocation.method(
             #show,
@@ -4733,32 +4745,32 @@ class MockMisskeyUsers extends _i1.Mock implements _i5.MisskeyUsers {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
+            _i18.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
           this,
           Invocation.method(
             #show,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.UsersShowResponse>);
+      ) as _i18.Future<_i5.UsersShowResponse>);
 
   @override
-  _i17.Future<Iterable<_i5.UsersShowResponse>> showByIds(
+  _i18.Future<Iterable<_i5.UsersShowResponse>> showByIds(
           _i5.UsersShowByIdsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #showByIds,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.UsersShowResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.UsersShowResponse>>.value(
             <_i5.UsersShowResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.UsersShowResponse>>.value(
+            _i18.Future<Iterable<_i5.UsersShowResponse>>.value(
                 <_i5.UsersShowResponse>[]),
-      ) as _i17.Future<Iterable<_i5.UsersShowResponse>>);
+      ) as _i18.Future<Iterable<_i5.UsersShowResponse>>);
 
   @override
-  _i17.Future<_i5.UsersShowResponse> showByName(
+  _i18.Future<_i5.UsersShowResponse> showByName(
           _i5.UsersShowByUserNameRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4766,7 +4778,7 @@ class MockMisskeyUsers extends _i1.Mock implements _i5.MisskeyUsers {
           [request],
         ),
         returnValue:
-            _i17.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
+            _i18.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
           this,
           Invocation.method(
             #showByName,
@@ -4774,41 +4786,41 @@ class MockMisskeyUsers extends _i1.Mock implements _i5.MisskeyUsers {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
+            _i18.Future<_i5.UsersShowResponse>.value(_FakeUsersShowResponse_53(
           this,
           Invocation.method(
             #showByName,
             [request],
           ),
         )),
-      ) as _i17.Future<_i5.UsersShowResponse>);
+      ) as _i18.Future<_i5.UsersShowResponse>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> notes(_i5.UsersNotesRequest? request) =>
+  _i18.Future<Iterable<_i5.Note>> notes(_i5.UsersNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Clip>> clips(_i5.UsersClipsRequest? request) =>
+  _i18.Future<Iterable<_i5.Clip>> clips(_i5.UsersClipsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #clips,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+        returnValue: _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
-      ) as _i17.Future<Iterable<_i5.Clip>>);
+            _i18.Future<Iterable<_i5.Clip>>.value(<_i5.Clip>[]),
+      ) as _i18.Future<Iterable<_i5.Clip>>);
 
   @override
-  _i17.Future<Iterable<_i5.Following>> followers(
+  _i18.Future<Iterable<_i5.Following>> followers(
           _i5.UsersFollowersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4816,13 +4828,13 @@ class MockMisskeyUsers extends _i1.Mock implements _i5.MisskeyUsers {
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
+            _i18.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
-      ) as _i17.Future<Iterable<_i5.Following>>);
+            _i18.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
+      ) as _i18.Future<Iterable<_i5.Following>>);
 
   @override
-  _i17.Future<Iterable<_i5.Following>> following(
+  _i18.Future<Iterable<_i5.Following>> following(
           _i5.UsersFollowingRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4830,121 +4842,121 @@ class MockMisskeyUsers extends _i1.Mock implements _i5.MisskeyUsers {
           [request],
         ),
         returnValue:
-            _i17.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
+            _i18.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
-      ) as _i17.Future<Iterable<_i5.Following>>);
+            _i18.Future<Iterable<_i5.Following>>.value(<_i5.Following>[]),
+      ) as _i18.Future<Iterable<_i5.Following>>);
 
   @override
-  _i17.Future<void> reportAbuse(_i5.UsersReportAbuseRequest? request) =>
+  _i18.Future<void> reportAbuse(_i5.UsersReportAbuseRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #reportAbuse,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.UsersReactionsResponse>> reactions(
+  _i18.Future<Iterable<_i5.UsersReactionsResponse>> reactions(
           _i5.UsersReactionsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #reactions,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.UsersReactionsResponse>>.value(
+        returnValue: _i18.Future<Iterable<_i5.UsersReactionsResponse>>.value(
             <_i5.UsersReactionsResponse>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.UsersReactionsResponse>>.value(
+            _i18.Future<Iterable<_i5.UsersReactionsResponse>>.value(
                 <_i5.UsersReactionsResponse>[]),
-      ) as _i17.Future<Iterable<_i5.UsersReactionsResponse>>);
+      ) as _i18.Future<Iterable<_i5.UsersReactionsResponse>>);
 
   @override
-  _i17.Future<Iterable<_i5.User>> search(_i5.UsersSearchRequest? request) =>
+  _i18.Future<Iterable<_i5.User>> search(_i5.UsersSearchRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #search,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+        returnValue: _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
-      ) as _i17.Future<Iterable<_i5.User>>);
+            _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i18.Future<Iterable<_i5.User>>);
 
   @override
-  _i17.Future<Iterable<_i5.User>> recommendation(
+  _i18.Future<Iterable<_i5.User>> recommendation(
           _i5.UsersRecommendationRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #recommendation,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+        returnValue: _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
-      ) as _i17.Future<Iterable<_i5.User>>);
+            _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i18.Future<Iterable<_i5.User>>);
 
   @override
-  _i17.Future<Iterable<_i5.User>> users(_i5.UsersUsersRequest? request) =>
+  _i18.Future<Iterable<_i5.User>> users(_i5.UsersUsersRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #users,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+        returnValue: _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
-      ) as _i17.Future<Iterable<_i5.User>>);
+            _i18.Future<Iterable<_i5.User>>.value(<_i5.User>[]),
+      ) as _i18.Future<Iterable<_i5.User>>);
 
   @override
-  _i17.Future<void> updateMemo(_i5.UsersUpdateMemoRequest? request) =>
+  _i18.Future<void> updateMemo(_i5.UsersUpdateMemoRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateMemo,
           [request],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Iterable<_i5.Flash>> flashs(_i5.UsersFlashsRequest? request) =>
+  _i18.Future<Iterable<_i5.Flash>> flashs(_i5.UsersFlashsRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #flashs,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Flash>>.value(<_i5.Flash>[]),
+        returnValue: _i18.Future<Iterable<_i5.Flash>>.value(<_i5.Flash>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Flash>>.value(<_i5.Flash>[]),
-      ) as _i17.Future<Iterable<_i5.Flash>>);
+            _i18.Future<Iterable<_i5.Flash>>.value(<_i5.Flash>[]),
+      ) as _i18.Future<Iterable<_i5.Flash>>);
 
   @override
-  _i17.Future<Iterable<_i5.Note>> featuredNotes(
+  _i18.Future<Iterable<_i5.Note>> featuredNotes(
           _i5.UsersFeaturedNotesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #featuredNotes,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+        returnValue: _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
-      ) as _i17.Future<Iterable<_i5.Note>>);
+            _i18.Future<Iterable<_i5.Note>>.value(<_i5.Note>[]),
+      ) as _i18.Future<Iterable<_i5.Note>>);
 
   @override
-  _i17.Future<Iterable<_i5.Page>> pages(_i5.UsersPagesRequest? request) =>
+  _i18.Future<Iterable<_i5.Page>> pages(_i5.UsersPagesRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #pages,
           [request],
         ),
-        returnValue: _i17.Future<Iterable<_i5.Page>>.value(<_i5.Page>[]),
+        returnValue: _i18.Future<Iterable<_i5.Page>>.value(<_i5.Page>[]),
         returnValueForMissingStub:
-            _i17.Future<Iterable<_i5.Page>>.value(<_i5.Page>[]),
-      ) as _i17.Future<Iterable<_i5.Page>>);
+            _i18.Future<Iterable<_i5.Page>>.value(<_i5.Page>[]),
+      ) as _i18.Future<Iterable<_i5.Page>>);
 }
 
 /// A class which mocks [Dio].
@@ -5042,7 +5054,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
       );
 
   @override
-  _i17.Future<_i11.Response<T>> head<T>(
+  _i18.Future<_i11.Response<T>> head<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
@@ -5060,7 +5072,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #head,
@@ -5074,7 +5086,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #head,
@@ -5087,10 +5099,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> headUri<T>(
+  _i18.Future<_i11.Response<T>> headUri<T>(
     Uri? uri, {
     Object? data,
     _i11.Options? options,
@@ -5106,7 +5118,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #headUri,
@@ -5119,7 +5131,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #headUri,
@@ -5131,10 +5143,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> get<T>(
+  _i18.Future<_i11.Response<T>> get<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
@@ -5154,7 +5166,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #get,
@@ -5169,7 +5181,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #get,
@@ -5183,10 +5195,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> getUri<T>(
+  _i18.Future<_i11.Response<T>> getUri<T>(
     Uri? uri, {
     Object? data,
     _i11.Options? options,
@@ -5204,7 +5216,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #getUri,
@@ -5218,7 +5230,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #getUri,
@@ -5231,10 +5243,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> post<T>(
+  _i18.Future<_i11.Response<T>> post<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
@@ -5256,7 +5268,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #post,
@@ -5272,7 +5284,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #post,
@@ -5287,10 +5299,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> postUri<T>(
+  _i18.Future<_i11.Response<T>> postUri<T>(
     Uri? uri, {
     Object? data,
     _i11.Options? options,
@@ -5310,7 +5322,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #postUri,
@@ -5325,7 +5337,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #postUri,
@@ -5339,10 +5351,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> put<T>(
+  _i18.Future<_i11.Response<T>> put<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
@@ -5364,7 +5376,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #put,
@@ -5380,7 +5392,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #put,
@@ -5395,10 +5407,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> putUri<T>(
+  _i18.Future<_i11.Response<T>> putUri<T>(
     Uri? uri, {
     Object? data,
     _i11.Options? options,
@@ -5418,7 +5430,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #putUri,
@@ -5433,7 +5445,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #putUri,
@@ -5447,10 +5459,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> patch<T>(
+  _i18.Future<_i11.Response<T>> patch<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
@@ -5472,7 +5484,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #patch,
@@ -5488,7 +5500,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #patch,
@@ -5503,10 +5515,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> patchUri<T>(
+  _i18.Future<_i11.Response<T>> patchUri<T>(
     Uri? uri, {
     Object? data,
     _i11.Options? options,
@@ -5526,7 +5538,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #patchUri,
@@ -5541,7 +5553,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #patchUri,
@@ -5555,10 +5567,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> delete<T>(
+  _i18.Future<_i11.Response<T>> delete<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
@@ -5576,7 +5588,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #delete,
@@ -5590,7 +5602,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #delete,
@@ -5603,10 +5615,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> deleteUri<T>(
+  _i18.Future<_i11.Response<T>> deleteUri<T>(
     Uri? uri, {
     Object? data,
     _i11.Options? options,
@@ -5622,7 +5634,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #deleteUri,
@@ -5635,7 +5647,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #deleteUri,
@@ -5647,10 +5659,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<dynamic>> download(
+  _i18.Future<_i11.Response<dynamic>> download(
     String? urlPath,
     dynamic savePath, {
     _i11.ProgressCallback? onReceiveProgress,
@@ -5679,7 +5691,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           },
         ),
         returnValue:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
+            _i18.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
           this,
           Invocation.method(
             #download,
@@ -5699,7 +5711,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
+            _i18.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
           this,
           Invocation.method(
             #download,
@@ -5718,10 +5730,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<dynamic>>);
+      ) as _i18.Future<_i11.Response<dynamic>>);
 
   @override
-  _i17.Future<_i11.Response<dynamic>> downloadUri(
+  _i18.Future<_i11.Response<dynamic>> downloadUri(
     Uri? uri,
     dynamic savePath, {
     _i11.ProgressCallback? onReceiveProgress,
@@ -5748,7 +5760,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           },
         ),
         returnValue:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
+            _i18.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
           this,
           Invocation.method(
             #downloadUri,
@@ -5767,7 +5779,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
+            _i18.Future<_i11.Response<dynamic>>.value(_FakeResponse_58<dynamic>(
           this,
           Invocation.method(
             #downloadUri,
@@ -5785,10 +5797,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<dynamic>>);
+      ) as _i18.Future<_i11.Response<dynamic>>);
 
   @override
-  _i17.Future<_i11.Response<T>> request<T>(
+  _i18.Future<_i11.Response<T>> request<T>(
     String? url, {
     Object? data,
     Map<String, dynamic>? queryParameters,
@@ -5810,7 +5822,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #request,
@@ -5826,7 +5838,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #request,
@@ -5841,10 +5853,10 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> requestUri<T>(
+  _i18.Future<_i11.Response<T>> requestUri<T>(
     Uri? uri, {
     Object? data,
     _i11.CancelToken? cancelToken,
@@ -5864,7 +5876,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #requestUri,
@@ -5879,7 +5891,7 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #requestUri,
@@ -5893,16 +5905,16 @@ class MockDio extends _i1.Mock implements _i11.Dio {
             },
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 
   @override
-  _i17.Future<_i11.Response<T>> fetch<T>(_i11.RequestOptions? requestOptions) =>
+  _i18.Future<_i11.Response<T>> fetch<T>(_i11.RequestOptions? requestOptions) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetch,
           [requestOptions],
         ),
-        returnValue: _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+        returnValue: _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #fetch,
@@ -5910,14 +5922,14 @@ class MockDio extends _i1.Mock implements _i11.Dio {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
+            _i18.Future<_i11.Response<T>>.value(_FakeResponse_58<T>(
           this,
           Invocation.method(
             #fetch,
             [requestOptions],
           ),
         )),
-      ) as _i17.Future<_i11.Response<T>>);
+      ) as _i18.Future<_i11.Response<T>>);
 }
 
 /// A class which mocks [HttpClient].
@@ -5991,7 +6003,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
 
   @override
   set authenticate(
-          _i17.Future<bool> Function(
+          _i18.Future<bool> Function(
             Uri,
             String,
             String?,
@@ -6006,7 +6018,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
 
   @override
   set connectionFactory(
-          _i17.Future<_i12.ConnectionTask<_i12.Socket>> Function(
+          _i18.Future<_i12.ConnectionTask<_i12.Socket>> Function(
             Uri,
             String?,
             int?,
@@ -6030,7 +6042,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
 
   @override
   set authenticateProxy(
-          _i17.Future<bool> Function(
+          _i18.Future<bool> Function(
             String,
             int,
             String,
@@ -6069,7 +6081,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
       );
 
   @override
-  _i17.Future<_i12.HttpClientRequest> open(
+  _i18.Future<_i12.HttpClientRequest> open(
     String? method,
     String? host,
     int? port,
@@ -6086,7 +6098,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #open,
@@ -6099,7 +6111,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #open,
@@ -6111,10 +6123,10 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> openUrl(
+  _i18.Future<_i12.HttpClientRequest> openUrl(
     String? method,
     Uri? url,
   ) =>
@@ -6127,7 +6139,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #openUrl,
@@ -6138,7 +6150,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #openUrl,
@@ -6148,10 +6160,10 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> get(
+  _i18.Future<_i12.HttpClientRequest> get(
     String? host,
     int? port,
     String? path,
@@ -6166,7 +6178,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #get,
@@ -6178,7 +6190,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #get,
@@ -6189,16 +6201,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
+  _i18.Future<_i12.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #getUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #getUrl,
@@ -6206,17 +6218,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #getUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> post(
+  _i18.Future<_i12.HttpClientRequest> post(
     String? host,
     int? port,
     String? path,
@@ -6231,7 +6243,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #post,
@@ -6243,7 +6255,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #post,
@@ -6254,16 +6266,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
+  _i18.Future<_i12.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #postUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #postUrl,
@@ -6271,17 +6283,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #postUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> put(
+  _i18.Future<_i12.HttpClientRequest> put(
     String? host,
     int? port,
     String? path,
@@ -6296,7 +6308,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #put,
@@ -6308,7 +6320,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #put,
@@ -6319,16 +6331,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
+  _i18.Future<_i12.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #putUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #putUrl,
@@ -6336,17 +6348,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #putUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> delete(
+  _i18.Future<_i12.HttpClientRequest> delete(
     String? host,
     int? port,
     String? path,
@@ -6361,7 +6373,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #delete,
@@ -6373,7 +6385,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #delete,
@@ -6384,17 +6396,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> deleteUrl(Uri? url) =>
+  _i18.Future<_i12.HttpClientRequest> deleteUrl(Uri? url) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #deleteUrl,
@@ -6402,17 +6414,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #deleteUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> patch(
+  _i18.Future<_i12.HttpClientRequest> patch(
     String? host,
     int? port,
     String? path,
@@ -6427,7 +6439,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #patch,
@@ -6439,7 +6451,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #patch,
@@ -6450,16 +6462,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
+  _i18.Future<_i12.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #patchUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #patchUrl,
@@ -6467,17 +6479,17 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #patchUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> head(
+  _i18.Future<_i12.HttpClientRequest> head(
     String? host,
     int? port,
     String? path,
@@ -6492,7 +6504,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #head,
@@ -6504,7 +6516,7 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #head,
@@ -6515,16 +6527,16 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
             ],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
-  _i17.Future<_i12.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
+  _i18.Future<_i12.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #headUrl,
           [url],
         ),
         returnValue:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #headUrl,
@@ -6532,14 +6544,14 @@ class MockHttpClient extends _i1.Mock implements _i12.HttpClient {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
+            _i18.Future<_i12.HttpClientRequest>.value(_FakeHttpClientRequest_60(
           this,
           Invocation.method(
             #headUrl,
             [url],
           ),
         )),
-      ) as _i17.Future<_i12.HttpClientRequest>);
+      ) as _i18.Future<_i12.HttpClientRequest>);
 
   @override
   void addCredentials(
@@ -6610,22 +6622,22 @@ class MockSocketController extends _i1.Mock implements _i5.SocketController {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i26.dummyValue<String>(
+        returnValue: _i27.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i26.dummyValue<String>(
+        returnValueForMissingStub: _i27.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i28.Channel get channel => (super.noSuchMethod(
+  _i29.Channel get channel => (super.noSuchMethod(
         Invocation.getter(#channel),
-        returnValue: _i28.Channel.homeTimeline,
-        returnValueForMissingStub: _i28.Channel.homeTimeline,
-      ) as _i28.Channel);
+        returnValue: _i29.Channel.homeTimeline,
+        returnValueForMissingStub: _i29.Channel.homeTimeline,
+      ) as _i29.Channel);
 
   @override
   bool get isDisconnected => (super.noSuchMethod(
@@ -6642,6 +6654,19 @@ class MockSocketController extends _i1.Mock implements _i5.SocketController {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i13.WebSocketChannel get webSocketChannel => (super.noSuchMethod(
+        Invocation.getter(#webSocketChannel),
+        returnValue: _FakeWebSocketChannel_61(
+          this,
+          Invocation.getter(#webSocketChannel),
+        ),
+        returnValueForMissingStub: _FakeWebSocketChannel_61(
+          this,
+          Invocation.getter(#webSocketChannel),
+        ),
+      ) as _i13.WebSocketChannel);
 
   @override
   void connect() => super.noSuchMethod(
@@ -6671,27 +6696,27 @@ class MockSocketController extends _i1.Mock implements _i5.SocketController {
       );
 
   @override
-  _i17.Future<void> subNote(String? noteId) => (super.noSuchMethod(
+  _i18.Future<void> subNote(String? noteId) => (super.noSuchMethod(
         Invocation.method(
           #subNote,
           [noteId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> unsubNote(String? noteId) => (super.noSuchMethod(
+  _i18.Future<void> unsubNote(String? noteId) => (super.noSuchMethod(
         Invocation.method(
           #unsubNote,
           [noteId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> requestLog({
+  _i18.Future<void> requestLog({
     String? id,
     int? length,
   }) =>
@@ -6704,14 +6729,14 @@ class MockSocketController extends _i1.Mock implements _i5.SocketController {
             #length: length,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> send(
+  _i18.Future<void> send(
     _i5.StreamingRequestType? requestType,
-    _i29.StreamingRequestBody? body,
+    _i30.StreamingRequestBody? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6721,9 +6746,9 @@ class MockSocketController extends _i1.Mock implements _i5.SocketController {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [StreamingService].
@@ -6733,34 +6758,34 @@ class MockStreamingService extends _i1.Mock implements _i5.StreamingService {
   @override
   String get host => (super.noSuchMethod(
         Invocation.getter(#host),
-        returnValue: _i26.dummyValue<String>(
+        returnValue: _i27.dummyValue<String>(
           this,
           Invocation.getter(#host),
         ),
-        returnValueForMissingStub: _i26.dummyValue<String>(
+        returnValueForMissingStub: _i27.dummyValue<String>(
           this,
           Invocation.getter(#host),
         ),
       ) as String);
 
   @override
-  _i30.HashMap<String, _i5.SocketController> get streamingChannelControllers =>
+  _i31.HashMap<String, _i5.SocketController> get streamingChannelControllers =>
       (super.noSuchMethod(
         Invocation.getter(#streamingChannelControllers),
         returnValue:
-            _i26.dummyValue<_i30.HashMap<String, _i5.SocketController>>(
+            _i27.dummyValue<_i31.HashMap<String, _i5.SocketController>>(
           this,
           Invocation.getter(#streamingChannelControllers),
         ),
         returnValueForMissingStub:
-            _i26.dummyValue<_i30.HashMap<String, _i5.SocketController>>(
+            _i27.dummyValue<_i31.HashMap<String, _i5.SocketController>>(
           this,
           Invocation.getter(#streamingChannelControllers),
         ),
-      ) as _i30.HashMap<String, _i5.SocketController>);
+      ) as _i31.HashMap<String, _i5.SocketController>);
 
   @override
-  set subscription(_i17.StreamSubscription<dynamic>? _subscription) =>
+  set subscription(_i18.StreamSubscription<dynamic>? _subscription) =>
       super.noSuchMethod(
         Invocation.setter(
           #subscription,
@@ -6770,9 +6795,22 @@ class MockStreamingService extends _i1.Mock implements _i5.StreamingService {
       );
 
   @override
-  _i17.Future<void> onChannelEventReceived(
+  _i13.WebSocketChannel get webSocketChannel => (super.noSuchMethod(
+        Invocation.getter(#webSocketChannel),
+        returnValue: _FakeWebSocketChannel_61(
+          this,
+          Invocation.getter(#webSocketChannel),
+        ),
+        returnValueForMissingStub: _FakeWebSocketChannel_61(
+          this,
+          Invocation.getter(#webSocketChannel),
+        ),
+      ) as _i13.WebSocketChannel);
+
+  @override
+  _i18.Future<void> onChannelEventReceived(
     String? id,
-    _i31.ChannelEventType? type,
+    _i32.ChannelEventType? type,
     dynamic body,
   ) =>
       (super.noSuchMethod(
@@ -6784,14 +6822,14 @@ class MockStreamingService extends _i1.Mock implements _i5.StreamingService {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> onNoteUpdatedEventReceived(
+  _i18.Future<void> onNoteUpdatedEventReceived(
     String? id,
-    _i32.NoteUpdatedEventType? type,
+    _i33.NoteUpdatedEventType? type,
     Map<String, dynamic>? body,
   ) =>
       (super.noSuchMethod(
@@ -6803,13 +6841,13 @@ class MockStreamingService extends _i1.Mock implements _i5.StreamingService {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> onBroadcastEventReceived(
-    _i33.BroadcastEventType? type,
+  _i18.Future<void> onBroadcastEventReceived(
+    _i34.BroadcastEventType? type,
     Map<String, dynamic>? body,
   ) =>
       (super.noSuchMethod(
@@ -6820,35 +6858,35 @@ class MockStreamingService extends _i1.Mock implements _i5.StreamingService {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> startStreaming() => (super.noSuchMethod(
+  _i18.Future<void> startStreaming() => (super.noSuchMethod(
         Invocation.method(
           #startStreaming,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   _i5.SocketController connect({
     String? id,
-    required _i28.Channel? channel,
-    _i17.Future<void> Function(
-      _i31.ChannelEventType,
+    required _i29.Channel? channel,
+    _i18.Future<void> Function(
+      _i32.ChannelEventType,
       dynamic,
     )? onChannelEventReceived,
-    _i17.Future<void> Function(
+    _i18.Future<void> Function(
       String,
-      _i32.NoteUpdatedEventType,
+      _i33.NoteUpdatedEventType,
       Map<String, dynamic>,
     )? onNoteUpdatedEventReceived,
-    _i17.Future<void> Function(
-      _i33.BroadcastEventType,
+    _i18.Future<void> Function(
+      _i34.BroadcastEventType,
       Map<String, dynamic>,
     )? onBroadcastEventReceived,
     Map<String, dynamic>? parameters,
@@ -6899,38 +6937,38 @@ class MockStreamingService extends _i1.Mock implements _i5.StreamingService {
       ) as _i5.SocketController);
 
   @override
-  _i17.Future<void> close() => (super.noSuchMethod(
+  _i18.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> restart() => (super.noSuchMethod(
+  _i18.Future<void> restart() => (super.noSuchMethod(
         Invocation.method(
           #restart,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [FakeFilePickerPlatform].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFilePickerPlatform extends _i1.Mock
-    implements _i34.FakeFilePickerPlatform {
+    implements _i35.FakeFilePickerPlatform {
   @override
-  _i17.Future<_i35.FilePickerResult?> pickFiles({
+  _i18.Future<_i36.FilePickerResult?> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
-    _i35.FileType? type = _i35.FileType.any,
+    _i36.FileType? type = _i36.FileType.any,
     List<String>? allowedExtensions,
-    dynamic Function(_i35.FilePickerStatus)? onFileLoading,
+    dynamic Function(_i36.FilePickerStatus)? onFileLoading,
     bool? allowCompression = true,
     bool? allowMultiple = false,
     bool? withData = false,
@@ -6954,22 +6992,22 @@ class MockFilePickerPlatform extends _i1.Mock
             #lockParentWindow: lockParentWindow,
           },
         ),
-        returnValue: _i17.Future<_i35.FilePickerResult?>.value(),
-        returnValueForMissingStub: _i17.Future<_i35.FilePickerResult?>.value(),
-      ) as _i17.Future<_i35.FilePickerResult?>);
+        returnValue: _i18.Future<_i36.FilePickerResult?>.value(),
+        returnValueForMissingStub: _i18.Future<_i36.FilePickerResult?>.value(),
+      ) as _i18.Future<_i36.FilePickerResult?>);
 
   @override
-  _i17.Future<bool?> clearTemporaryFiles() => (super.noSuchMethod(
+  _i18.Future<bool?> clearTemporaryFiles() => (super.noSuchMethod(
         Invocation.method(
           #clearTemporaryFiles,
           [],
         ),
-        returnValue: _i17.Future<bool?>.value(),
-        returnValueForMissingStub: _i17.Future<bool?>.value(),
-      ) as _i17.Future<bool?>);
+        returnValue: _i18.Future<bool?>.value(),
+        returnValueForMissingStub: _i18.Future<bool?>.value(),
+      ) as _i18.Future<bool?>);
 
   @override
-  _i17.Future<String?> getDirectoryPath({
+  _i18.Future<String?> getDirectoryPath({
     String? dialogTitle,
     bool? lockParentWindow = false,
     String? initialDirectory,
@@ -6984,16 +7022,16 @@ class MockFilePickerPlatform extends _i1.Mock
             #initialDirectory: initialDirectory,
           },
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
-  _i17.Future<String?> saveFile({
+  _i18.Future<String?> saveFile({
     String? dialogTitle,
     String? fileName,
     String? initialDirectory,
-    _i35.FileType? type = _i35.FileType.any,
+    _i36.FileType? type = _i36.FileType.any,
     List<String>? allowedExtensions,
     bool? lockParentWindow = false,
   }) =>
@@ -7010,18 +7048,18 @@ class MockFilePickerPlatform extends _i1.Mock
             #lockParentWindow: lockParentWindow,
           },
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 }
 
 /// A class which mocks [$MockBaseCacheManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockBaseCacheManager extends _i1.Mock
-    implements _i34.$MockBaseCacheManager {
+    implements _i35.$MockBaseCacheManager {
   @override
-  _i17.Future<_i13.File> getSingleFile(
+  _i18.Future<_i14.File> getSingleFile(
     String? url, {
     String? key,
     Map<String, String>? headers,
@@ -7035,7 +7073,7 @@ class MockBaseCacheManager extends _i1.Mock
             #headers: headers,
           },
         ),
-        returnValue: _i17.Future<_i13.File>.value(_FakeFile_61(
+        returnValue: _i18.Future<_i14.File>.value(_FakeFile_62(
           this,
           Invocation.method(
             #getSingleFile,
@@ -7046,7 +7084,7 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i13.File>.value(_FakeFile_61(
+        returnValueForMissingStub: _i18.Future<_i14.File>.value(_FakeFile_62(
           this,
           Invocation.method(
             #getSingleFile,
@@ -7057,10 +7095,10 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i13.File>);
+      ) as _i18.Future<_i14.File>);
 
   @override
-  _i17.Stream<_i14.FileInfo> getFile(
+  _i18.Stream<_i15.FileInfo> getFile(
     String? url, {
     String? key,
     Map<String, String>? headers,
@@ -7074,12 +7112,12 @@ class MockBaseCacheManager extends _i1.Mock
             #headers: headers,
           },
         ),
-        returnValue: _i17.Stream<_i14.FileInfo>.empty(),
-        returnValueForMissingStub: _i17.Stream<_i14.FileInfo>.empty(),
-      ) as _i17.Stream<_i14.FileInfo>);
+        returnValue: _i18.Stream<_i15.FileInfo>.empty(),
+        returnValueForMissingStub: _i18.Stream<_i15.FileInfo>.empty(),
+      ) as _i18.Stream<_i15.FileInfo>);
 
   @override
-  _i17.Stream<_i14.FileResponse> getFileStream(
+  _i18.Stream<_i15.FileResponse> getFileStream(
     String? url, {
     String? key,
     Map<String, String>? headers,
@@ -7095,12 +7133,12 @@ class MockBaseCacheManager extends _i1.Mock
             #withProgress: withProgress,
           },
         ),
-        returnValue: _i17.Stream<_i14.FileResponse>.empty(),
-        returnValueForMissingStub: _i17.Stream<_i14.FileResponse>.empty(),
-      ) as _i17.Stream<_i14.FileResponse>);
+        returnValue: _i18.Stream<_i15.FileResponse>.empty(),
+        returnValueForMissingStub: _i18.Stream<_i15.FileResponse>.empty(),
+      ) as _i18.Stream<_i15.FileResponse>);
 
   @override
-  _i17.Future<_i14.FileInfo> downloadFile(
+  _i18.Future<_i15.FileInfo> downloadFile(
     String? url, {
     String? key,
     Map<String, String>? authHeaders,
@@ -7116,7 +7154,7 @@ class MockBaseCacheManager extends _i1.Mock
             #force: force,
           },
         ),
-        returnValue: _i17.Future<_i14.FileInfo>.value(_FakeFileInfo_62(
+        returnValue: _i18.Future<_i15.FileInfo>.value(_FakeFileInfo_63(
           this,
           Invocation.method(
             #downloadFile,
@@ -7129,7 +7167,7 @@ class MockBaseCacheManager extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i14.FileInfo>.value(_FakeFileInfo_62(
+            _i18.Future<_i15.FileInfo>.value(_FakeFileInfo_63(
           this,
           Invocation.method(
             #downloadFile,
@@ -7141,10 +7179,10 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i14.FileInfo>);
+      ) as _i18.Future<_i15.FileInfo>);
 
   @override
-  _i17.Future<_i14.FileInfo?> getFileFromCache(
+  _i18.Future<_i15.FileInfo?> getFileFromCache(
     String? key, {
     bool? ignoreMemCache = false,
   }) =>
@@ -7154,25 +7192,25 @@ class MockBaseCacheManager extends _i1.Mock
           [key],
           {#ignoreMemCache: ignoreMemCache},
         ),
-        returnValue: _i17.Future<_i14.FileInfo?>.value(),
-        returnValueForMissingStub: _i17.Future<_i14.FileInfo?>.value(),
-      ) as _i17.Future<_i14.FileInfo?>);
+        returnValue: _i18.Future<_i15.FileInfo?>.value(),
+        returnValueForMissingStub: _i18.Future<_i15.FileInfo?>.value(),
+      ) as _i18.Future<_i15.FileInfo?>);
 
   @override
-  _i17.Future<_i14.FileInfo?> getFileFromMemory(String? key) =>
+  _i18.Future<_i15.FileInfo?> getFileFromMemory(String? key) =>
       (super.noSuchMethod(
         Invocation.method(
           #getFileFromMemory,
           [key],
         ),
-        returnValue: _i17.Future<_i14.FileInfo?>.value(),
-        returnValueForMissingStub: _i17.Future<_i14.FileInfo?>.value(),
-      ) as _i17.Future<_i14.FileInfo?>);
+        returnValue: _i18.Future<_i15.FileInfo?>.value(),
+        returnValueForMissingStub: _i18.Future<_i15.FileInfo?>.value(),
+      ) as _i18.Future<_i15.FileInfo?>);
 
   @override
-  _i17.Future<_i13.File> putFile(
+  _i18.Future<_i14.File> putFile(
     String? url,
-    _i27.Uint8List? fileBytes, {
+    _i28.Uint8List? fileBytes, {
     String? key,
     String? eTag,
     Duration? maxAge = const Duration(days: 30),
@@ -7192,7 +7230,7 @@ class MockBaseCacheManager extends _i1.Mock
             #fileExtension: fileExtension,
           },
         ),
-        returnValue: _i17.Future<_i13.File>.value(_FakeFile_61(
+        returnValue: _i18.Future<_i14.File>.value(_FakeFile_62(
           this,
           Invocation.method(
             #putFile,
@@ -7208,7 +7246,7 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i13.File>.value(_FakeFile_61(
+        returnValueForMissingStub: _i18.Future<_i14.File>.value(_FakeFile_62(
           this,
           Invocation.method(
             #putFile,
@@ -7224,12 +7262,12 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i13.File>);
+      ) as _i18.Future<_i14.File>);
 
   @override
-  _i17.Future<_i13.File> putFileStream(
+  _i18.Future<_i14.File> putFileStream(
     String? url,
-    _i17.Stream<List<int>>? source, {
+    _i18.Stream<List<int>>? source, {
     String? key,
     String? eTag,
     Duration? maxAge = const Duration(days: 30),
@@ -7249,7 +7287,7 @@ class MockBaseCacheManager extends _i1.Mock
             #fileExtension: fileExtension,
           },
         ),
-        returnValue: _i17.Future<_i13.File>.value(_FakeFile_61(
+        returnValue: _i18.Future<_i14.File>.value(_FakeFile_62(
           this,
           Invocation.method(
             #putFileStream,
@@ -7265,7 +7303,7 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i13.File>.value(_FakeFile_61(
+        returnValueForMissingStub: _i18.Future<_i14.File>.value(_FakeFile_62(
           this,
           Invocation.method(
             #putFileStream,
@@ -7281,56 +7319,56 @@ class MockBaseCacheManager extends _i1.Mock
             },
           ),
         )),
-      ) as _i17.Future<_i13.File>);
+      ) as _i18.Future<_i14.File>);
 
   @override
-  _i17.Future<void> removeFile(String? key) => (super.noSuchMethod(
+  _i18.Future<void> removeFile(String? key) => (super.noSuchMethod(
         Invocation.method(
           #removeFile,
           [key],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> emptyCache() => (super.noSuchMethod(
+  _i18.Future<void> emptyCache() => (super.noSuchMethod(
         Invocation.method(
           #emptyCache,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> dispose() => (super.noSuchMethod(
+  _i18.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [$MockUrlLauncherPlatform].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockUrlLauncherPlatform extends _i1.Mock
-    implements _i34.$MockUrlLauncherPlatform {
+    implements _i35.$MockUrlLauncherPlatform {
   @override
-  _i17.Future<bool> canLaunch(String? url) => (super.noSuchMethod(
+  _i18.Future<bool> canLaunch(String? url) => (super.noSuchMethod(
         Invocation.method(
           #canLaunch,
           [url],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> launch(
+  _i18.Future<bool> launch(
     String? url, {
     required bool? useSafariVC,
     required bool? useWebView,
@@ -7354,14 +7392,14 @@ class MockUrlLauncherPlatform extends _i1.Mock
             #webOnlyWindowName: webOnlyWindowName,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> launchUrl(
+  _i18.Future<bool> launchUrl(
     String? url,
-    _i36.LaunchOptions? options,
+    _i37.LaunchOptions? options,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7371,39 +7409,39 @@ class MockUrlLauncherPlatform extends _i1.Mock
             options,
           ],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> closeWebView() => (super.noSuchMethod(
+  _i18.Future<void> closeWebView() => (super.noSuchMethod(
         Invocation.method(
           #closeWebView,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<bool> supportsMode(_i36.PreferredLaunchMode? mode) =>
+  _i18.Future<bool> supportsMode(_i37.PreferredLaunchMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #supportsMode,
           [mode],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> supportsCloseForMode(_i36.PreferredLaunchMode? mode) =>
+  _i18.Future<bool> supportsCloseForMode(_i37.PreferredLaunchMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #supportsCloseForMode,
           [mode],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 }


### PR DESCRIPTION
ユーザーのアバターを非表示にするオプションを追加しました

- 有効にすると、ノート詳細ページ以外のノートではアバターが表示されないようになります
- ユーザーの名前とユーザーネームをタップしたときにユーザーページに遷移するようにしました

Resolve #428