### PR TITLE
リモートのユーザーページをブラウザで開くときに`uri`ではなく`url`を優先する

### DIFF
--- a/lib/view/user_page/user_control_dialog.dart
+++ b/lib/view/user_page/user_control_dialog.dart
@@ -96,7 +96,7 @@ class UserControlDialog extends HookConsumerWidget implements AutoRouteWrapper {
       Navigator.of(context).pop();
     });
     final openBrowserAsRemote = useAsync(() async {
-      final uri = response.uri ?? response.url;
+      final uri = response.url ?? response.uri;
       if (uri == null) return;
       await launchUrl(uri, mode: LaunchMode.externalApplication);
       if (!context.mounted) return;


### PR DESCRIPTION
リモートのユーザーページをブラウザで開くときに`uri`ではなく`url`を優先するようにしました

（PRの背景：Threadsの返す`uri`が`https://threads.net/ap/users/xxxxxx`であり、この`uri`をブラウザで開くと`{"success":false,"error":"Not found"}`のみが表示されるため。ブラウザで開くには`https://threads.net/@userId`の形式である`url`を選択する必要がある）