### PR TITLE
fix: 画像編集保存確認ボタンの翻訳キーを修正

### DIFF
--- a/lib/view/photo_edit_page/photo_edit_page.dart
+++ b/lib/view/photo_edit_page/photo_edit_page.dart
@@ -62,8 +62,8 @@ class PhotoEditPageState extends ConsumerState<PhotoEditPage> {
                     final confirm = await SimpleConfirmDialog.show(
                         context: context,
                         message: S.of(context).confirmSavingPhoto,
-                        primary: S.of(context).confirmSavingPhoto,
-                        secondary: S.of(context).doneEditingPhoto);
+                        primary: S.of(context).doneEditingPhoto,
+                        secondary: S.of(context).continueEditingPhoto);
 
                     final result =
                         await photoEdit.createSaveData(renderingAreaKey);


### PR DESCRIPTION
以前修正の要望があった、画像編集ページの保存確認メッセージのボタンの翻訳キーを修正