### PR TITLE
[デスクトップ] 前回終了時のウィンドウサイズで起動するように

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,12 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:miria/model/desktop_settings.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
 import 'package:miria/view/common/error_dialog_listener.dart';
@@ -10,10 +14,14 @@ import 'package:miria/view/common/sharing_intent_listener.dart';
 import 'package:miria/view/themes/app_theme_scope.dart';
 import 'package:stack_trace/stack_trace.dart' as stack_trace;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:window_manager/window_manager.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   MediaKit.ensureInitialized();
+  if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
+    windowManager.ensureInitialized();
+  }
   FlutterError.demangleStackTrace = (StackTrace stack) {
     if (stack is stack_trace.Trace) return stack.vmTrace;
     if (stack is stack_trace.Chain) return stack.toTrace().vmTrace;
@@ -23,14 +31,96 @@ Future<void> main() async {
   runApp(ProviderScope(child: MyApp()));
 }
 
-class MyApp extends ConsumerWidget {
-  MyApp({super.key});
+class MyApp extends ConsumerStatefulWidget {
+  const MyApp({super.key});
 
+  @override
+  ConsumerState<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends ConsumerState<MyApp> with WindowListener {
   final _appRouter = AppRouter();
+  final isDesktop = Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+
+  @override
+  void initState() {
+    if (isDesktop) {
+      windowManager.addListener(this);
+      ref
+          .read(desktopSettingsRepositoryProvider)
+          .load()
+          .then((_) => _initWindow());
+    }
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    if (isDesktop) {
+      windowManager.removeListener(this);
+    }
+    super.dispose();
+  }
+
+  @override
+  void onWindowClose() async {
+    if (!isDesktop) return;
+
+    bool isPreventClose = await windowManager.isPreventClose();
+    if (isPreventClose) {
+      final size = await windowManager.getSize();
+      final position = await windowManager.getPosition();
+      try {
+        final settings = ref.read(desktopSettingsRepositoryProvider).settings;
+        await ref.read(desktopSettingsRepositoryProvider).update(
+            settings.copyWith(
+                window: DesktopWindowSettings(
+                    w: size.width,
+                    h: size.height,
+                    x: position.dx,
+                    y: position.dy)));
+      } catch (e) {
+        if (kDebugMode) print(e);
+      } finally {
+        await windowManager.destroy();
+      }
+    }
+  }
+
+  Future<void> _initWindow() async {
+    await windowManager.setPreventClose(true);
+    DesktopSettings config =
+        ref.read(desktopSettingsRepositoryProvider).settings;
+
+    Size size = (config.window.w > 0 && config.window.h > 0)
+        ? Size(config.window.w, config.window.h)
+        : const Size(400, 700);
+
+    Offset? position = (config.window.x != null && config.window.y != null)
+        ? Offset(config.window.x!, config.window.y!)
+        : null;
+
+    WindowOptions opt = WindowOptions(
+      size: size,
+      center: (position == null),
+      backgroundColor: Colors.transparent,
+      skipTaskbar: false,
+      titleBarStyle: TitleBarStyle.normal,
+    );
+
+    if (position != null) {
+      windowManager.setPosition(position);
+    }
+
+    windowManager.waitUntilReadyToShow(opt, () async {
+      await windowManager.show();
+      await windowManager.focus();
+    });
+  }
 
   // This widget is the root of your application.
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final language = ref.watch(generalSettingsRepositoryProvider
         .select((value) => value.settings.languages));
 

--- a/lib/model/desktop_settings.dart
+++ b/lib/model/desktop_settings.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'desktop_settings.freezed.dart';
+part 'desktop_settings.g.dart';
+
+@freezed
+class DesktopSettings with _$DesktopSettings {
+  const factory DesktopSettings({
+    @Default(DesktopWindowSettings()) DesktopWindowSettings window,
+  }) = _DesktopSettings;
+
+  factory DesktopSettings.fromJson(Map<String, dynamic> json) =>
+      _$DesktopSettingsFromJson(json);
+}
+
+@freezed
+class DesktopWindowSettings with _$DesktopWindowSettings {
+  const factory DesktopWindowSettings({
+    @Default(null) double? x,
+    @Default(null) double? y,
+    @Default(400) double w,
+    @Default(700) double h,
+  }) = _DesktopWindowSettings;
+
+  factory DesktopWindowSettings.fromJson(Map<String, dynamic> json) =>
+      _$DesktopWindowSettingsFromJson(json);
+}

--- a/lib/model/desktop_settings.freezed.dart
+++ b/lib/model/desktop_settings.freezed.dart
@@ -1,0 +1,365 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'desktop_settings.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+DesktopSettings _$DesktopSettingsFromJson(Map<String, dynamic> json) {
+  return _DesktopSettings.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DesktopSettings {
+  DesktopWindowSettings get window => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $DesktopSettingsCopyWith<DesktopSettings> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DesktopSettingsCopyWith<$Res> {
+  factory $DesktopSettingsCopyWith(
+          DesktopSettings value, $Res Function(DesktopSettings) then) =
+      _$DesktopSettingsCopyWithImpl<$Res, DesktopSettings>;
+  @useResult
+  $Res call({DesktopWindowSettings window});
+
+  $DesktopWindowSettingsCopyWith<$Res> get window;
+}
+
+/// @nodoc
+class _$DesktopSettingsCopyWithImpl<$Res, $Val extends DesktopSettings>
+    implements $DesktopSettingsCopyWith<$Res> {
+  _$DesktopSettingsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? window = null,
+  }) {
+    return _then(_value.copyWith(
+      window: null == window
+          ? _value.window
+          : window // ignore: cast_nullable_to_non_nullable
+              as DesktopWindowSettings,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $DesktopWindowSettingsCopyWith<$Res> get window {
+    return $DesktopWindowSettingsCopyWith<$Res>(_value.window, (value) {
+      return _then(_value.copyWith(window: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$DesktopSettingsImplCopyWith<$Res>
+    implements $DesktopSettingsCopyWith<$Res> {
+  factory _$$DesktopSettingsImplCopyWith(_$DesktopSettingsImpl value,
+          $Res Function(_$DesktopSettingsImpl) then) =
+      __$$DesktopSettingsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({DesktopWindowSettings window});
+
+  @override
+  $DesktopWindowSettingsCopyWith<$Res> get window;
+}
+
+/// @nodoc
+class __$$DesktopSettingsImplCopyWithImpl<$Res>
+    extends _$DesktopSettingsCopyWithImpl<$Res, _$DesktopSettingsImpl>
+    implements _$$DesktopSettingsImplCopyWith<$Res> {
+  __$$DesktopSettingsImplCopyWithImpl(
+      _$DesktopSettingsImpl _value, $Res Function(_$DesktopSettingsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? window = null,
+  }) {
+    return _then(_$DesktopSettingsImpl(
+      window: null == window
+          ? _value.window
+          : window // ignore: cast_nullable_to_non_nullable
+              as DesktopWindowSettings,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DesktopSettingsImpl implements _DesktopSettings {
+  const _$DesktopSettingsImpl({this.window = const DesktopWindowSettings()});
+
+  factory _$DesktopSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DesktopSettingsImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final DesktopWindowSettings window;
+
+  @override
+  String toString() {
+    return 'DesktopSettings(window: $window)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DesktopSettingsImpl &&
+            (identical(other.window, window) || other.window == window));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, window);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DesktopSettingsImplCopyWith<_$DesktopSettingsImpl> get copyWith =>
+      __$$DesktopSettingsImplCopyWithImpl<_$DesktopSettingsImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DesktopSettingsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DesktopSettings implements DesktopSettings {
+  const factory _DesktopSettings({final DesktopWindowSettings window}) =
+      _$DesktopSettingsImpl;
+
+  factory _DesktopSettings.fromJson(Map<String, dynamic> json) =
+      _$DesktopSettingsImpl.fromJson;
+
+  @override
+  DesktopWindowSettings get window;
+  @override
+  @JsonKey(ignore: true)
+  _$$DesktopSettingsImplCopyWith<_$DesktopSettingsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+DesktopWindowSettings _$DesktopWindowSettingsFromJson(
+    Map<String, dynamic> json) {
+  return _DesktopWindowSettings.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DesktopWindowSettings {
+  double? get x => throw _privateConstructorUsedError;
+  double? get y => throw _privateConstructorUsedError;
+  double get w => throw _privateConstructorUsedError;
+  double get h => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $DesktopWindowSettingsCopyWith<DesktopWindowSettings> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DesktopWindowSettingsCopyWith<$Res> {
+  factory $DesktopWindowSettingsCopyWith(DesktopWindowSettings value,
+          $Res Function(DesktopWindowSettings) then) =
+      _$DesktopWindowSettingsCopyWithImpl<$Res, DesktopWindowSettings>;
+  @useResult
+  $Res call({double? x, double? y, double w, double h});
+}
+
+/// @nodoc
+class _$DesktopWindowSettingsCopyWithImpl<$Res,
+        $Val extends DesktopWindowSettings>
+    implements $DesktopWindowSettingsCopyWith<$Res> {
+  _$DesktopWindowSettingsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? x = freezed,
+    Object? y = freezed,
+    Object? w = null,
+    Object? h = null,
+  }) {
+    return _then(_value.copyWith(
+      x: freezed == x
+          ? _value.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double?,
+      y: freezed == y
+          ? _value.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double?,
+      w: null == w
+          ? _value.w
+          : w // ignore: cast_nullable_to_non_nullable
+              as double,
+      h: null == h
+          ? _value.h
+          : h // ignore: cast_nullable_to_non_nullable
+              as double,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$DesktopWindowSettingsImplCopyWith<$Res>
+    implements $DesktopWindowSettingsCopyWith<$Res> {
+  factory _$$DesktopWindowSettingsImplCopyWith(
+          _$DesktopWindowSettingsImpl value,
+          $Res Function(_$DesktopWindowSettingsImpl) then) =
+      __$$DesktopWindowSettingsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({double? x, double? y, double w, double h});
+}
+
+/// @nodoc
+class __$$DesktopWindowSettingsImplCopyWithImpl<$Res>
+    extends _$DesktopWindowSettingsCopyWithImpl<$Res,
+        _$DesktopWindowSettingsImpl>
+    implements _$$DesktopWindowSettingsImplCopyWith<$Res> {
+  __$$DesktopWindowSettingsImplCopyWithImpl(_$DesktopWindowSettingsImpl _value,
+      $Res Function(_$DesktopWindowSettingsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? x = freezed,
+    Object? y = freezed,
+    Object? w = null,
+    Object? h = null,
+  }) {
+    return _then(_$DesktopWindowSettingsImpl(
+      x: freezed == x
+          ? _value.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double?,
+      y: freezed == y
+          ? _value.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double?,
+      w: null == w
+          ? _value.w
+          : w // ignore: cast_nullable_to_non_nullable
+              as double,
+      h: null == h
+          ? _value.h
+          : h // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DesktopWindowSettingsImpl implements _DesktopWindowSettings {
+  const _$DesktopWindowSettingsImpl(
+      {this.x = null, this.y = null, this.w = 400, this.h = 700});
+
+  factory _$DesktopWindowSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DesktopWindowSettingsImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final double? x;
+  @override
+  @JsonKey()
+  final double? y;
+  @override
+  @JsonKey()
+  final double w;
+  @override
+  @JsonKey()
+  final double h;
+
+  @override
+  String toString() {
+    return 'DesktopWindowSettings(x: $x, y: $y, w: $w, h: $h)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DesktopWindowSettingsImpl &&
+            (identical(other.x, x) || other.x == x) &&
+            (identical(other.y, y) || other.y == y) &&
+            (identical(other.w, w) || other.w == w) &&
+            (identical(other.h, h) || other.h == h));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, x, y, w, h);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DesktopWindowSettingsImplCopyWith<_$DesktopWindowSettingsImpl>
+      get copyWith => __$$DesktopWindowSettingsImplCopyWithImpl<
+          _$DesktopWindowSettingsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DesktopWindowSettingsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DesktopWindowSettings implements DesktopWindowSettings {
+  const factory _DesktopWindowSettings(
+      {final double? x,
+      final double? y,
+      final double w,
+      final double h}) = _$DesktopWindowSettingsImpl;
+
+  factory _DesktopWindowSettings.fromJson(Map<String, dynamic> json) =
+      _$DesktopWindowSettingsImpl.fromJson;
+
+  @override
+  double? get x;
+  @override
+  double? get y;
+  @override
+  double get w;
+  @override
+  double get h;
+  @override
+  @JsonKey(ignore: true)
+  _$$DesktopWindowSettingsImplCopyWith<_$DesktopWindowSettingsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/model/desktop_settings.g.dart
+++ b/lib/model/desktop_settings.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'desktop_settings.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$DesktopSettingsImpl _$$DesktopSettingsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DesktopSettingsImpl(
+      window: json['window'] == null
+          ? const DesktopWindowSettings()
+          : DesktopWindowSettings.fromJson(
+              json['window'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$DesktopSettingsImplToJson(
+        _$DesktopSettingsImpl instance) =>
+    <String, dynamic>{
+      'window': instance.window.toJson(),
+    };
+
+_$DesktopWindowSettingsImpl _$$DesktopWindowSettingsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DesktopWindowSettingsImpl(
+      x: (json['x'] as num?)?.toDouble() ?? null,
+      y: (json['y'] as num?)?.toDouble() ?? null,
+      w: (json['w'] as num?)?.toDouble() ?? 400,
+      h: (json['h'] as num?)?.toDouble() ?? 700,
+    );
+
+Map<String, dynamic> _$$DesktopWindowSettingsImplToJson(
+        _$DesktopWindowSettingsImpl instance) =>
+    <String, dynamic>{
+      'x': instance.x,
+      'y': instance.y,
+      'w': instance.w,
+      'h': instance.h,
+    };

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -9,6 +9,7 @@ import 'package:miria/repository/account_repository.dart';
 import 'package:miria/repository/account_settings_repository.dart';
 import 'package:miria/repository/antenna_timeline_repository.dart';
 import 'package:miria/repository/channel_time_line_repository.dart';
+import 'package:miria/repository/desktop_settings_repository.dart';
 import 'package:miria/repository/emoji_repository.dart';
 import 'package:miria/repository/favorite_repository.dart';
 import 'package:miria/repository/general_settings_repository.dart';
@@ -237,6 +238,9 @@ final accountSettingsRepositoryProvider =
 
 final generalSettingsRepositoryProvider =
     ChangeNotifierProvider((ref) => GeneralSettingsRepository());
+
+final desktopSettingsRepositoryProvider =
+    ChangeNotifierProvider((ref) => DesktopSettingsRepository());
 
 final errorEventProvider =
     StateProvider<(Object? error, BuildContext? context)>(

--- a/lib/repository/desktop_settings_repository.dart
+++ b/lib/repository/desktop_settings_repository.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:miria/model/desktop_settings.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+
+class DesktopSettingsRepository extends ChangeNotifier {
+  var _settings = const DesktopSettings();
+  DesktopSettings get settings => _settings;
+
+  Future<void> load() async {
+    final f = File(await getSettingPath());
+    if (kDebugMode) print("path: ${f.path}");
+    try {
+      _settings = (await f.exists())
+          ? DesktopSettings.fromJson(await json.decode(await f.readAsString()))
+          : const DesktopSettings();
+    } catch (e) {
+      if (kDebugMode) print(e);
+      _settings = const DesktopSettings();
+    }
+  }
+
+  Future<void> update(DesktopSettings settings) async {
+    _settings = settings;
+    notifyListeners();
+
+    final f = File(await getSettingPath());
+    await f.writeAsString(jsonEncode(settings.toJson()));
+  }
+
+  Future<String> getSettingPath() async {
+    return join(
+        (await getApplicationSupportDirectory()).path, "desktopSettings.json");
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,7 +9,9 @@
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
+#include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
@@ -21,7 +23,13 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) media_kit_video_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitVideoPlugin");
   media_kit_video_plugin_register_with_registrar(media_kit_video_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
+  screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,7 +6,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
   media_kit_libs_linux
   media_kit_video
+  screen_retriever
   url_launcher_linux
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -47,10 +47,11 @@ static void my_application_activate(GApplication* application) {
     gtk_window_set_title(window, "miria");
   }
 
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  gtk_window_set_icon_from_file(window, g_strconcat(fl_dart_project_get_assets_path(project), "/assets/images/icon.png", NULL), NULL);
   gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));
 
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
 
   FlView* view = fl_view_new(project);

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -50,7 +50,7 @@ static void my_application_activate(GApplication* application) {
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   gtk_window_set_icon_from_file(window, g_strconcat(fl_dart_project_get_assets_path(project), "/assets/images/icon.png", NULL), NULL);
   gtk_window_set_default_size(window, 1280, 720);
-  gtk_widget_show(GTK_WIDGET(window));
+  gtk_widget_realize(GTK_WIDGET(window));
 
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,11 +14,13 @@ import media_kit_video
 import package_info_plus
 import path_provider_foundation
 import screen_brightness_macos
+import screen_retriever
 import share_plus
 import shared_preferences_foundation
 import sqflite
 import url_launcher_macos
 import wakelock_plus
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
@@ -30,9 +32,11 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
+  ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -25,6 +25,8 @@ PODS:
     - FlutterMacOS
   - screen_brightness_macos (0.1.0):
     - FlutterMacOS
+  - screen_retriever (0.0.1):
+    - FlutterMacOS
   - share_plus (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
@@ -36,6 +38,8 @@ PODS:
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
   - wakelock_plus (0.0.1):
+    - FlutterMacOS
+  - window_manager (0.2.0):
     - FlutterMacOS
 
 DEPENDENCIES:
@@ -50,11 +54,13 @@ DEPENDENCIES:
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - screen_brightness_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos`)
+  - screen_retriever (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
+  - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 SPEC REPOS:
   trunk:
@@ -83,6 +89,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   screen_brightness_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos
+  screen_retriever:
+    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
@@ -93,6 +101,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   wakelock_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
+  window_manager:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
   device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
@@ -107,11 +117,13 @@ SPEC CHECKSUMS:
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   screen_brightness_macos: 2d6d3af2165592d9a55ffcd95b7550970e41ebda
+  screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea
   url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
+  window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 
 PODFILE CHECKSUM: 76079db0da3234e173fb67f3880ef7f6fc358307
 

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import window_manager
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
@@ -11,5 +12,9 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+  }
+  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+    super.order(place, relativeTo: otherWin)
+    hiddenWindowAtLaunch()
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -744,6 +744,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -780,18 +804,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   matrix2d:
     dependency: "direct main"
     description:
@@ -876,10 +900,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mfm:
     dependency: "direct main"
     description:
@@ -965,10 +989,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_drawing:
     dependency: transitive
     description:
@@ -1233,6 +1257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.3"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.9"
   scrollable_positioned_list:
     dependency: "direct main"
     description:
@@ -1606,6 +1638,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   volume_controller:
     dependency: "direct main"
     description:
@@ -1702,6 +1742,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: b3c895bdf936c77b83c5254bec2e6b3f066710c1f89c38b20b8acc382b525494
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.8"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,8 @@ dependencies:
   media_kit_libs_video: ^1.0.3
   flutter_colorpicker: ^1.0.3
   volume_controller: ^2.0.7
+  window_manager: ^0.3.8
+
 
 dependency_overrides:
   image_editor:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,8 +11,10 @@
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin.h>
+#include <screen_retriever/screen_retriever_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
@@ -25,8 +27,12 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenBrightnessWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPlugin"));
+  ScreenRetrieverPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,8 +8,10 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_video
   permission_handler_windows
   screen_brightness_windows
+  screen_retriever
   share_plus
   url_launcher_windows
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -117,7 +117,8 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
   double scale_factor = dpi / 96.0;
 
   HWND window = CreateWindow(
-      window_class, title.c_str(), WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+      window_class, title.c_str(),
+      WS_OVERLAPPEDWINDOW, // do not add WS_VISIBLE since the window will be shown later
       Scale(origin.x, scale_factor), Scale(origin.y, scale_factor),
       Scale(size.width, scale_factor), Scale(size.height, scale_factor),
       nullptr, nullptr, GetModuleHandle(nullptr), this);


### PR DESCRIPTION
・[window_manager](https://pub.dev/packages/window_manager)を使用し、Win/Mac/Linuxで終了時にウィンドウサイズと位置を保存、次回起動時に復元するようにしました。
・Linuxでアイコン表示するようにしました。

Win10(22H2) / MacOS(14.2.1) / Linux(Debian 12)でとりあえず動作するのを確認済み。