### PR TITLE
アカウントリストにseveral_account_settingの設定ボタンを追加

### DIFF
--- a/lib/view/settings_page/account_settings_page/account_list.dart
+++ b/lib/view/settings_page/account_settings_page/account_list.dart
@@ -96,6 +96,12 @@ class AccountListItem extends ConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              context.pushRoute(SeveralAccountGeneralSettingsRoute(account: account));
+            },
+          ),
+          IconButton(
             icon: const Icon(Icons.delete),
             onPressed: () {
               showDialog(


### PR DESCRIPTION
アカウントリストにアカウントごとの設定へのリンクを追加しました。
![画像](https://media.misskeyusercontent.com/io/3a3e7770-32a1-45b7-b21a-a67792f5b564.png)
このPRでは`common_drawer.dart`のリンクは削除していません。

ref: https://misskey.io/notes/9p6ou3280ymd09pj