### PR TITLE
アカウント情報でのスクロールパフォーマンスの改善

### DIFF
--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -535,12 +535,15 @@ class UserDetailState extends ConsumerState<UserDetail> {
                 const Padding(padding: EdgeInsets.only(top: 20))
                 ]))),
         if (response.pinnedNotes != null)
-          SliverList.builder(
-            itemCount: response.pinnedNotes!.length,
-            itemBuilder: (context, index) => 
-              MisskeyNote(
-                note: response.pinnedNotes![index],
-                loginAs: widget.controlAccount))
+          SliverPadding(
+            padding: const EdgeInsets.only(right: 10),
+            sliver: SliverList.builder(
+              itemCount: response.pinnedNotes!.length,
+              itemBuilder: (context, index) => 
+                MisskeyNote(
+                  note: response.pinnedNotes![index],
+                  loginAs: widget.controlAccount)
+            ))
       ]);
   }
 }

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -519,36 +519,29 @@ class UserDetailState extends ConsumerState<UserDetail> {
 
   @override
   Widget build(BuildContext context) {
-    return BirthdayConfetti(
-      response: widget.response,
-      child: Column(
-        children: [
-          if (response.bannerUrl != null)
-            Image.network(response.bannerUrl.toString()),
-          Align(
-            alignment: Alignment.center,
-            child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 800),
-                child: buildContent()),
-          ),
-          const Padding(padding: EdgeInsets.only(top: 20)),
-          Padding(
-            padding: const EdgeInsets.only(right: 10),
-            child: ListView(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              children: [
-                for (final note in response.pinnedNotes ?? [])
-                  MisskeyNote(
-                    note: note,
-                    loginAs: widget.controlAccount,
-                  ),
-              ],
-            ),
-          )
-        ],
-      ),
-    );
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+            child: BirthdayConfetti(
+              response: widget.response,
+              child:Column(children: [
+                if (response.bannerUrl != null)
+                  Image.network(response.bannerUrl.toString()),
+                Align(
+                    alignment: Alignment.center,
+                    child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 800),
+                        child: buildContent())),
+                const Padding(padding: EdgeInsets.only(top: 20))
+                ]))),
+        if (response.pinnedNotes != null)
+          SliverList.builder(
+            itemCount: response.pinnedNotes!.length,
+            itemBuilder: (context, index) => 
+              MisskeyNote(
+                note: response.pinnedNotes![index],
+                loginAs: widget.controlAccount))
+      ]);
   }
 }
 

--- a/lib/view/user_page/user_page.dart
+++ b/lib/view/user_page/user_page.dart
@@ -97,14 +97,12 @@ class UserPageState extends ConsumerState<UserPage> {
                       AccountScope(
                         account: Account.demoAccount(
                             userInfo!.response!.host!, userInfo.metaResponse!),
-                        child: SingleChildScrollView(
-                          child: UserDetail(
-                            response: userInfo.remoteResponse!,
-                            account: Account.demoAccount(
-                                userInfo.response!.host!,
-                                userInfo.metaResponse!),
-                            controlAccount: widget.account,
-                          ),
+                        child: UserDetail(
+                          response: userInfo.remoteResponse!,
+                          account: Account.demoAccount(
+                              userInfo.response!.host!,
+                              userInfo.metaResponse!),
+                          controlAccount: widget.account,
                         ),
                       ),
                     Padding(
@@ -259,12 +257,10 @@ class UserDetailTabState extends ConsumerState<UserDetailTab> {
   @override
   Widget build(BuildContext context) {
     if (response != null) {
-      return SingleChildScrollView(
-        child: UserDetail(
-          response: response!,
-          account: AccountScope.of(context),
-          controlAccount: null,
-        ),
+      return UserDetail(
+        response: response!,
+        account: AccountScope.of(context),
+        controlAccount: null,
       );
     }
     if (error != null) {

--- a/test/view/user_page/user_page_test.dart
+++ b/test/view/user_page/user_page_test.dart
@@ -532,7 +532,11 @@ void main() {
           ),
         ));
         await tester.pumpAndSettle();
-        await tester.ensureVisible(find.text("フォロー"));
+        await tester.dragUntilVisible(
+          find.text("フォロー"),
+          find.byType(CustomScrollView),
+          const Offset(0, -50));
+        await tester.pump();
         await tester.tap(find.text("フォロー"));
         await tester.pumpAndSettle();
 
@@ -571,7 +575,11 @@ void main() {
           ),
         ));
         await tester.pumpAndSettle();
-        await tester.ensureVisible(find.text("フォロワー"));
+        await tester.dragUntilVisible(
+          find.text("フォロワー"),
+          find.byType(CustomScrollView),
+          const Offset(0, -50));
+        await tester.pump();
         await tester.tap(find.text("フォロワー"));
         await tester.pumpAndSettle();
 


### PR DESCRIPTION
Androidの一部機種にて、アカウント情報(ピン留めノートが多いアカウントなど)を
開いた際に著しくスクロール時のfpsが低下していたのを改善しました