### PR TITLE
remote_modal_sheet にアイコンを追加

### DIFF
--- a/lib/view/common/misskey_notes/renote_modal_sheet.dart
+++ b/lib/view/common/misskey_notes/renote_modal_sheet.dart
@@ -67,6 +67,25 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                   .showSnackBar(SnackBar(content: Text(localize.renoted)));
               navigator.pop();
             }.expectFailure(context),
+            leading: const SizedBox(
+              height: 30,
+              width: 30,
+              child: Stack(
+                children: [
+                  Align(
+                    alignment: Alignment.bottomLeft,
+                    child: Icon(
+                      Icons.monitor,
+                      size: 24,
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.topRight,
+                    child: Icon(Icons.repeat, size: 18,)
+                  )
+                ],
+              ),
+            ),
             title: Padding(
               padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
               child: Text(S.of(context).renoteInSpecificChannel(channel.name)),
@@ -86,6 +105,25 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                   channel: channelsShowData,
                   initialAccount: widget.account));
             }.expectFailure(context),
+              leading: const SizedBox(
+                height: 30,
+                width: 30,
+                child: Stack(
+                  children: [
+                    Align(
+                      alignment: Alignment.bottomLeft,
+                      child: Icon(
+                        Icons.monitor,
+                        size: 24,
+                      ),
+                    ),
+                    Align(
+                      alignment: Alignment.topRight,
+                      child: Icon(Icons.format_quote, size: 18,)
+                    )
+                  ],
+                ),
+              ),
             title: Padding(
               padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
               child: Text(
@@ -111,6 +149,7 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                   .showSnackBar(SnackBar(content: Text(localize.renoted)));
               navigator.pop();
             }.expectFailure(context),
+            leading: const Icon(Icons.repeat),
             title: const Padding(
               padding: EdgeInsets.only(top: 10.0, bottom: 10.0),
               child: Text("Renote"),
@@ -149,6 +188,7 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                     renote: widget.note, initialAccount: widget.account));
                 navigator.pop();
               },
+              leading: const Icon(Icons.format_quote),
               title: Text(S.of(context).quotedRenote)),
           ListTile(
               onTap: () async {
@@ -174,6 +214,25 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                   navigator.pop();
                 }
               }.expectFailure(context),
+              leading: const SizedBox(
+                height: 30,
+                width: 30,
+                child: Stack(
+                  children: [
+                    Align(
+                      alignment: Alignment.bottomLeft,
+                      child: Icon(
+                        Icons.monitor,
+                        size: 24,
+                      ),
+                    ),
+                    Align(
+                      alignment: Alignment.topRight,
+                      child: Icon(Icons.repeat, size: 18,)
+                    )
+                  ],
+                ),
+              ),
               title: Text(widget.note.channel != null
                   ? S.of(context).renoteInOtherChannel
                   : S.of(context).renoteInChannel)),
@@ -193,6 +252,25 @@ class RenoteModalSheetState extends ConsumerState<RenoteModalSheet> {
                   navigator.pop();
                 }
               },
+              leading: const SizedBox(
+                height: 30,
+                width: 30,
+                child: Stack(
+                  children: [
+                    Align(
+                      alignment: Alignment.bottomLeft,
+                      child: Icon(
+                        Icons.monitor,
+                        size: 24,
+                      ),
+                    ),
+                    Align(
+                      alignment: Alignment.topRight,
+                      child: Icon(Icons.format_quote, size: 18,)
+                    )
+                  ],
+                ),
+              ),
               title: Text(widget.note.channel != null
                   ? S.of(context).quotedRenoteInOtherChannel
                   : S.of(context).quotedRenoteInOtherChannel)),


### PR DESCRIPTION
リノートメニューにアイコンを追加する提案です。

![1710149834713](https://github.com/shiosyakeyakini-info/miria/assets/66727014/e5b689f5-9975-4e77-b067-09796b6e676b)

Conflict with #565
```dart:修正
            leading: const Icon(Icons.repeat),
            title: Padding(
              padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
              child: Text(S.of(context).renote),
            ),
```