### PR TITLE
[Linux] (snap) zenityの`layout`変更 及び core22等の重複ファイルのクリーンアップを追加

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,6 +97,16 @@ parts:
       - usr/share/zenity/*
       - usr/share/doc/*/copyright*
 
+  cleanup:
+    after: [miria, zenity]  # Make this part run last; list all your other parts here
+    plugin: nil
+    build-snaps: [gnome-42-2204, gtk-common-themes, core22]  # List all content-snaps you're using here
+    override-prime: |
+      set -eux
+      for snap in "gnome-42-2204" "gtk-common-themes" "core22"; do  # List all content-snaps you're using here
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" "$SNAPCRAFT_PRIME/usr/{}" \;
+      done
+
 layout:
   # Fix resource relocation problem of zenity part
   /usr/share/zenity:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,12 +87,20 @@ parts:
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/
 
   zenity:
+  # Integrate custom dialogs in your snap - doc - snapcraft.io
+  # https://forum.snapcraft.io/t/integrate-custom-dialogs-in-your-snap/10825
     plugin: nil
     stage-packages:
       - zenity
     prime:
       - usr/bin/zenity
       - usr/share/zenity/*
+      - usr/share/doc/*/copyright*
+
+layout:
+  # Fix resource relocation problem of zenity part
+  /usr/share/zenity:
+    symlink: $SNAP/usr/share/zenity
 
 lint:
   ignore:


### PR DESCRIPTION
- zenityのリソースが正しく配置されるよう変更しました
  - これに併せてコピーライトなどのドキュメントを含めるようにしました
  - 参考: https://forum.snapcraft.io/t/support-presenting-gui-dialogs-using-zenity/41218
- `core22`などのベースSnapと共有されるライブラリなどを削除するようにしました
  - これによりSnapファイルのサイズが100MB程度に削減されます