### PR TITLE
動画再生後にバックグラウンドの音楽が止まるようになる不具合の修正

### DIFF
--- a/lib/view/common/misskey_notes/video_dialog.dart
+++ b/lib/view/common/misskey_notes/video_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:volume_controller/volume_controller.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
@@ -34,6 +35,7 @@ class _VideoDialogState extends State<VideoDialog> {
   @override
   void dispose() {
     player.dispose();
+    VolumeController().removeListener();
     super.dispose();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1607,7 +1607,7 @@ packages:
     source: hosted
     version: "0.4.0+2"
   volume_controller:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: volume_controller
       sha256: "189bdc7a554f476b412e4c8b2f474562b09d74bc458c23667356bce3ca1d48c9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   media_kit_video: ^1.2.1
   media_kit_libs_video: ^1.0.3
   flutter_colorpicker: ^1.0.3
+  volume_controller: ^2.0.7
 
 dependency_overrides:
   image_editor:


### PR DESCRIPTION
Fix #525

ライブラリ側でNotificationCenterの登録解除がされていないことが原因で
アプリがアクティブになるたびに、AVAudioSessionのSetActiveが呼ばれていたため
バックグラウンドの音楽が止まってしまうようでしたので
dispose時に登録解除するように修正しました。