### PR TITLE
[Linux](snap) Update snapcraft.yaml's description

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,10 +3,6 @@ title: Miria
 type: app
 summary: Misskey Client App # 79文字まで
 description: |
-  **NOTE: Allow access to `password-manager-service` after installation.**
-  ```
-  $ snap connect miria:password-manager-service
-  ```
   Miria is Misskey Client App for iOS, Android and many targets which made by Flutter.
   Miria includes these features.
   - Login, Logout, Management multiple servers and accounts


### PR DESCRIPTION
手動で`password-manager-service`へ接続する操作が不要になっていることが確認されたため、概要文の注意書きを削除しました。