### PR TITLE
フォロワーへのメッセージにおいてカスタム絵文字が表示できるように

### DIFF
--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -234,6 +234,7 @@ class UserDetail extends ConsumerWidget {
                     S
                         .of(context)
                         .messageForFollower(response.followedMessage ?? ""),
+                    emojis: response.emojis,
                   ),
                 ),
               const Padding(padding: EdgeInsets.only(top: 5)),


### PR DESCRIPTION
Misskeyサーバー側で2024.10.1より後のバージョンであるのが条件
Fix #650
Related to https://github.com/misskey-dev/misskey/pull/14904