### PR TITLE
[Linux] (snap) `CRAFT_ARCH_TRIPLET`を`CRAFT_ARCH_TRIPLET_BUILD_FOR`へ

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ apps:
       - removable-media # カメラのSDカードから直接取り込むユーザー向け
       - password-manager-service # ログイン情報の保存＆読み込みのため必須
     environment:
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/lapack
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack
 
 parts:
   miria:


### PR DESCRIPTION
`CRAFT_ARCH_TRIPLET`がdeprecatedとなったため