### PR TITLE
絵文字名で絵文字を取得するときのパフォーマンス改善

### DIFF
--- a/lib/model/misskey_emoji_data.dart
+++ b/lib/model/misskey_emoji_data.dart
@@ -44,11 +44,10 @@ sealed class MisskeyEmojiData {
     // 自分のサーバー :ai@.:
     if (customEmojiRegExp.hasMatch(emojiName)) {
       assert(repository != null);
-      final found = repository!.emoji?.firstWhereOrNull(
-        (e) =>
-            e.emoji.baseName ==
-            (customEmojiRegExp.firstMatch(emojiName)?.group(1) ?? emojiName),
-      );
+      final name =
+          customEmojiRegExp.firstMatch(emojiName)?.group(1) ?? emojiName;
+      final found = repository!.emojiMap?[name];
+
       if (found != null) {
         return found.emoji;
       } else {
@@ -60,12 +59,9 @@ sealed class MisskeyEmojiData {
     final customEmojiRegExp2 = RegExp(r"^:(.+?):$");
     if (customEmojiRegExp2.hasMatch(emojiName)) {
       assert(repository != null);
-      final found = repository!.emoji?.firstWhereOrNull(
-        (e) =>
-            e.emoji.baseName ==
-            (customEmojiRegExp2.firstMatch(emojiName)?.group(1) ?? emojiName),
-      );
-
+      final name =
+          customEmojiRegExp2.firstMatch(emojiName)?.group(1) ?? emojiName;
+      final found = repository!.emojiMap?[name];
       if (found != null) {
         return found.emoji;
       } else {

--- a/lib/repository/emoji_repository.dart
+++ b/lib/repository/emoji_repository.dart
@@ -224,10 +224,7 @@ class EmojiRepositoryImpl extends EmojiRepository {
       return [];
     } else {
       return reactionDeck
-          .map(
-            (e) => emoji
-                ?.firstWhereOrNull((element) => element.emoji.baseName == e),
-          )
+          .map((e) => emojiMap?[e])
           .whereNotNull()
           .map((e) => e.emoji)
           .toList();

--- a/lib/repository/emoji_repository.dart
+++ b/lib/repository/emoji_repository.dart
@@ -1,3 +1,4 @@
+import "dart:collection";
 import "dart:convert";
 
 import "package:collection/collection.dart";
@@ -13,6 +14,7 @@ import "package:misskey_dart/misskey_dart.dart";
 
 abstract class EmojiRepository {
   List<EmojiRepositoryData>? emoji;
+  Map<String, EmojiRepositoryData>? emojiMap;
   Future<void> loadFromSourceIfNeed();
   Future<void> loadFromSource();
 
@@ -150,6 +152,12 @@ class EmojiRepositoryImpl extends EmojiRepository {
         )
         .toList();
     emoji!.addAll(unicodeEmojis);
+
+    emojiMap = HashMap<String, EmojiRepositoryData>.fromIterable(
+      emoji!,
+      key: (e) => (e as EmojiRepositoryData).emoji.baseName,
+      value: (e) => e,
+    );
   }
 
   bool emojiSearchCondition(


### PR DESCRIPTION
保有しているAndroid端末では気になる程度にフレームレートが低下していたため
MisskeyEmojiData.fromEmojiName内のfirstWhereOrNullを、絵文字のbasenameをキーとするHashMapから取得するように変更しました。
