### PR TITLE
ワードミュートで正規表現のフラグに対応

### DIFF
--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -42,10 +42,21 @@ class NoteRepository extends ChangeNotifier {
         softMuteWordContents.add(content);
       }
       if (regExp != null) {
-        try {
-          softMuteWordRegExps
-              .add(RegExp(regExp.substring(1, regExp.length - 1)));
-        } catch (e) {}
+        final regExpAndFlags = RegExp(r'^\/(.+)\/(.*)$').firstMatch(regExp);
+        if (regExpAndFlags != null) {
+          try {
+            final flags = regExpAndFlags[2] ?? '';
+            softMuteWordRegExps.add(
+              RegExp(
+                regExpAndFlags[1]!,
+                multiLine: flags.contains('m'),
+                caseSensitive: !flags.contains('i'),
+                unicode: flags.contains('u'),
+                dotAll: flags.contains('s'),
+              ),
+            );
+          } catch (_) {}
+        }
       }
     }
 
@@ -56,10 +67,21 @@ class NoteRepository extends ChangeNotifier {
         hardMuteWordContents.add(content);
       }
       if (regExp != null) {
-        try {
-          hardMuteWordRegExps
-              .add(RegExp(regExp.substring(1, regExp.length - 1)));
-        } catch (e) {}
+        final regExpAndFlags = RegExp(r'^\/(.+)\/(.*)$').firstMatch(regExp);
+        if (regExpAndFlags != null) {
+          try {
+            final flags = regExpAndFlags[2] ?? '';
+            hardMuteWordRegExps.add(
+              RegExp(
+                regExpAndFlags[1]!,
+                multiLine: flags.contains('m'),
+                caseSensitive: !flags.contains('i'),
+                unicode: flags.contains('u'),
+                dotAll: flags.contains('s'),
+              ),
+            );
+          } catch (_) {}
+        }
       }
     }
   }


### PR DESCRIPTION
ワードミュートの正規表現にm, i, u, sのフラグが含まれている場合にRegExpの対応するプロパティを変更するようにしました

Fix #580 