### PR TITLE
中国語(zh-CN)サポート

### DIFF
--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -35,8 +35,10 @@ jobs:
         run: |
           flutter build windows --release
 
-      - run: |
+      - name: Get translation files for Inno Setup
+        run: |
           curl -o ${{ env.builddir }}\Korean.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Korean.isl
+          curl -o ${{ env.builddir }}\ChineseSimplified.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl
 
       - name: Compile .ISS to .EXE Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.3

--- a/lib/l10n/app_zh-cn.arb
+++ b/lib/l10n/app_zh-cn.arb
@@ -1,0 +1,943 @@
+{
+    "announcement": "公告",
+    "antenna": "天线",
+    "user": "用户",
+    "channel": "频道",
+    "timeline": "时间线",
+    "sensitive": "敏感内容",
+    "favorite": "收藏",
+    "trend": "趋势",
+    "clip": "便签",
+    "edit": "编辑",
+    "create": "创建",
+    "delete": "删除",
+    "search": "搜索",
+    "detail": "详细",
+    "save": "保存",
+    "hide": "隐藏",
+    "note": "帖子",
+    "mention": "提及",
+    "renote": "转发",
+    "quotedRenote": "引用的转发",
+    "notification": "通知",
+    "list": "列表",
+    "explore": "发现",
+    "highlight": "高光",
+    "role": "角色",
+    "page": "页面",
+    "flash": "Play",
+    "hashtag": "标签",
+    "otherServers": "其他服务器",
+    "follow": "关注",
+    "following": "关注中",
+    "managing": "管理中",
+    "done": "完成",
+    "public": "公开",
+    "home": "首页",
+    "local": "本地",
+    "direct": "直接",
+    "onlyLocal": "仅本地",
+    "remote": "远程",
+    "@done": {
+        "description": "完成"
+    },
+    "software": "软件",
+    "federatedPosts": "投稿",
+    "language": "语言",
+    "administrator": "管理员",
+    "contact": "联系人",
+    "serverRules": "服务器规则",
+    "tos": "服务条款",
+    "privacyPolicy": "隐私政策",
+    "impressum": "运营商信息",
+    "willDelete": "将删除",
+    "cancel": "取消",
+    "noneAction": "什么也不做",
+    "pleaseInput": "请输入",
+    "pleaseSelect": "请选择",
+    "login": "登录",
+    "settings": "设置",
+    "ad": "广告",
+    "customEmoji": "自定义表情符号",
+    "localTimeline": "本地时间线",
+    "localTimelineAbbr": "LTL",
+    "homeTimeline": "主页时间线",
+    "homeTimelineAbbr": "HTL",
+    "socialTimeline": "社交时间线",
+    "socialTimelineAbbr": "STL",
+    "globalTimeline": "全球时间线",
+    "roleTimeline": "角色时间线",
+    "server": "服务器",
+    "miAuth": "MiAuth",
+    "apiKey": "API密钥",
+    "contentWarning": "标注",
+    "follower": "粉丝",
+    "antennaName": "天线名称",
+    "antennaSource": "接收来源",
+    "antennaSourceHome": "主页",
+    "antennaSourceAll": "全部",
+    "antennaSourceUser": "用户",
+    "antennaSourceList": "列表",
+    "selectAntennaSource": "选择源",
+    "selectList": "选择列表",
+    "antennaSourceUserHintText": "指定用户名，并用新行隔开",
+    "addUser": "添加用户",
+    "keywords": "关键字",
+    "antennaSourceKeywordsHintText": "用空格分隔的单词按 AND 条件处理，用换行符分隔的行按 OR 条件处理",
+    "excludeKeywords": "排除关键词",
+    "antennaSourceExcludeKeywordsHintText": "用空格分隔的单词按 AND 条件处理，用换行符分隔的行按 OR 条件处理",
+    "discriminateUpperLower": "区分大小写",
+    "receiveReplies": "接收回复",
+    "receiveOnlyFiles": "只接收附有文件的帖子",
+    "receiveLocal": "只接收本地",
+    "receiveLocalAvailability": "只指定本地对 Misskey 2023.10.2 及更高版本有效。",
+    "confirmDeletingAntenna": "要删除天线吗？",
+    "channelJoinningCounts": "{usersCount} 人加入",
+    "@channelJoinningCounts": {
+        "description": "频道加入人数",
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "channelNotes": "{notesCount}投稿",
+    "@channelNotes": {
+        "description": "频道帖子数",
+        "placeholders": {
+            "notesCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "channelLastNotedAt": "{lastNotedAt} 更新",
+    "@channelLastNotedAt": {
+        "description": "频道帖子数",
+        "placeholders": {
+            "lastNotedAt": {
+                "type": "String"
+            }
+        }
+    },
+    "favorited": "已加入收藏夹。",
+    "willFavorite": "添加到收藏夹",
+    "willFollow": "加关注",
+    "channelInformation": "频道信息",
+    "channelStatistics": "{notesCount} 投稿 / {usersCount} 人加入 / {lastNotedAt} 更新",
+    "@channelStatistics": {
+        "description": "频道统计信息",
+        "placeholders": {
+            "notesCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            },
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            },
+            "lastNotedAt": {
+                "type": "String"
+            }
+        }
+    },
+    "notImplemented": "准备中",
+    "createClip": "创建便签",
+    "confirmDeleteClip": "要删除这个便签吗？",
+    "clipName": "便签名称",
+    "clipDescription": "说明（可省略）",
+    "alreadyAddedClip": "它看起来像是已经添加到便签中的帖子",
+    "deleteClip": "从便签中删除",
+    "thanksForReport": "您的内容已发送。感谢您的举报。",
+    "reportAbuseOf": "举报 {name}",
+    "@reportAbuseOf": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "pleaseInputReasonWhyAbuse": "请输入举报原因的详细信息。如果您有具体帖子，请同时输入其 URL。",
+    "reportAbuse": "举报",
+    "closeTweet": "关闭推文",
+    "closePlayer": "关闭播放器",
+    "doneCopy": "复制了",
+    "mutedNotePlaceholder": "{userName} 说了些啥",
+    "@mutedNotePlaceholder": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "showCw": "看看剩下隐藏的",
+    "showReactionedNote": "展示更多",
+    "showLongText": "展示更多",
+    "showMoreFiles": "展示更多",
+    "otherReactions": "还有{reactionCounts}个",
+    "@otherReactions": {
+        "placeholders": {
+            "reactionCounts": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "confirmDeleteReaction": "要取消回应吗？",
+    "cancelReaction": "取消",
+    "renotedBy": "{user} 转发了",
+    "selfRenotedBy": "自转发了",
+    "savedImage": "图片已保存",
+    "tapToShow": "点击查看",
+    "copyContents": "复制内容",
+    "copyLinks": "复制链接",
+    "copyName": "复制用户名",
+    "copyUserScreenName": "复制用户屏幕名称",
+    "openBrowsers": "在浏览器中打开",
+    "openBrowsersAsRemote": "在浏览器中打开远程目标",
+    "openInAnotherAccount": "使用另一个账户打开",
+    "changeFullScreen": "切换到全屏",
+    "shareNotes": "分享帖子",
+    "deleteFavorite": "取消收藏",
+    "notesAfterRenote": "转发后的帖子",
+    "deletedRecreate": "删除并重新创建",
+    "confirmDeletedRecreate": "要删除这个帖子吗？回应、转发和回复消失且无法返回？",
+    "deleteRenote": "取消转发",
+    "confirmDelete": "真的要删除吗？",
+    "doDeleting": "删掉！",
+    "confirmPoll": "您想投票给{choiced}吗？",
+    "@confirmPoll": {
+        "placeholders": {
+            "choiced": {
+                "type": "String"
+            }
+        }
+    },
+    "votesCount": "({votes}票)",
+    "@votesCount": {
+        "placeholders": {
+            "votes": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "totalVotesCount": "共{votes}票・",
+    "@totalVotesCount": {
+        "placeholders": {
+            "votes": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "finished": "已结束",
+    "openResult": "查看结果",
+    "doVoting": "投票",
+    "alreadyVoted": "已投票",
+    "remainDiffer": "还有{differ}",
+    "@remainDiffer": {
+        "placeholders": {
+            "differ": {
+                "type": "String"
+            }
+        }
+    },
+    "renoted": "已转发。",
+    "renoteInSpecificChannel": "在{channelName}内转发",
+    "@renoteInSpecificChannel": {
+        "placeholders": {
+            "channelName": {
+                "type": "String"
+            }
+        }
+    },
+    "quotedRenoteInSpecificChannel": "在{channelName}中引用转发",
+    "@quotedRenoteInSpecificChannel": {
+        "placeholders": {
+            "channelName": {
+                "type": "String"
+            }
+        }
+    },
+    "renoteInChannel": "转发至频道",
+    "renoteInOtherChannel": "转发至另一个频道",
+    "quotedRenoteInChannel": "引用转发至频道",
+    "quotedRenoteInOtherChannel": "引用转发至另一个频道",
+    "renotedUsers": "转发的用户",
+    "otherComplementReactions": "其他的",
+    "openAsOtherAccount": "选择要打开的账户",
+    "pickColor": "选择颜色",
+    "decideColor": "就这个",
+    "accountSetting": "{accountName}的设置",
+    "@accountSetting": {
+        "placeholders": {
+            "accountName": {
+                "type": "String"
+            }
+        }
+    },
+    "chooseFile": "选择文件",
+    "uploadFile": "上传",
+    "fromDrive": "从网盘中",
+    "fileName": "文件名称",
+    "randomizeFileName": "随机化文件名",
+    "caption": "标题",
+    "sensitiveSubTitle": "即使您删除阅读警告设置，该页面也可能会自动标记为阅读警告。",
+    "replyNotePlaceholder": "发点什么？",
+    "defaultNotePlaceholder": "在干啥？",
+    "hasMediaButCannotEdit": "有媒体（无法编辑）",
+    "hasVoteButCannotEdit": "有投票（无法编辑）",
+    "followedNotification": "{userName}已关注",
+    "@followedNotification": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "followRequestAcceptedNotification": "{userName}同意了您的关注请求",
+    "@followRequestAcceptedNotification": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "receiveFollowRequestNotification": "{userName}希望您关注",
+    "@receiveFollowRequestNotification": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "achievementEarnedNotification": "成就已解锁",
+    "testNotification": "这是一个测试",
+    "renotedUsersInNotification": "转发的人",
+    "reactionUsersInNotification": "回应的人",
+    "finishedVotedNotification": "投票已经结束了",
+    "renoteAndReactionsNotification": "{reactionUser}回应了，{renotedUser}转发了",
+    "@renoteAndReactionsNotification": {
+        "placeholders": {
+            "reactionUser": {
+                "type": "String?"
+            },
+            "renotedUser": {
+                "type": "String?"
+            }
+        }
+    },
+    "renoteNotification": "{renoteUser}已转发",
+    "@renoteNotification": {
+        "placeholders": {
+            "renoteUser": {
+                "type": "String?"
+            }
+        }
+    },
+    "reactionNotification": "{reactionUser}已回应",
+    "@reactionNotification": {
+        "placeholders": {
+            "reactionUser": {
+                "type": "String?"
+            }
+        }
+    },
+    "notedNotification": "{notedUser}发了帖子",
+    "@notedNotification": {
+        "placeholders": {
+            "notedUser": {
+                "type": "String"
+            }
+        }
+    },
+    "roleAssignedNotification": "您已被分配至角色「{role}」",
+    "@roleAssignedNotification": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationAll": "所有人",
+    "notificationForMe": "给自己的",
+    "notificationDirect": "直接",
+    "editPhoto": "编辑图片",
+    "customEmojiLicensedBy": "该自定义表情符号的许可如下。",
+    "customEmojiLicensedByNone": "※尚未为此自定义表情符号设置许可证。",
+    "cancelEmojiChoosing": "取消表情符号选择",
+    "doneEmojiChoosing": "完成表情符号选择",
+    "confirmSavingPhoto": "保存吗？",
+    "doneEditingPhoto": "保存",
+    "continueEditingPhoto": "继续修改图片",
+    "disabledUsingSensitiveCustomEmoji": "此处无法使用敏感的自定义表情符号",
+    "markAsSensitive": "标记为敏感内容",
+    "publicSubTitle": "向所有人开放",
+    "homeSubTitle": "仅在主页时间轴上可见",
+    "followersSubTitle": "仅我的关注者可见",
+    "specifiedSubTitle": "仅对选定的用户可见",
+    "favoriteAll": "全部",
+    "favoriteLikeOnly": "仅点赞",
+    "favoriteLikeOnlyForRemote": "远程仅点赞",
+    "favoriteNonSensitiveOnly": "仅非敏感内容",
+    "favoriteNonSensitiveOnlyAndLikeOnlyForRemote": "仅非敏感内容（远程仅点赞）",
+    "replyTo": "回复给",
+    "addChoice": "增加",
+    "choiceNumber": "选项{choice}",
+    "@choiceNumber": {
+        "placeholders": {
+            "choice": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "canMultipleChoice": "可多选",
+    "disabledInHashtag": "这在哈希标签中不起作用。",
+    "joiningHashtagUsers": "{usersCount}<small>人</small>",
+    "@joiningHashtagUsers": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "searchVoteTab": "问卷调查",
+    "allocatedRolesCount": "{usersCount}<small>人</small>",
+    "@allocatedRolesCount": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "pageWrittenBy": "写此页面的人",
+    "pageCreatedAt": "创建日期: {createdAt}",
+    "@pageCreatedAt": {
+        "placeholders": {
+            "createdAt": {
+                "type": "DateTime",
+                "format": "yMMMd"
+            }
+        }
+    },
+    "pageUpdatedAt": "更新日期: {updatedAt}",
+    "@pageUpdatedAt": {
+        "placeholders": {
+            "updatedAt": {
+                "type": "DateTime",
+                "format": "yMMMd"
+            }
+        }
+    },
+    "unsupportedPage": "Miria 不支持此页面，请在浏览器中查看",
+    "canNotFavoriteMyPage": "无法给自己的页面点赞哦",
+    "activeAnnouncements": "当前的",
+    "inactiveAnnouncements": "以前的",
+    "announcementsForYou": "针对你的公告",
+    "confirmAnnouncementsRead": "已经好好阅读了「{title}」的内容吗？",
+    "readAnnouncement": "已读",
+    "didNotReadAnnouncement": "还没读，请稍等",
+    "onlineUsers": "服务器在线人数",
+    "onlineUsersCount": "{n} 人在线",
+    "@onlineUsersCount": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "cpuUsageRate": "CPU使用率",
+    "memoryUsageRate": "内存使用率",
+    "responseTime": "响应时间",
+    "inboxQueue": "Inbox queue",
+    "inboxProcessQueue": "Process",
+    "inboxActiveQueue": "Active",
+    "inboxDelayedQueue": "Delayed",
+    "inboxWaitingQueue": "Waiting",
+    "deliverQueue": "Deliver queue",
+    "deliverProcessQueue": "Process",
+    "deliverActiveQueue": "Active",
+    "deliverDelayedQueue": "Delayed",
+    "deliverWaitingQueue": "Waiting",
+    "persons": "人",
+    "milliSeconds": "毫秒",
+    "pinnedUser": "置顶用户",
+    "sort": "排序",
+    "joiningServerUsers": "{usersCount} 人正在加入",
+    "@joiningServerUsers": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "serverInformation": "服务器信息",
+    "loginAsMiAuth": "使用 MiAuth 登录",
+    "loginAsAPIKey": "使用 API 密钥登录",
+    "authorizate": "认证",
+    "reauthorizate": "再次验证",
+    "chooseLoginServer": "请选择要登录的服务器",
+    "didAuthorize": "我已认证",
+    "thrownConnectionError": "连接通讯失败。",
+    "thrownConnectionTimeout": "连接超时了。",
+    "thrownWebSocketException": "连接通讯失败（WebSocketException）。",
+    "thrownTimeoutException": "服务器没有响应。",
+    "thrownUnknownError": "未知错误",
+    "thrownError": "似乎发生了错误",
+    "unsupportedServer": "这是不受支持的服务器",
+    "future": "未来",
+    "justNow": "现在",
+    "secondsAgo": "{n}秒前",
+    "@secondsAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "minutesAgo": "{n}分前",
+    "@minutesAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "hoursAgo": "{n}小时前",
+    "@hoursAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "daysAgo": "{n}天前",
+    "@daysAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "yearsAgo": "{n}年前",
+    "@yearsAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inSeconds": "{n}秒后",
+    "@inSeconds": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inMinutes": "{n}分后",
+    "@inMinutes": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inHours": "{n}小时后",
+    "@inHours": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inDays": "{n}天后",
+    "@inDays": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inYears": "{n}年后",
+    "@inYears": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nSeconds": "{n, plural, other {{n}秒}}",
+    "@nSeconds": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nMinutes": "{n, plural, other {{n}分}}",
+    "@nMinutes": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nHours": "{n, plural, other {{n}小时}}",
+    "@nHours": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nDays": "{n, plural, other {{n}日}}",
+    "@nDays": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "lightMode": "浅色模式",
+    "darkMode": "深色模式",
+    "syncWithSystem": "遵循系统设置",
+    "hideSensitiveMedia": "隐藏阅读警告的媒体",
+    "showSensitiveMedia": "不要隐藏阅读警告的媒体",
+    "hideAllMedia": "始终隐藏媒体",
+    "removeSensitiveNotes": "TL上不显示带有阅读警告的帖子",
+    "enableInfiniteScroll": "启用自动滚动页面模式",
+    "disableInfiniteScroll": "不自动加载下一个",
+    "top": "上",
+    "bottom": "下",
+    "systemEmoji": "标准",
+    "invalidServer": "{server} 无法识别为服务器。\n请在服务器字段输入类似「misskey.io」的内容。",
+    "@invalidServer": {
+        "placeholders": {
+            "server": {
+                "type": "String"
+            }
+        }
+    },
+    "serverIsNotMisskey": "{server} 无法识别为 Misskey 服务器。",
+    "@serverIsNotMisskey": {
+        "placeholders": {
+            "server": {
+                "type": "String"
+            }
+        }
+    },
+    "softwareNotSupported": "Miria 与 {software} 不兼容。",
+    "@softwareNotSupported": {
+        "placeholders": {
+            "software": {
+                "type": "String"
+            }
+        }
+    },
+    "softwareNotCompatible": "Miria 与该软件不兼容。\n{software} {version}",
+    "@softwareNotCompatible": {
+        "placeholders": {
+            "software": {
+                "type": "String"
+            },
+            "version": {
+                "type": "String"
+            }
+        }
+    },
+    "alreadyLoggedIn": "已使用{acct}登录",
+    "@alreadyLoggedIn": {
+        "placeholders": {
+            "acct": {
+                "type": "String"
+            }
+        }
+    },
+    "importFromThisFolder": "从该文件夹导入",
+    "exportedFileNotFound": "在这里没有找到 Miria 的配置文件",
+    "importCompleted": "导入完成。",
+    "exportToThisFolder": "导出到该文件夹",
+    "confirmOverwrite": "该文件已存在，你想覆盖它吗？",
+    "overwrite": "覆盖",
+    "exportedFileComment": "Miria 配置文件",
+    "exportCompleted": "导出完成",
+    "cannotOpenLocalOnlyNoteFromRemote": "无法在其他服务器上打开仅本地的帖子",
+    "unlimited": "无限期",
+    "specifyByDate": "日時指定",
+    "specifyByDuration": "期間指定",
+    "seconds": "秒",
+    "minutes": "分",
+    "hours": "小时",
+    "days": "天",
+    "pleaseInputSomething": "请输入内容",
+    "pleaseAddVoteChoice": "请输入两个或多个投票选项",
+    "pleaseSpecifyExpirationDate": "请指定投票截止日期",
+    "pleaseSpecifyExpirationDuration": "请指定投票期限",
+    "cannotMentionToRemoteInLocalOnlyNote": "您不能在仅本地的帖子中提及其他服务器的用户",
+    "cannotPublicReplyToPrivateNote": "无法对{visibility}的私密帖子进行公开回复",
+    "@cannotPublicReplyToPrivateNote": {
+        "placeholders": {
+            "visibility": {
+                "type": "String"
+            }
+        }
+    },
+    "cannotPublicNoteBySilencedUser": "由于用户被禁言，无法公开发布帖子。",
+    "cannotFederateNoteToChannel": "チャンネルのノートを連合にすることはでけへんねん。",
+    "cannotFederateReplyToLocalOnlyNote": "リプライの元ノートが連合なしに設定されとるから、このノートも連合なしにしかでけへんねん。",
+    "cannotFederateRenoteToLocalOnlyNote": "リノートしようとしてるノートが連合なしに設定されとるから、このノートも連合なしにしかでけへんねん。",
+    "unexpectedSensitive": "试图上传的文件被服务器认为是敏感文件，该怎么办？",
+    "staySensitive": "保持敏感",
+    "unsetSensitive": "取消设置敏感",
+    "noteCreatedAt": "发布时间: {createdAt}",
+    "@noteCreatedAt": {
+        "placeholders": {
+            "createdAt": {
+                "type": "String"
+            }
+        }
+    },
+    "accept": "允许",
+    "reject": "拒绝",
+    "generalSettings": "常规设置",
+    "accountSettings": "账户设置",
+    "tabSettings": "选项卡设置",
+    "settingsImportAndExport": "导入/导出设置",
+    "aboutMiria": "关于本应用程序",
+    "quitAccountSettings": "完成账户设置",
+    "packageName": "包名",
+    "version": "版本",
+    "developer": "开发者",
+    "officialWebSite": "官方网站",
+    "openSourceLicense": "开源许可证",
+    "showLicense": "查看许可证",
+    "general": "常规设置",
+    "displayOfSensitiveNotes": "显示标有阅读警告的帖子",
+    "infiniteScroll": "无限滚动",
+    "enableAnimatedMfm": "启用 MFM 动画",
+    "enableAnimatedMfmDescription": "在绘制动画时启用 MFM。",
+    "collapseNotes": "折叠帖子",
+    "collapseReactionedRenotes": "折叠有回应的转发的帖子。",
+    "collapseLongNotes": "折叠长帖子。",
+    "tabPosition": "选项卡位置",
+    "tabPositionDescription": "显示在 {tabPosition}",
+    "@tabPositionDescription": {
+        "placeholders": {
+            "tabPosition": {
+                "type": "String"
+            }
+        }
+    },
+    "theme": "主题",
+    "themeForLightMode": "在浅色模式下使用的主题",
+    "themeForDarkMode": "在深色模式下使用的主题",
+    "themeIsh": "类似于 {theme} 的主题",
+    "@themeIsh": {
+        "placeholders": {
+            "theme": {
+                "type": "String"
+            }
+        }
+    },
+    "selectLightOrDarkMode": "选择浅色或深色模式",
+    "reaction": "回应",
+    "emojiTapReaction": "在帖子中点击表情符号以进行回应",
+    "emojiTapReactionDescription": "点击帖子中的表情符号以进行回应。在某些情况下，来自 MFM 或外部服务器的表情符号可能无法正常工作。",
+    "emojiStyle": "表情符号的样式",
+    "fontStandard": "字体（标准）",
+    "fontSerif": "字体（$[font.serif 用）",
+    "fontMonospace": "字体 （适用于 $[font.monospace ）",
+    "fontCursive": "字体 （适用于 $[font.cursive ）",
+    "fontFantasy": "字体 （适用于 $[font.fantasy ）",
+    "fontSize": "字体大小",
+    "systemFont": "系统标准",
+    "selectFolder": "选择文件夹",
+    "importSettings": "导入设置",
+    "importSettingsDescription": "从驱动器加载配置文件。配置文件保存时会记录所有账号的配置信息，但只会加载登录本设备的账号的信息。",
+    "pleaseSelectAccount": "请选择账户",
+    "select": "选择",
+    "exportSettings": "导出设置",
+    "exportSettingsDescription1": "将配置文件保存到驱动器。配置文件记录了该设备上登录的所有账户除登录信息以外的信息。",
+    "exportSettingsDescription2": "每次导出都会为1个账户保存1个配置文件。",
+    "pleaseSelectAccountToExportSettings": "选择一个账户来保存配置文件",
+    "selectAntenna": "选择天线",
+    "selectChannel": "选择频道",
+    "selectIcon": "选择图标",
+    "standardIcon": "标准",
+    "emojiIcon": "自定义表情符号",
+    "selectRole": "选择角色",
+    "apply": "应用",
+    "account": "账户",
+    "tabType": "选项卡类型",
+    "tabName": "选项卡名称",
+    "icon": "头像",
+    "displayRenotes": "显示转发帖子",
+    "includeReplies": "包括回复",
+    "includeRepliesAvailability": "这是 Misskey v2023.10.1 或更高版本的功能。",
+    "mediaOnly": "仅文件",
+    "subscribeNotes": "自动更新回应和投票计数",
+    "subscribeNotesDescription": "如果将其关闭，回应和投票将不会自动更新，但可能会减少电池消耗。",
+    "pleaseSelectTabType": "请选择选项卡类型。",
+    "pleaseSelectIcon": "请选择图标。",
+    "pleaseSelectChannel": "请选择频道。",
+    "pleaseSelectList": "请选择列表。",
+    "pleaseSelectAntenna": "请选择天线。",
+    "pleaseSelectRole": "请选择角色。",
+    "reactionDeck": "回应面板",
+    "wordMute": "文字屏蔽",
+    "hardWordMute": "屏蔽关键词",
+    "instanceMute": "被屏蔽的服务器",
+    "cacheSettings": "缓存设置",
+    "hideConditionalNotes": "从时间线中隐藏具有指定条件的帖子。",
+    "muteSettingDescription": "用空格分隔的单词按 AND 条件处理，用换行符分隔的行按 OR 条件处理。\n用斜杠括住关键字可使其成为正则表达式。",
+    "refreshOnTabChange": "每次切换标签时都刷新",
+    "refreshOnLaunch": "每次启动时刷新",
+    "refreshOnceADay": "每天刷新一次",
+    "userCache": "有关您自己的信息（包括通知等）",
+    "emojiCache": "表情符号信息",
+    "serverCache": "服务器信息",
+    "instanceMuteDescription1": "隐藏已配置的服务器帖子。",
+    "instanceMuteDescription2": "将已配置服务器上的所有帖子和转帖屏蔽，包括对屏蔽服务器上的用户的回复。\n设置在新行上，以换行符分隔。",
+    "bulkAddReactions": "批量添加",
+    "bulkAddReactionsDescription1": "请使用您的浏览器登录到要复制回应面板的帐户",
+    "bulkAddReactionsDescription2": "在同一个浏览器中访问以下 URL，选择并复制「值 (JSON)」中的所有内容",
+    "bulkAddReactionsDescription3": "将复制的内容粘贴到下面的文本框中",
+    "pasteHere": "粘贴在这里",
+    "invalidInput": "输入的值无效",
+    "clear": "清除",
+    "copy": "复制",
+    "editReactionDeckDescription": "长按以重新排序，点击以删除，点击+以添加。",
+    "confirmClearReactionDeck": "是否要清除所有已设置的回应面板？",
+    "clearReactionDeck": "清除",
+    "accountGeneralSettings": "{accountName} 常规设置",
+    "@accountGeneralSettings": {
+        "placeholders": {
+            "accountName": {
+                "type": "String"
+            }
+        }
+    },
+    "privacy": "隐私",
+    "setDefaultNoteVisibility": "设置默认公开范围。",
+    "noteVisibility": "帖子公开范围",
+    "disableFederation": "不参与联合",
+    "disableFederationDescription": "禁用联合不会将帖子设为私有。在大多数情况下，不需要禁用联合。",
+    "reactionAcceptance": "接受表情回应",
+    "reactionAcceptanceAll": "全部",
+    "forceShowAds": "总是显示广告",
+    "wordMuteDescription": "AND 条件用空格分隔，OR 条件用换行符分隔。\n用斜杠括住关键字可使其成为正则表达式。\n不过，由于正则表达式的规范与 Misskey Web 不同，在 Miria 中有效的正则表达式在 Misskey Web 中可能无效，反之亦然。",
+    "selectAccountToShare": "选择要分享的账户",
+    "createAntenna": "创建天线",
+    "memo": "便笺",
+    "memoDescription": "有什么要写的，就写下来吧",
+    "confirmCreateBlock": "确定要拉黑吗？",
+    "createBlock": "拉黑",
+    "addToList": "添加至列表",
+    "addToAntenna": "添加到天线",
+    "searchNote": "搜索帖子",
+    "deleteRenoteMute": "解除屏蔽转帖",
+    "createRenoteMute": "屏蔽转帖",
+    "deleteMute": "解除屏蔽",
+    "createMute": "屏蔽",
+    "deleteBlock": "取消拉黑",
+    "minutes10": "10分钟",
+    "hours1": "1小时",
+    "day1": "1天",
+    "week1": "1周",
+    "selectDuration": "请选择截止日期。",
+    "confirmUnfollow": "要取消关注吗？",
+    "deleteFollow": "取消关注",
+    "renoteMuting": "屏蔽转帖中",
+    "muting": "屏蔽",
+    "blocking": "拉黑中",
+    "followed": "已关注",
+    "unfollow": "取消关注",
+    "followRequestPending": "关注请求批准中",
+    "followRequest": "关注申请",
+    "createFollow": "关注",
+    "refreshing": "刷新中",
+    "remoteUserCaution": "由于此用户来自其它服务器，显示的信息可能不完整。",
+    "showServerInformation": "查看服务器信息",
+    "location": "位置",
+    "registeredDate": "注册于",
+    "birthday": "生日",
+    "includeRepliesShort": "包括回复",
+    "mediaOnlyShort": "仅媒体",
+    "displayRenotesShort": "显示转帖",
+    "showNotesBeforeThisDate": "显示此日期之前的帖子",
+    "userHighlightAvailability": "高亮显示是从 Misskey 2023.10.0 开始提供的功能。",
+    "userInfomation": "账户信息",
+    "userInfomationLocal": "账户信息（本地）",
+    "userInfomationRemote": "账户信息（远程）",
+    "userNotes": "帖子",
+    "userNotesLocal": "帖子（本地）",
+    "userNotesRemote": "帖子（远程）",
+    "userReactions": "回应",
+    "userPages": "页面",
+    "userPlays": "Play",
+    "userPlaysAvailability": "该功能仅适用于 Misskey 2023.9 及更高版本。",
+    "createList": "创建列表",
+    "listName": "列表名称",
+    "members": "成员",
+    "listCapacity": "{members}/{limit}人",
+    "@listCapacity": {
+        "placeholders": {
+            "members": {
+                "type": "int",
+                "format": "decimalPattern"
+            },
+            "limit": {
+                "type": "double",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "confirmRemoveUser": "确定将此用户移出列表吗？",
+    "removeUser": "移出",
+    "confirmDeleteList": "确定删除此列表吗？",
+    "homeOnly": "仅主页",
+    "followersOnly": "仅粉丝",
+    "originCombined": "全部",
+    "followerAscendingOrder": "粉丝从少到多",
+    "followerDescendingOrder": "粉丝从多到少",
+    "createdAtAscendingOrder": "创建时间从旧到新",
+    "createdAtDescendingOrder": "创建时间从新到旧",
+    "updatedAtAscendingOrder": "更新时间从旧到新",
+    "updatedAtDescendingOrder": "更新时间从新到旧",
+    "misskeyGames": "Misskey Games",
+    "cookieCliker": "Cookie Cliker",
+    "bubbleGame": "Bubble Game",
+    "reversi": "黑白棋",
+    "loading": "加载中...",
+    "invitedReversi": "收到了来自{users}的邀请",
+    "@invitedReversi": {
+        "placeholders": {
+            "users": {
+                "type": "String"
+            }
+        }
+    },
+    "nonInvitedReversi": "好像没有收到邀请"
+}

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,0 +1,943 @@
+{
+    "announcement": "公告",
+    "antenna": "天线",
+    "user": "用户",
+    "channel": "频道",
+    "timeline": "时间线",
+    "sensitive": "敏感内容",
+    "favorite": "收藏",
+    "trend": "趋势",
+    "clip": "便签",
+    "edit": "编辑",
+    "create": "创建",
+    "delete": "删除",
+    "search": "搜索",
+    "detail": "详细",
+    "save": "保存",
+    "hide": "隐藏",
+    "note": "帖子",
+    "mention": "提及",
+    "renote": "转发",
+    "quotedRenote": "引用的转发",
+    "notification": "通知",
+    "list": "列表",
+    "explore": "发现",
+    "highlight": "高光",
+    "role": "角色",
+    "page": "页面",
+    "flash": "Play",
+    "hashtag": "标签",
+    "otherServers": "其他服务器",
+    "follow": "关注",
+    "following": "关注中",
+    "managing": "管理中",
+    "done": "完成",
+    "public": "公开",
+    "home": "首页",
+    "local": "本地",
+    "direct": "直接",
+    "onlyLocal": "仅本地",
+    "remote": "远程",
+    "@done": {
+        "description": "完成"
+    },
+    "software": "软件",
+    "federatedPosts": "投稿",
+    "language": "语言",
+    "administrator": "管理员",
+    "contact": "联系人",
+    "serverRules": "服务器规则",
+    "tos": "服务条款",
+    "privacyPolicy": "隐私政策",
+    "impressum": "运营商信息",
+    "willDelete": "将删除",
+    "cancel": "取消",
+    "noneAction": "什么也不做",
+    "pleaseInput": "请输入",
+    "pleaseSelect": "请选择",
+    "login": "登录",
+    "settings": "设置",
+    "ad": "广告",
+    "customEmoji": "自定义表情符号",
+    "localTimeline": "本地时间线",
+    "localTimelineAbbr": "LTL",
+    "homeTimeline": "主页时间线",
+    "homeTimelineAbbr": "HTL",
+    "socialTimeline": "社交时间线",
+    "socialTimelineAbbr": "STL",
+    "globalTimeline": "全球时间线",
+    "roleTimeline": "角色时间线",
+    "server": "服务器",
+    "miAuth": "MiAuth",
+    "apiKey": "API密钥",
+    "contentWarning": "标注",
+    "follower": "粉丝",
+    "antennaName": "天线名称",
+    "antennaSource": "接收来源",
+    "antennaSourceHome": "主页",
+    "antennaSourceAll": "全部",
+    "antennaSourceUser": "用户",
+    "antennaSourceList": "列表",
+    "selectAntennaSource": "选择源",
+    "selectList": "选择列表",
+    "antennaSourceUserHintText": "指定用户名，并用新行隔开",
+    "addUser": "添加用户",
+    "keywords": "关键字",
+    "antennaSourceKeywordsHintText": "用空格分隔的单词按 AND 条件处理，用换行符分隔的行按 OR 条件处理",
+    "excludeKeywords": "排除关键词",
+    "antennaSourceExcludeKeywordsHintText": "用空格分隔的单词按 AND 条件处理，用换行符分隔的行按 OR 条件处理",
+    "discriminateUpperLower": "区分大小写",
+    "receiveReplies": "接收回复",
+    "receiveOnlyFiles": "只接收附有文件的帖子",
+    "receiveLocal": "只接收本地",
+    "receiveLocalAvailability": "只指定本地对 Misskey 2023.10.2 及更高版本有效。",
+    "confirmDeletingAntenna": "要删除天线吗？",
+    "channelJoinningCounts": "{usersCount} 人加入",
+    "@channelJoinningCounts": {
+        "description": "频道加入人数",
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "channelNotes": "{notesCount}投稿",
+    "@channelNotes": {
+        "description": "频道帖子数",
+        "placeholders": {
+            "notesCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "channelLastNotedAt": "{lastNotedAt} 更新",
+    "@channelLastNotedAt": {
+        "description": "频道帖子数",
+        "placeholders": {
+            "lastNotedAt": {
+                "type": "String"
+            }
+        }
+    },
+    "favorited": "已加入收藏夹。",
+    "willFavorite": "添加到收藏夹",
+    "willFollow": "加关注",
+    "channelInformation": "频道信息",
+    "channelStatistics": "{notesCount} 投稿 / {usersCount} 人加入 / {lastNotedAt} 更新",
+    "@channelStatistics": {
+        "description": "频道统计信息",
+        "placeholders": {
+            "notesCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            },
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            },
+            "lastNotedAt": {
+                "type": "String"
+            }
+        }
+    },
+    "notImplemented": "准备中",
+    "createClip": "创建便签",
+    "confirmDeleteClip": "要删除这个便签吗？",
+    "clipName": "便签名称",
+    "clipDescription": "说明（可省略）",
+    "alreadyAddedClip": "它看起来像是已经添加到便签中的帖子",
+    "deleteClip": "从便签中删除",
+    "thanksForReport": "您的内容已发送。感谢您的举报。",
+    "reportAbuseOf": "举报 {name}",
+    "@reportAbuseOf": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "pleaseInputReasonWhyAbuse": "请输入举报原因的详细信息。如果您有具体帖子，请同时输入其 URL。",
+    "reportAbuse": "举报",
+    "closeTweet": "关闭推文",
+    "closePlayer": "关闭播放器",
+    "doneCopy": "复制了",
+    "mutedNotePlaceholder": "{userName} 说了些啥",
+    "@mutedNotePlaceholder": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "showCw": "看看剩下隐藏的",
+    "showReactionedNote": "展示更多",
+    "showLongText": "展示更多",
+    "showMoreFiles": "展示更多",
+    "otherReactions": "还有{reactionCounts}个",
+    "@otherReactions": {
+        "placeholders": {
+            "reactionCounts": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "confirmDeleteReaction": "要取消回应吗？",
+    "cancelReaction": "取消",
+    "renotedBy": "{user} 转发了",
+    "selfRenotedBy": "自转发了",
+    "savedImage": "图片已保存",
+    "tapToShow": "点击查看",
+    "copyContents": "复制内容",
+    "copyLinks": "复制链接",
+    "copyName": "复制用户名",
+    "copyUserScreenName": "复制用户屏幕名称",
+    "openBrowsers": "在浏览器中打开",
+    "openBrowsersAsRemote": "在浏览器中打开远程目标",
+    "openInAnotherAccount": "使用另一个账户打开",
+    "changeFullScreen": "切换到全屏",
+    "shareNotes": "分享帖子",
+    "deleteFavorite": "取消收藏",
+    "notesAfterRenote": "转发后的帖子",
+    "deletedRecreate": "删除并重新创建",
+    "confirmDeletedRecreate": "要删除这个帖子吗？回应、转发和回复消失且无法返回？",
+    "deleteRenote": "取消转发",
+    "confirmDelete": "真的要删除吗？",
+    "doDeleting": "删掉！",
+    "confirmPoll": "您想投票给{choiced}吗？",
+    "@confirmPoll": {
+        "placeholders": {
+            "choiced": {
+                "type": "String"
+            }
+        }
+    },
+    "votesCount": "({votes}票)",
+    "@votesCount": {
+        "placeholders": {
+            "votes": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "totalVotesCount": "共{votes}票・",
+    "@totalVotesCount": {
+        "placeholders": {
+            "votes": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "finished": "已结束",
+    "openResult": "查看结果",
+    "doVoting": "投票",
+    "alreadyVoted": "已投票",
+    "remainDiffer": "还有{differ}",
+    "@remainDiffer": {
+        "placeholders": {
+            "differ": {
+                "type": "String"
+            }
+        }
+    },
+    "renoted": "已转发。",
+    "renoteInSpecificChannel": "在{channelName}内转发",
+    "@renoteInSpecificChannel": {
+        "placeholders": {
+            "channelName": {
+                "type": "String"
+            }
+        }
+    },
+    "quotedRenoteInSpecificChannel": "在{channelName}中引用转发",
+    "@quotedRenoteInSpecificChannel": {
+        "placeholders": {
+            "channelName": {
+                "type": "String"
+            }
+        }
+    },
+    "renoteInChannel": "转发至频道",
+    "renoteInOtherChannel": "转发至另一个频道",
+    "quotedRenoteInChannel": "引用转发至频道",
+    "quotedRenoteInOtherChannel": "引用转发至另一个频道",
+    "renotedUsers": "转发的用户",
+    "otherComplementReactions": "其他的",
+    "openAsOtherAccount": "选择要打开的账户",
+    "pickColor": "选择颜色",
+    "decideColor": "就这个",
+    "accountSetting": "{accountName}的设置",
+    "@accountSetting": {
+        "placeholders": {
+            "accountName": {
+                "type": "String"
+            }
+        }
+    },
+    "chooseFile": "选择文件",
+    "uploadFile": "上传",
+    "fromDrive": "从网盘中",
+    "fileName": "文件名称",
+    "randomizeFileName": "随机化文件名",
+    "caption": "标题",
+    "sensitiveSubTitle": "即使您删除阅读警告设置，该页面也可能会自动标记为阅读警告。",
+    "replyNotePlaceholder": "发点什么？",
+    "defaultNotePlaceholder": "在干啥？",
+    "hasMediaButCannotEdit": "有媒体（无法编辑）",
+    "hasVoteButCannotEdit": "有投票（无法编辑）",
+    "followedNotification": "{userName}已关注",
+    "@followedNotification": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "followRequestAcceptedNotification": "{userName}同意了您的关注请求",
+    "@followRequestAcceptedNotification": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "receiveFollowRequestNotification": "{userName}希望您关注",
+    "@receiveFollowRequestNotification": {
+        "placeholders": {
+            "userName": {
+                "type": "String"
+            }
+        }
+    },
+    "achievementEarnedNotification": "成就已解锁",
+    "testNotification": "这是一个测试",
+    "renotedUsersInNotification": "转发的人",
+    "reactionUsersInNotification": "回应的人",
+    "finishedVotedNotification": "投票已经结束了",
+    "renoteAndReactionsNotification": "{reactionUser}回应了，{renotedUser}转发了",
+    "@renoteAndReactionsNotification": {
+        "placeholders": {
+            "reactionUser": {
+                "type": "String?"
+            },
+            "renotedUser": {
+                "type": "String?"
+            }
+        }
+    },
+    "renoteNotification": "{renoteUser}已转发",
+    "@renoteNotification": {
+        "placeholders": {
+            "renoteUser": {
+                "type": "String?"
+            }
+        }
+    },
+    "reactionNotification": "{reactionUser}已回应",
+    "@reactionNotification": {
+        "placeholders": {
+            "reactionUser": {
+                "type": "String?"
+            }
+        }
+    },
+    "notedNotification": "{notedUser}发了帖子",
+    "@notedNotification": {
+        "placeholders": {
+            "notedUser": {
+                "type": "String"
+            }
+        }
+    },
+    "roleAssignedNotification": "您已被分配至角色「{role}」",
+    "@roleAssignedNotification": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "notificationAll": "所有人",
+    "notificationForMe": "给自己的",
+    "notificationDirect": "直接",
+    "editPhoto": "编辑图片",
+    "customEmojiLicensedBy": "该自定义表情符号的许可如下。",
+    "customEmojiLicensedByNone": "※尚未为此自定义表情符号设置许可证。",
+    "cancelEmojiChoosing": "取消表情符号选择",
+    "doneEmojiChoosing": "完成表情符号选择",
+    "confirmSavingPhoto": "保存吗？",
+    "doneEditingPhoto": "保存",
+    "continueEditingPhoto": "继续修改图片",
+    "disabledUsingSensitiveCustomEmoji": "此处无法使用敏感的自定义表情符号",
+    "markAsSensitive": "标记为敏感内容",
+    "publicSubTitle": "向所有人开放",
+    "homeSubTitle": "仅在主页时间轴上可见",
+    "followersSubTitle": "仅我的关注者可见",
+    "specifiedSubTitle": "仅对选定的用户可见",
+    "favoriteAll": "全部",
+    "favoriteLikeOnly": "仅点赞",
+    "favoriteLikeOnlyForRemote": "远程仅点赞",
+    "favoriteNonSensitiveOnly": "仅非敏感内容",
+    "favoriteNonSensitiveOnlyAndLikeOnlyForRemote": "仅非敏感内容（远程仅点赞）",
+    "replyTo": "回复给",
+    "addChoice": "增加",
+    "choiceNumber": "选项{choice}",
+    "@choiceNumber": {
+        "placeholders": {
+            "choice": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "canMultipleChoice": "可多选",
+    "disabledInHashtag": "这在哈希标签中不起作用。",
+    "joiningHashtagUsers": "{usersCount}<small>人</small>",
+    "@joiningHashtagUsers": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "searchVoteTab": "问卷调查",
+    "allocatedRolesCount": "{usersCount}<small>人</small>",
+    "@allocatedRolesCount": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "pageWrittenBy": "写此页面的人",
+    "pageCreatedAt": "创建日期: {createdAt}",
+    "@pageCreatedAt": {
+        "placeholders": {
+            "createdAt": {
+                "type": "DateTime",
+                "format": "yMMMd"
+            }
+        }
+    },
+    "pageUpdatedAt": "更新日期: {updatedAt}",
+    "@pageUpdatedAt": {
+        "placeholders": {
+            "updatedAt": {
+                "type": "DateTime",
+                "format": "yMMMd"
+            }
+        }
+    },
+    "unsupportedPage": "Miria 不支持此页面，请在浏览器中查看",
+    "canNotFavoriteMyPage": "无法给自己的页面点赞哦",
+    "activeAnnouncements": "当前的",
+    "inactiveAnnouncements": "以前的",
+    "announcementsForYou": "针对你的公告",
+    "confirmAnnouncementsRead": "已经好好阅读了「{title}」的内容吗？",
+    "readAnnouncement": "已读",
+    "didNotReadAnnouncement": "还没读，请稍等",
+    "onlineUsers": "服务器在线人数",
+    "onlineUsersCount": "{n} 人在线",
+    "@onlineUsersCount": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "cpuUsageRate": "CPU使用率",
+    "memoryUsageRate": "内存使用率",
+    "responseTime": "响应时间",
+    "inboxQueue": "Inbox queue",
+    "inboxProcessQueue": "Process",
+    "inboxActiveQueue": "Active",
+    "inboxDelayedQueue": "Delayed",
+    "inboxWaitingQueue": "Waiting",
+    "deliverQueue": "Deliver queue",
+    "deliverProcessQueue": "Process",
+    "deliverActiveQueue": "Active",
+    "deliverDelayedQueue": "Delayed",
+    "deliverWaitingQueue": "Waiting",
+    "persons": "人",
+    "milliSeconds": "毫秒",
+    "pinnedUser": "置顶用户",
+    "sort": "排序",
+    "joiningServerUsers": "{usersCount} 人正在加入",
+    "@joiningServerUsers": {
+        "placeholders": {
+            "usersCount": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "serverInformation": "服务器信息",
+    "loginAsMiAuth": "使用 MiAuth 登录",
+    "loginAsAPIKey": "使用 API 密钥登录",
+    "authorizate": "认证",
+    "reauthorizate": "再次验证",
+    "chooseLoginServer": "请选择要登录的服务器",
+    "didAuthorize": "我已认证",
+    "thrownConnectionError": "连接通讯失败。",
+    "thrownConnectionTimeout": "连接超时了。",
+    "thrownWebSocketException": "连接通讯失败（WebSocketException）。",
+    "thrownTimeoutException": "服务器没有响应。",
+    "thrownUnknownError": "未知错误",
+    "thrownError": "似乎发生了错误",
+    "unsupportedServer": "这是不受支持的服务器",
+    "future": "未来",
+    "justNow": "现在",
+    "secondsAgo": "{n}秒前",
+    "@secondsAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "minutesAgo": "{n}分前",
+    "@minutesAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "hoursAgo": "{n}小时前",
+    "@hoursAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "daysAgo": "{n}天前",
+    "@daysAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "yearsAgo": "{n}年前",
+    "@yearsAgo": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inSeconds": "{n}秒后",
+    "@inSeconds": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inMinutes": "{n}分后",
+    "@inMinutes": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inHours": "{n}小时后",
+    "@inHours": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inDays": "{n}天后",
+    "@inDays": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "inYears": "{n}年后",
+    "@inYears": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nSeconds": "{n, plural, other {{n}秒}}",
+    "@nSeconds": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nMinutes": "{n, plural, other {{n}分}}",
+    "@nMinutes": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nHours": "{n, plural, other {{n}小时}}",
+    "@nHours": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "nDays": "{n, plural, other {{n}日}}",
+    "@nDays": {
+        "placeholders": {
+            "n": {
+                "type": "int",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "lightMode": "浅色模式",
+    "darkMode": "深色模式",
+    "syncWithSystem": "遵循系统设置",
+    "hideSensitiveMedia": "隐藏阅读警告的媒体",
+    "showSensitiveMedia": "不要隐藏阅读警告的媒体",
+    "hideAllMedia": "始终隐藏媒体",
+    "removeSensitiveNotes": "TL上不显示带有阅读警告的帖子",
+    "enableInfiniteScroll": "启用自动滚动页面模式",
+    "disableInfiniteScroll": "不自动加载下一个",
+    "top": "上",
+    "bottom": "下",
+    "systemEmoji": "标准",
+    "invalidServer": "{server} 无法识别为服务器。\n请在服务器字段输入类似「misskey.io」的内容。",
+    "@invalidServer": {
+        "placeholders": {
+            "server": {
+                "type": "String"
+            }
+        }
+    },
+    "serverIsNotMisskey": "{server} 无法识别为 Misskey 服务器。",
+    "@serverIsNotMisskey": {
+        "placeholders": {
+            "server": {
+                "type": "String"
+            }
+        }
+    },
+    "softwareNotSupported": "Miria 与 {software} 不兼容。",
+    "@softwareNotSupported": {
+        "placeholders": {
+            "software": {
+                "type": "String"
+            }
+        }
+    },
+    "softwareNotCompatible": "Miria 与该软件不兼容。\n{software} {version}",
+    "@softwareNotCompatible": {
+        "placeholders": {
+            "software": {
+                "type": "String"
+            },
+            "version": {
+                "type": "String"
+            }
+        }
+    },
+    "alreadyLoggedIn": "已使用{acct}登录",
+    "@alreadyLoggedIn": {
+        "placeholders": {
+            "acct": {
+                "type": "String"
+            }
+        }
+    },
+    "importFromThisFolder": "从该文件夹导入",
+    "exportedFileNotFound": "在这里没有找到 Miria 的配置文件",
+    "importCompleted": "导入完成。",
+    "exportToThisFolder": "导出到该文件夹",
+    "confirmOverwrite": "该文件已存在，你想覆盖它吗？",
+    "overwrite": "覆盖",
+    "exportedFileComment": "Miria 配置文件",
+    "exportCompleted": "导出完成",
+    "cannotOpenLocalOnlyNoteFromRemote": "无法在其他服务器上打开仅本地的帖子",
+    "unlimited": "无限期",
+    "specifyByDate": "日時指定",
+    "specifyByDuration": "期間指定",
+    "seconds": "秒",
+    "minutes": "分",
+    "hours": "小时",
+    "days": "天",
+    "pleaseInputSomething": "请输入内容",
+    "pleaseAddVoteChoice": "请输入两个或多个投票选项",
+    "pleaseSpecifyExpirationDate": "请指定投票截止日期",
+    "pleaseSpecifyExpirationDuration": "请指定投票期限",
+    "cannotMentionToRemoteInLocalOnlyNote": "您不能在仅本地的帖子中提及其他服务器的用户",
+    "cannotPublicReplyToPrivateNote": "无法对{visibility}的私密帖子进行公开回复",
+    "@cannotPublicReplyToPrivateNote": {
+        "placeholders": {
+            "visibility": {
+                "type": "String"
+            }
+        }
+    },
+    "cannotPublicNoteBySilencedUser": "由于用户被禁言，无法公开发布帖子。",
+    "cannotFederateNoteToChannel": "チャンネルのノートを連合にすることはでけへんねん。",
+    "cannotFederateReplyToLocalOnlyNote": "リプライの元ノートが連合なしに設定されとるから、このノートも連合なしにしかでけへんねん。",
+    "cannotFederateRenoteToLocalOnlyNote": "リノートしようとしてるノートが連合なしに設定されとるから、このノートも連合なしにしかでけへんねん。",
+    "unexpectedSensitive": "试图上传的文件被服务器认为是敏感文件，该怎么办？",
+    "staySensitive": "保持敏感",
+    "unsetSensitive": "取消设置敏感",
+    "noteCreatedAt": "发布时间: {createdAt}",
+    "@noteCreatedAt": {
+        "placeholders": {
+            "createdAt": {
+                "type": "String"
+            }
+        }
+    },
+    "accept": "允许",
+    "reject": "拒绝",
+    "generalSettings": "常规设置",
+    "accountSettings": "账户设置",
+    "tabSettings": "选项卡设置",
+    "settingsImportAndExport": "导入/导出设置",
+    "aboutMiria": "关于本应用程序",
+    "quitAccountSettings": "完成账户设置",
+    "packageName": "包名",
+    "version": "版本",
+    "developer": "开发者",
+    "officialWebSite": "官方网站",
+    "openSourceLicense": "开源许可证",
+    "showLicense": "查看许可证",
+    "general": "常规设置",
+    "displayOfSensitiveNotes": "显示标有阅读警告的帖子",
+    "infiniteScroll": "无限滚动",
+    "enableAnimatedMfm": "启用 MFM 动画",
+    "enableAnimatedMfmDescription": "在绘制动画时启用 MFM。",
+    "collapseNotes": "折叠帖子",
+    "collapseReactionedRenotes": "折叠有回应的转发的帖子。",
+    "collapseLongNotes": "折叠长帖子。",
+    "tabPosition": "选项卡位置",
+    "tabPositionDescription": "显示在 {tabPosition}",
+    "@tabPositionDescription": {
+        "placeholders": {
+            "tabPosition": {
+                "type": "String"
+            }
+        }
+    },
+    "theme": "主题",
+    "themeForLightMode": "在浅色模式下使用的主题",
+    "themeForDarkMode": "在深色模式下使用的主题",
+    "themeIsh": "类似于 {theme} 的主题",
+    "@themeIsh": {
+        "placeholders": {
+            "theme": {
+                "type": "String"
+            }
+        }
+    },
+    "selectLightOrDarkMode": "选择浅色或深色模式",
+    "reaction": "回应",
+    "emojiTapReaction": "在帖子中点击表情符号以进行回应",
+    "emojiTapReactionDescription": "点击帖子中的表情符号以进行回应。在某些情况下，来自 MFM 或外部服务器的表情符号可能无法正常工作。",
+    "emojiStyle": "表情符号的样式",
+    "fontStandard": "字体（标准）",
+    "fontSerif": "字体（$[font.serif 用）",
+    "fontMonospace": "字体 （适用于 $[font.monospace ）",
+    "fontCursive": "字体 （适用于 $[font.cursive ）",
+    "fontFantasy": "字体 （适用于 $[font.fantasy ）",
+    "fontSize": "字体大小",
+    "systemFont": "系统标准",
+    "selectFolder": "选择文件夹",
+    "importSettings": "导入设置",
+    "importSettingsDescription": "从驱动器加载配置文件。配置文件保存时会记录所有账号的配置信息，但只会加载登录本设备的账号的信息。",
+    "pleaseSelectAccount": "请选择账户",
+    "select": "选择",
+    "exportSettings": "导出设置",
+    "exportSettingsDescription1": "将配置文件保存到驱动器。配置文件记录了该设备上登录的所有账户除登录信息以外的信息。",
+    "exportSettingsDescription2": "每次导出都会为1个账户保存1个配置文件。",
+    "pleaseSelectAccountToExportSettings": "选择一个账户来保存配置文件",
+    "selectAntenna": "选择天线",
+    "selectChannel": "选择频道",
+    "selectIcon": "选择图标",
+    "standardIcon": "标准",
+    "emojiIcon": "自定义表情符号",
+    "selectRole": "选择角色",
+    "apply": "应用",
+    "account": "账户",
+    "tabType": "选项卡类型",
+    "tabName": "选项卡名称",
+    "icon": "头像",
+    "displayRenotes": "显示转发帖子",
+    "includeReplies": "包括回复",
+    "includeRepliesAvailability": "这是 Misskey v2023.10.1 或更高版本的功能。",
+    "mediaOnly": "仅文件",
+    "subscribeNotes": "自动更新回应和投票计数",
+    "subscribeNotesDescription": "如果将其关闭，回应和投票将不会自动更新，但可能会减少电池消耗。",
+    "pleaseSelectTabType": "请选择选项卡类型。",
+    "pleaseSelectIcon": "请选择图标。",
+    "pleaseSelectChannel": "请选择频道。",
+    "pleaseSelectList": "请选择列表。",
+    "pleaseSelectAntenna": "请选择天线。",
+    "pleaseSelectRole": "请选择角色。",
+    "reactionDeck": "回应面板",
+    "wordMute": "文字屏蔽",
+    "hardWordMute": "屏蔽关键词",
+    "instanceMute": "被屏蔽的服务器",
+    "cacheSettings": "缓存设置",
+    "hideConditionalNotes": "从时间线中隐藏具有指定条件的帖子。",
+    "muteSettingDescription": "用空格分隔的单词按 AND 条件处理，用换行符分隔的行按 OR 条件处理。\n用斜杠括住关键字可使其成为正则表达式。",
+    "refreshOnTabChange": "每次切换标签时都刷新",
+    "refreshOnLaunch": "每次启动时刷新",
+    "refreshOnceADay": "每天刷新一次",
+    "userCache": "有关您自己的信息（包括通知等）",
+    "emojiCache": "表情符号信息",
+    "serverCache": "服务器信息",
+    "instanceMuteDescription1": "隐藏已配置的服务器帖子。",
+    "instanceMuteDescription2": "将已配置服务器上的所有帖子和转帖屏蔽，包括对屏蔽服务器上的用户的回复。\n设置在新行上，以换行符分隔。",
+    "bulkAddReactions": "批量添加",
+    "bulkAddReactionsDescription1": "请使用您的浏览器登录到要复制回应面板的帐户",
+    "bulkAddReactionsDescription2": "在同一个浏览器中访问以下 URL，选择并复制「值 (JSON)」中的所有内容",
+    "bulkAddReactionsDescription3": "将复制的内容粘贴到下面的文本框中",
+    "pasteHere": "粘贴在这里",
+    "invalidInput": "输入的值无效",
+    "clear": "清除",
+    "copy": "复制",
+    "editReactionDeckDescription": "长按以重新排序，点击以删除，点击+以添加。",
+    "confirmClearReactionDeck": "是否要清除所有已设置的回应面板？",
+    "clearReactionDeck": "清除",
+    "accountGeneralSettings": "{accountName} 常规设置",
+    "@accountGeneralSettings": {
+        "placeholders": {
+            "accountName": {
+                "type": "String"
+            }
+        }
+    },
+    "privacy": "隐私",
+    "setDefaultNoteVisibility": "设置默认公开范围。",
+    "noteVisibility": "帖子公开范围",
+    "disableFederation": "不参与联合",
+    "disableFederationDescription": "禁用联合不会将帖子设为私有。在大多数情况下，不需要禁用联合。",
+    "reactionAcceptance": "接受表情回应",
+    "reactionAcceptanceAll": "全部",
+    "forceShowAds": "总是显示广告",
+    "wordMuteDescription": "AND 条件用空格分隔，OR 条件用换行符分隔。\n用斜杠括住关键字可使其成为正则表达式。\n不过，由于正则表达式的规范与 Misskey Web 不同，在 Miria 中有效的正则表达式在 Misskey Web 中可能无效，反之亦然。",
+    "selectAccountToShare": "选择要分享的账户",
+    "createAntenna": "创建天线",
+    "memo": "便笺",
+    "memoDescription": "有什么要写的，就写下来吧",
+    "confirmCreateBlock": "确定要拉黑吗？",
+    "createBlock": "拉黑",
+    "addToList": "添加至列表",
+    "addToAntenna": "添加到天线",
+    "searchNote": "搜索帖子",
+    "deleteRenoteMute": "解除屏蔽转帖",
+    "createRenoteMute": "屏蔽转帖",
+    "deleteMute": "解除屏蔽",
+    "createMute": "屏蔽",
+    "deleteBlock": "取消拉黑",
+    "minutes10": "10分钟",
+    "hours1": "1小时",
+    "day1": "1天",
+    "week1": "1周",
+    "selectDuration": "请选择截止日期。",
+    "confirmUnfollow": "要取消关注吗？",
+    "deleteFollow": "取消关注",
+    "renoteMuting": "屏蔽转帖中",
+    "muting": "屏蔽",
+    "blocking": "拉黑中",
+    "followed": "已关注",
+    "unfollow": "取消关注",
+    "followRequestPending": "关注请求批准中",
+    "followRequest": "关注申请",
+    "createFollow": "关注",
+    "refreshing": "刷新中",
+    "remoteUserCaution": "由于此用户来自其它服务器，显示的信息可能不完整。",
+    "showServerInformation": "查看服务器信息",
+    "location": "位置",
+    "registeredDate": "注册于",
+    "birthday": "生日",
+    "includeRepliesShort": "包括回复",
+    "mediaOnlyShort": "仅媒体",
+    "displayRenotesShort": "显示转帖",
+    "showNotesBeforeThisDate": "显示此日期之前的帖子",
+    "userHighlightAvailability": "高亮显示是从 Misskey 2023.10.0 开始提供的功能。",
+    "userInfomation": "账户信息",
+    "userInfomationLocal": "账户信息（本地）",
+    "userInfomationRemote": "账户信息（远程）",
+    "userNotes": "帖子",
+    "userNotesLocal": "帖子（本地）",
+    "userNotesRemote": "帖子（远程）",
+    "userReactions": "回应",
+    "userPages": "页面",
+    "userPlays": "Play",
+    "userPlaysAvailability": "该功能仅适用于 Misskey 2023.9 及更高版本。",
+    "createList": "创建列表",
+    "listName": "列表名称",
+    "members": "成员",
+    "listCapacity": "{members}/{limit}人",
+    "@listCapacity": {
+        "placeholders": {
+            "members": {
+                "type": "int",
+                "format": "decimalPattern"
+            },
+            "limit": {
+                "type": "double",
+                "format": "decimalPattern"
+            }
+        }
+    },
+    "confirmRemoveUser": "确定将此用户移出列表吗？",
+    "removeUser": "移出",
+    "confirmDeleteList": "确定删除此列表吗？",
+    "homeOnly": "仅主页",
+    "followersOnly": "仅粉丝",
+    "originCombined": "全部",
+    "followerAscendingOrder": "粉丝从少到多",
+    "followerDescendingOrder": "粉丝从多到少",
+    "createdAtAscendingOrder": "创建时间从旧到新",
+    "createdAtDescendingOrder": "创建时间从新到旧",
+    "updatedAtAscendingOrder": "更新时间从旧到新",
+    "updatedAtDescendingOrder": "更新时间从新到旧",
+    "misskeyGames": "Misskey Games",
+    "cookieCliker": "Cookie Cliker",
+    "bubbleGame": "Bubble Game",
+    "reversi": "黑白棋",
+    "loading": "加载中...",
+    "invitedReversi": "收到了来自{users}的邀请",
+    "@invitedReversi": {
+        "placeholders": {
+            "users": {
+                "type": "String"
+            }
+        }
+    },
+    "nonInvitedReversi": "好像没有收到邀请"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,7 +38,7 @@ class MyApp extends ConsumerWidget {
       title: 'Miria',
       debugShowCheckedModeBanner: false,
       locale: Locale(language.countryCode, language.languageCode),
-      supportedLocales: const [Locale("ja", "JP"), Locale("ja", "OJ")],
+      supportedLocales: const [Locale("ja", "JP"), Locale("ja", "OJ"), Locale("zh", "CN")],
       scrollBehavior: AppScrollBehavior(),
       localizationsDelegates: const [
         S.delegate,

--- a/lib/model/general_settings.dart
+++ b/lib/model/general_settings.dart
@@ -73,7 +73,8 @@ enum EmojiType {
 
 enum Languages {
   jaJP("日本語", "ja", "JP"),
-  jaOJ("日本語（お嬢様）", "ja", "OJ");
+  jaOJ("日本語（お嬢様）", "ja", "OJ"),
+  zhCN("简体中文", "zh", "CN");
 
   final String displayName;
   final String countryCode;
@@ -132,7 +133,7 @@ class GeneralSettings with _$GeneralSettings {
     @Default("") String fantasyFontName,
 
     /// 言語設定
-    @Default(Languages.jaJP) Languages languages,
+    @Default(Languages.zhCN) Languages languages,
   }) = _GeneralSettings;
 
   factory GeneralSettings.fromJson(Map<String, dynamic> json) =>

--- a/lib/model/general_settings.dart
+++ b/lib/model/general_settings.dart
@@ -133,7 +133,7 @@ class GeneralSettings with _$GeneralSettings {
     @Default("") String fantasyFontName,
 
     /// 言語設定
-    @Default(Languages.zhCN) Languages languages,
+    @Default(Languages.jaJP) Languages languages,
   }) = _GeneralSettings;
 
   factory GeneralSettings.fromJson(Map<String, dynamic> json) =>

--- a/windows/innosetup.iss
+++ b/windows/innosetup.iss
@@ -37,6 +37,7 @@ UninstallDisplayIcon={app}\{#MyAppExeName}
 [Languages]
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "korean"; MessagesFile: "{#MyWorkDir}\Korean.isl"
+Name: "chinesesimplified"; MessagesFile: "{#MyWorkDir}\ChineseSimplified.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked


### PR DESCRIPTION
Cherry-pick from https://github.com/GilbertJin/miria/commit/55df6641f66f90b34a1939b8cf17b422a05cab13
Related to #164 

フォークから中国語(zh-CN)のサポートを追加します。
- インストーラーの翻訳は[Unofficialフォルダ以下にある](https://github.com/jrsoftware/issrc/blob/main/Files/Languages/Unofficial/ChineseSimplified.isl)ため~~追加しない予定~~→問題無さそうなので追加

todo: `dart run build_runner build`