### PR TITLE
federation_infoにHTML表示を使用する

### DIFF
--- a/lib/view/federation_page/federation_info.dart
+++ b/lib/view/federation_page/federation_info.dart
@@ -9,6 +9,8 @@ import 'package:miria/view/federation_page/federation_page.dart';
 import 'package:miria/view/themes/app_theme.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 class FederationInfo extends ConsumerStatefulWidget {
   final String host;
@@ -30,7 +32,7 @@ class FederationInfoState extends ConsumerState<FederationInfo> {
   Widget build(BuildContext context) {
     final data = ref.watch(federationPageFederationDataProvider);
     if (data != null) {
-      final description = data.description.replaceAll(htmlTagRemove, "");
+      final description = data.description;
       return SingleChildScrollView(
         child: Padding(
           padding:
@@ -63,7 +65,13 @@ class FederationInfoState extends ConsumerState<FederationInfo> {
                 ],
               ),
               const Padding(padding: EdgeInsets.only(top: 5)),
-              Text(description),
+              Html(
+                data: description,
+                style: {"a": Style(color: AppTheme.of(context).linkStyle.color)},
+                onLinkTap: (url, _, __, ___) {
+                  launchUrlString(url.toString());
+                } 
+              ),
               const Padding(padding: EdgeInsets.only(top: 5)),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -149,7 +157,13 @@ class FederationInfoState extends ConsumerState<FederationInfo> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           for (final rule in data.serverRules.indexed)
-                            Text("${(rule.$1 + 1)}. ${rule.$2}\n")
+                            Html(
+                              data: "${(rule.$1 + 1)}. ${rule.$2}<br>",
+                              style: {"a": Style(color: AppTheme.of(context).linkStyle.color)},
+                              onLinkTap: (url, _, __, ___) {
+                                launchUrlString(url.toString());
+                              }
+                            )
                         ],
                       )
                     ]),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -744,6 +744,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -780,18 +804,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   matrix2d:
     dependency: "direct main"
     description:
@@ -876,10 +900,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mfm:
     dependency: "direct main"
     description:
@@ -965,10 +989,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_drawing:
     dependency: transitive
     description:
@@ -1606,6 +1630,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   volume_controller:
     dependency: "direct main"
     description:


### PR DESCRIPTION
`flutter_html`を使用して、サーバー情報の概要欄と「サーバーの決めごと」をHTMLで表示する提案です。
これにより、Misskey.ioなどの一部Misskeyサーバーで使用されているHTMLタグが設定通りに表示されるようになります。

| 適用前 | 適用後 |
| :-: | :-: |
| ![Screenshot from 2024-03-02 00-27-02](https://github.com/shiosyakeyakini-info/miria/assets/66727014/819cd25f-8018-41f6-86a7-7b8144ead5ef) | ![Screenshot from 2024-03-02 00-19-13](https://github.com/shiosyakeyakini-info/miria/assets/66727014/4b86113d-8241-4a35-9f37-ca979ccb036a) |

※: 元々`pubspec.yaml`上に`flutter_html`が追加されていたものの未使用であったため、このPRを拒否する場合、`flutter_html`を削除（`flutter pub remove flutter_html`）しても良いと思います。