### PR TITLE
アカウント情報タブのユーザー名でspinなどのMFMが使えてしまうのを修正

### DIFF
--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -169,10 +169,10 @@ class UserDetail extends ConsumerWidget {
                         mainAxisAlignment: MainAxisAlignment.start,
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          MfmText(
-                            mfmText: response.name ?? response.username,
+                          SimpleMfmText(
+                            response.name ?? response.username,
                             style: Theme.of(context).textTheme.headlineSmall,
-                            emoji: response.emojis,
+                            emojis: response.emojis,
                           ),
                           Text(
                             response.acct,


### PR DESCRIPTION
MfmTextからSimpleMfmTextに変更しました