### PR TITLE
`$[border.color`でカラーピッカーを表示

### DIFF
--- a/lib/view/common/note_create/mfm_fn_keyboard.dart
+++ b/lib/view/common/note_create/mfm_fn_keyboard.dart
@@ -210,7 +210,7 @@ class MfmFnKeyboard extends ConsumerWidget {
         controller.insert(arg.name.substring(queryLength));
       }
     }
-    if ((mfmFnName == "fg" || mfmFnName == "bg") && arg.name == "color") {
+    if ((mfmFnName == "fg" || mfmFnName == "bg" || mfmFnName == "border") && arg.name == "color") {
       final result = await showDialog<Color?>(
         context: parentContext,
         builder: (context) => const ColorPickerDialog(),


### PR DESCRIPTION
`$[border. ]`入力後、`color`を選択時に、`fg`, `bg`同様にカラーピッカーを表示する提案です。