### PR TITLE
[iOS] バックライトの輝度が変わってしまう問題の修正

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import "package:miria/view/common/error_dialog_listener.dart";
 import "package:miria/view/common/sharing_intent_listener.dart";
 import "package:miria/view/themes/app_theme_scope.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
+import "package:screen_brightness/screen_brightness.dart";
 import "package:stack_trace/stack_trace.dart" as stack_trace;
 import "package:window_manager/window_manager.dart";
 
@@ -26,6 +27,9 @@ Future<void> main() async {
   MediaKit.ensureInitialized();
   if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
     await windowManager.ensureInitialized();
+  }
+  if (Platform.isIOS) {
+    await ScreenBrightness().setAutoReset(false);
   }
   FlutterError.demangleStackTrace = (stack) {
     if (stack is stack_trace.Trace) return stack.vmTrace;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1322,7 +1322,7 @@ packages:
     source: hosted
     version: "1.0.2"
   screen_brightness:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: screen_brightness
       sha256: ed8da4a4511e79422fc1aa88138e920e4008cd312b72cdaa15ccb426c0faaedd

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,7 @@ dependencies:
   hooks_riverpod: ^3.0.0-dev.3
   flutter_hooks: ^0.20.5
   punycode: ^1.0.0
+  screen_brightness: ^0.2.2
 
 dependency_overrides:
   image_editor:


### PR DESCRIPTION
iOSで動画再生後にバックライトの輝度がサスペンド復帰時などに変わってしまう問題を修正しました。

**不具合再現手順**
1. 部屋を明るくしておく
2. Miria上で任意の動画を再生してプレイヤーを閉じる
3. 画面オフ
4. 環境光センサーを指などで隠してから画面をオンにしてロック解除