### PR TITLE
SnackBarの表示時間を1秒に短縮

### DIFF
--- a/lib/view/common/image_dialog.dart
+++ b/lib/view/common/image_dialog.dart
@@ -189,7 +189,8 @@ class ImageDialogState extends ConsumerState<ImageDialog> {
                           await ImageGallerySaver.saveImage(response.data);
                           if (!mounted) return;
                           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                              content: Text(S.of(context).savedImage)));
+                              content: Text(S.of(context).savedImage),
+                              duration: const Duration(seconds: 1)));
                         },
                         constraints:
                             const BoxConstraints(minWidth: 0, minHeight: 0),

--- a/lib/view/common/misskey_notes/link_preview.dart
+++ b/lib/view/common/misskey_notes/link_preview.dart
@@ -195,7 +195,7 @@ class LinkPreviewTile extends ConsumerWidget {
         onLongPress: () {
           Clipboard.setData(ClipboardData(text: link));
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(S.of(context).doneCopy)),
+            SnackBar(content: Text(S.of(context).doneCopy),duration: const Duration(seconds: 1)),
           );
         },
         child: DecoratedBox(

--- a/lib/view/common/misskey_notes/note_modal_sheet.dart
+++ b/lib/view/common/misskey_notes/note_modal_sheet.dart
@@ -58,6 +58,9 @@ class NoteModalSheet extends ConsumerWidget {
           onTap: () {
             Clipboard.setData(ClipboardData(text: targetNote.text ?? ""));
             Navigator.of(context).pop();
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(S.of(context).doneCopy), duration: const Duration(seconds: 1)),
+            );
           },
         ),
         ListTile(
@@ -70,6 +73,9 @@ class NoteModalSheet extends ConsumerWidget {
               ),
             );
             Navigator.of(context).pop();
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(S.of(context).doneCopy), duration: const Duration(seconds: 1)),
+            );
           },
         ),
         ListTile(

--- a/lib/view/common/misskey_notes/renote_modal_sheet.dart
+++ b/lib/view/common/misskey_notes/renote_modal_sheet.dart
@@ -64,7 +64,7 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                     channelId: channel.id,
                   ));
               scaffoldMessenger
-                  .showSnackBar(SnackBar(content: Text(localize.renoted)));
+                  .showSnackBar(SnackBar(content: Text(localize.renoted), duration: const Duration(seconds: 1)));
               navigator.pop();
             }.expectFailure(context),
             title: Padding(
@@ -108,7 +108,7 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                     visibility: visibility,
                   ));
               scaffoldMessenger
-                  .showSnackBar(SnackBar(content: Text(localize.renoted)));
+                  .showSnackBar(SnackBar(content: Text(localize.renoted), duration: const Duration(seconds: 1)));
               navigator.pop();
             }.expectFailure(context),
             title: const Padding(
@@ -170,7 +170,7 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                       ));
 
                   scaffoldMessenger
-                      .showSnackBar(SnackBar(content: Text(localize.renoted)));
+                      .showSnackBar(SnackBar(content: Text(localize.renoted), duration: const Duration(seconds: 1)));
                   navigator.pop();
                 }
               }.expectFailure(context),

--- a/lib/view/several_account_settings_page/reaction_deck_page/reaction_deck_page.dart
+++ b/lib/view/several_account_settings_page/reaction_deck_page/reaction_deck_page.dart
@@ -222,7 +222,7 @@ class ReactionDeckPageState extends ConsumerState<ReactionDeckPage> {
       ),
     );
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(S.of(context).doneCopy)),
+      SnackBar(content: Text(S.of(context).doneCopy), duration: const Duration(seconds: 1)),
     );
   }
 

--- a/lib/view/user_page/user_control_dialog.dart
+++ b/lib/view/user_page/user_control_dialog.dart
@@ -147,7 +147,7 @@ class UserControlDialogState extends ConsumerState<UserControlDialog> {
               ),
             );
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(S.of(context).doneCopy)),
+              SnackBar(content: Text(S.of(context).doneCopy), duration: const Duration(seconds: 1)),
             );
             Navigator.of(context).pop();
           },
@@ -158,7 +158,7 @@ class UserControlDialogState extends ConsumerState<UserControlDialog> {
           onTap: () {
             Clipboard.setData(ClipboardData(text: widget.response.acct));
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(S.of(context).doneCopy)),
+              SnackBar(content: Text(S.of(context).doneCopy), duration: const Duration(seconds: 1)),
             );
             Navigator.of(context).pop();
           },
@@ -177,7 +177,7 @@ class UserControlDialogState extends ConsumerState<UserControlDialog> {
               ),
             );
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(S.of(context).doneCopy)),
+              SnackBar(content: Text(S.of(context).doneCopy), duration: const Duration(seconds: 1)),
             );
             Navigator.of(context).pop();
           },


### PR DESCRIPTION
Fix #549 
SnackBarの表示時間を4秒（デフォルト）から1秒に変更しました。
また、ノートのメニューから内容またはリンクをコピーしたときにSnackBarが表示されるように変更しました。