### PR TITLE
[Windows] 韓国語をインストーラーに追加

### DIFF
--- a/windows/innosetup.iss
+++ b/windows/innosetup.iss
@@ -35,6 +35,7 @@ UninstallDisplayIcon={app}\{#MyAppExeName}
 
 [Languages]
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
+Name: "korean"; MessagesFile: "compiler:Languages\Korean.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked


### PR DESCRIPTION
#164 に合わせた、Windows用インストーラーの言語追加の一部です。

メモ: https://github.com/jrsoftware/issrc/tree/main/Files/Languages から言語ファイルがあることを確認（但しUnofficialは参照しない）し、`Name: "<language>"; MessagesFile: "compiler:\Languages\<Language>.isl"`を`windows/innosetup.iss`の`[Languages]`セクションに追加する。