### PR TITLE
fix: 簡易ノート投稿欄の投稿ボタン等を変更

### DIFF
--- a/lib/view/time_line_page/time_line_page.dart
+++ b/lib/view/time_line_page/time_line_page.dart
@@ -377,11 +377,11 @@ class TimeLinePageState extends ConsumerState<TimeLinePage> {
                   ),
                   IconButton(
                     onPressed: note.expectFailure(context),
-                    icon: const Icon(Icons.edit),
+                    icon: const Icon(Icons.send),
                   ),
                   IconButton(
                     onPressed: noteCreateRoute,
-                    icon: const Icon(Icons.keyboard_arrow_right),
+                    icon: const Icon(Icons.edit_note),
                   ),
                 ],
               ),


### PR DESCRIPTION
Close #451 

簡易投稿欄におけるボタンのアイコンを変更する提案です。

- 投稿ボタンを`edit`（ペン）から`send`（紙飛行機）に変更しました
  - Misskeyを始めAndroid SMSやLINEの投稿ボタンも紙飛行機アイコンが使用されていることから、統一した方がいいと思います
- ノート編集ページへのボタンを`keyboard_arrow_right`（右矢印）から`edit_note`（ノートを編集）に変更しました
  - 投稿ボタンを紙飛行機に変更したことでボタンの存在が認識しにくくなってしまったため、「編集の意味を持つもの」「ペン以外のもの（投稿ボタンとして捉えられる可能性があるため）」に変更しました
- ~~簡易投稿欄の左右に間隔を開けるように変更しました~~ →このPRでやる必要はないので削除

|変更前|変更後|
|:-:|:-:|
|![Screenshot from 2024-04-06 14-11-06](https://github.com/shiosyakeyakini-info/miria/assets/66727014/e7e627d1-5cb9-4028-bfc8-a81f7001c3e5)|![Screenshot from 2024-04-06 14-07-04](https://github.com/shiosyakeyakini-info/miria/assets/66727014/215a9c33-4fdd-40f9-b4ee-2a4d0e29b09f)|

> [!NOTE]
> アイコンの変更は、現在利用中のユーザーが混乱する可能性があります。