### PR TITLE
ダブルタップ後の上下ズームが動作していないのを修正

### DIFF
--- a/lib/view/common/image_dialog.dart
+++ b/lib/view/common/image_dialog.dart
@@ -110,7 +110,7 @@ class ImageDialog extends HookConsumerWidget {
                           final v = transformationController.toScene(position);
 
                           transformationController.value = Matrix4.identity()
-                            ..scale(scale);
+                            ..scale(scale.value);
 
                           final v2 =
                               transformationController.toScene(position) - v;


### PR DESCRIPTION
ImageDialogでダブルタップ後の上下ズームが機能しなくなっていたのを修正しました