### PR TITLE
[Windows] MyWorkDirの設定

### DIFF
--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -38,7 +38,7 @@ jobs:
           curl -o D:\a\miria\miria\build\Korean.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Korean.isl
 
       - name: Compile .ISS to .EXE Installer
-        uses: Minionguyjpro/Inno-Setup-Action@v1.1.0
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.3
         with:
           path: windows/innosetup.iss
           options: /dMyAppVersion="${{ env.version }}"

--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -34,6 +34,9 @@ jobs:
         run: |
           flutter build windows --release
 
+      - run: |
+          curl -o D:\a\miria\miria\build\Korean.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Korean.isl
+
       - name: Compile .ISS to .EXE Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.1.0
         with:

--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Get App Version
         run:  |
           echo "version=$(flutter pub run cider version)" >> $env:GITHUB_ENV
+          echo "builddir=$(pwd)" >> $env:GITHUB_ENV
 
       - name: Build for Windows
         run: |
@@ -44,7 +45,7 @@ jobs:
         uses: Minionguyjpro/Inno-Setup-Action@v1.1.0
         with:
           path: windows/innosetup.iss
-          options: /dMyAppVersion="${{ env.version }}"
+          options: /dMyAppVersion="${{ env.version }}" /dMyWorkDir="${{ env.builddir }}"
 
       - name: Rename .EXE Installer
         run:  mv miria-installer.exe miria-installer_${env:version}_x64.exe

--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -36,7 +36,7 @@ jobs:
           flutter build windows --release
 
       - run: |
-          curl -o D:\a\miria\miria\build\Korean.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Korean.isl
+          curl -o ${{ env.builddir }}\Korean.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Korean.isl
 
       - name: Compile .ISS to .EXE Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.3

--- a/windows/innosetup.iss
+++ b/windows/innosetup.iss
@@ -35,7 +35,7 @@ UninstallDisplayIcon={app}\{#MyAppExeName}
 
 [Languages]
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
-Name: "korean"; MessagesFile: "compiler:Languages\Korean.isl"
+Name: "korean"; MessagesFile: "D:\a\miria\miria\build\Korean.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked

--- a/windows/innosetup.iss
+++ b/windows/innosetup.iss
@@ -4,6 +4,7 @@
 #define MyAppName "Miria"
 #define MyAppExeName "miria.exe"
 ;#define MyAppVersion "1.0.13+86"
+;#define MyWorkDir "D:\a\miria\miria"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -21,13 +22,13 @@ ArchitecturesInstallIn64BitMode=x64
 CloseApplications=yes
 DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
-LicenseFile=D:\a\miria\miria\LICENSE
+LicenseFile={#MyWorkDir}\LICENSE
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
-OutputDir=D:\a\miria\miria
+OutputDir={#MyWorkDir}
 OutputBaseFilename=miria-installer
-SetupIconFile=D:\a\miria\miria\windows\runner\resources\app_icon.ico
+SetupIconFile={#MyWorkDir}\windows\runner\resources\app_icon.ico
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
@@ -40,8 +41,8 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "D:\a\miria\miria\build\windows\x64\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "D:\a\miria\miria\build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#MyWorkDir}\build\windows\x64\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyWorkDir}\build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/windows/innosetup.iss
+++ b/windows/innosetup.iss
@@ -36,7 +36,7 @@ UninstallDisplayIcon={app}\{#MyAppExeName}
 
 [Languages]
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
-Name: "korean"; MessagesFile: "D:\a\miria\miria\build\Korean.isl"
+Name: "korean"; MessagesFile: "{#MyWorkDir}\Korean.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked


### PR DESCRIPTION
`innosetup.iss`で一部ディレクトリがGitHub Actions上のディレクトリを直接指定していたのを、ビルド時に`pwd`で取得するようにする小さな変更です（GitHub Actions外で少しだけ使いやすくするための予防的な変更です）。