### PR TITLE
feat: TextSelectionThemeの設定

### DIFF
--- a/lib/view/themes/app_theme_scope.dart
+++ b/lib/view/themes/app_theme_scope.dart
@@ -337,6 +337,11 @@ class AppThemeScopeState extends ConsumerState<AppThemeScope> {
         valueIndicatorColor: theme.panel,
         valueIndicatorShape: const RectangularSliderValueIndicatorShape(),
       ),
+      textSelectionTheme: TextSelectionThemeData(
+        cursorColor: theme.primary,
+        selectionColor: theme.accentedBackground,
+        selectionHandleColor: theme.primary,
+      )
     );
 
     return themeData;


### PR DESCRIPTION
`TextSelectionTheme`を指定する提案です。
これにより、テキスト入力時のカーソルの色などがテーマに沿ったものになります。
||変更前|変更後|
|:-:|:-:|:-:|
|`cursorColor`|![Screenshot from 2024-04-13 09-52-57](https://github.com/shiosyakeyakini-info/miria/assets/66727014/feea773a-0716-4d61-b2de-7bb294087a62)|![Screenshot from 2024-04-13 09-48-11](https://github.com/shiosyakeyakini-info/miria/assets/66727014/4860b179-d6c4-44a2-a2cb-e0deed987391)|
|`selectionColor`|![Screenshot from 2024-04-13 09-53-04](https://github.com/shiosyakeyakini-info/miria/assets/66727014/8ad13ba4-1090-40fd-8198-75db0f4866a3)|![Screenshot from 2024-04-13 09-48-20](https://github.com/shiosyakeyakini-info/miria/assets/66727014/4d63710e-7cf1-4a67-a10c-f786d49ce7de)|

（テーマによって`accentedBackground`が見えにくいところがあるので要改善）