### PR TITLE
各種deployおよびdart_testにおける`.fvmrc`対応

### DIFF
--- a/.github/workflows/aab_deploy.yml
+++ b/.github/workflows/aab_deploy.yml
@@ -17,10 +17,13 @@ jobs:
     steps:
         - uses: actions/checkout@v4
 
+        - name: Get Flutter version from .fvmrc
+          run:  echo "FLUTTER_FVM_VERSION=$(jq -r .flutter .fvmrc)" >> $GITHUB_ENV
+
         - name: Install flutter
           uses: subosito/flutter-action@v2
           with:
-            channel: 'stable'
+            flutter-version: ${{ env.FLUTTER_FVM_VERSION }}
             cache: true
 
         - uses: actions/setup-java@v4

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -25,10 +25,13 @@ jobs:
 
       - run: dart format --output=none --set-exit-if-changed .
 
+      - name: Get Flutter version from .fvmrc
+        run:  echo "FLUTTER_FVM_VERSION=$(jq -r .flutter .fvmrc)" >> $GITHUB_ENV
+
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: ${{ env.FLUTTER_FVM_VERSION }}
           cache: true
 
       - name: Run flutter version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,13 @@ jobs:
     steps:
         - uses: actions/checkout@v4
 
+        - name: Get Flutter version from .fvmrc
+          run:  echo "FLUTTER_FVM_VERSION=$(jq -r .flutter .fvmrc)" >> $GITHUB_ENV
+
         - name: Install flutter
           uses: subosito/flutter-action@v2
           with:
-            channel: 'stable'
+            flutter-version: ${{ env.FLUTTER_FVM_VERSION }}
             cache: true
 
         - uses: actions/setup-java@v4

--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -15,10 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get Flutter version from .fvmrc
+        run:  echo "FLUTTER_FVM_VERSION=$(jq -r .flutter .fvmrc)" >> $env:GITHUB_ENV
+
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: ${{ env.FLUTTER_FVM_VERSION }}
           cache: true
 
       - name: Flutter pub get


### PR DESCRIPTION
Related to #606 
`flutter-action`において`channel`の代わりに`flutter-version`を指定して`.fvmrc`で指定されたFlutterバージョンを使用するようにしました