### PR TITLE
ログイン時にUnicode表記されたホストをpunycodeに変換する

### DIFF
--- a/lib/util/punycode.dart
+++ b/lib/util/punycode.dart
@@ -1,0 +1,15 @@
+import 'package:punycode/punycode.dart';
+
+String toAscii(String host) {
+  return host.splitMapJoin(
+    '.',
+    onNonMatch: (n) {
+      if (RegExp(r'[^\x00-\x7F]').hasMatch(n)) {
+        try {
+          return 'xn--${punycodeEncode(n)}';
+        } catch (_) {}
+      }
+      return n;
+    },
+  );
+}

--- a/lib/view/login_page/api_key_login.dart
+++ b/lib/view/login_page/api_key_login.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
+import 'package:miria/util/punycode.dart';
 import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:miria/view/common/modal_indicator.dart';
 import 'package:miria/view/login_page/centraing_widget.dart';
@@ -32,7 +33,7 @@ class APiKeyLoginState extends ConsumerState<ApiKeyLogin> {
       IndicatorView.showIndicator(context);
       await ref
           .read(accountRepositoryProvider.notifier)
-          .loginAsToken(serverController.text, apiKeyController.text);
+          .loginAsToken(toAscii(serverController.text), apiKeyController.text);
 
       if (!mounted) return;
       context.pushRoute(TimeLineRoute(

--- a/lib/view/login_page/mi_auth_login.dart
+++ b/lib/view/login_page/mi_auth_login.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:miria/providers.dart';
 import 'package:miria/router/app_router.dart';
+import 'package:miria/util/punycode.dart';
 import 'package:miria/view/common/error_dialog_handler.dart';
 import 'package:miria/view/common/modal_indicator.dart';
 import 'package:miria/view/login_page/centraing_widget.dart';
@@ -31,7 +32,7 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
       IndicatorView.showIndicator(context);
       await ref
           .read(accountRepositoryProvider.notifier)
-          .validateMiAuth(serverController.text);
+          .validateMiAuth(toAscii(serverController.text));
       if (!mounted) return;
       context.pushRoute(
         TimeLineRoute(
@@ -88,7 +89,7 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
                 onPressed: () {
                   ref
                       .read(accountRepositoryProvider.notifier)
-                      .openMiAuth(serverController.text)
+                      .openMiAuth(toAscii(serverController.text))
                       .expectFailure(context);
                   setState(() {
                     isAuthed = true;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1161,6 +1161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  punycode:
+    dependency: "direct main"
+    description:
+      name: punycode
+      sha256: "39b874cc1f78b94e57db17e74b3f2ba2a96e25c0bebdcc8a571614dccda0ff0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   receive_sharing_intent:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   volume_controller: ^2.0.7
   window_manager: ^0.3.8
   shared_preference_app_group: ^1.0.0+1
+  punycode: ^1.0.0
 
 dependency_overrides:
   image_editor:


### PR DESCRIPTION
MiAuthログインとAPIキーログインで入力されたホストをpunycodeに変換してからMisskeyサーバーの判定や認証を行うようにしました

Fix #567