### PR TITLE
翻訳キーの追加、修正など

### DIFF
--- a/lib/l10n/app_ja-oj.arb
+++ b/lib/l10n/app_ja-oj.arb
@@ -108,9 +108,9 @@
     "confirmCreateBlock": "ブロックなさりますの？",
 
     "unsupportedFile": "対応してないファイルのようですわ",
-    "failedFileSave": "ファイルの保存に失敗したようですわね…"
+    "failedFileSave": "ファイルの保存に失敗したようですわね…",
 
-
+    "nothingHere": "ここには何もありませんわ"
 
 
 

--- a/lib/l10n/app_ja-oj.arb
+++ b/lib/l10n/app_ja-oj.arb
@@ -8,7 +8,6 @@
     "noneAction": "なにもいたしませんわ",
     "pleaseInput": "お入れなさって",
     "pleaseSelect": "お選びになさって",
-    "clipDescription": "説明（なくてもよろしくてよ）",
 
     "serverRules": "サーバーの定め",
     "antennaSourceUserHintText": "ユーザーネームを改行で区切って指定いたしますわ",
@@ -21,9 +20,6 @@
     "receiveLocalAvailability": "ローカルのみの指定はMisskey 2023.10.2以降で有効ですこと",
     "confirmDeletingAntenna": "アンテナを削除いたしますこと？",
     "channelJoinningCounts": "{usersCount}人が参加なされてますわ",
-
-    "willFavorite": "お気に入りに入れますわ",
-    "willFollow": "フォローいたしますわ",
 
     "confirmDeleteClip": "クリップを削除いたしますこと？",
     "clipDescription": "説明（省略されてもよろしくてよ）",
@@ -58,6 +54,8 @@
     "openAsOtherAccount": "開くアカウントを選びなさって",
     "pickColor": "色を選びなさって",
     "decideColor": "これにいたしますわ",
+    "replyNotePlaceholder": "何と送りますの？",
+    "defaultNotePlaceholder": "ごきげんよう",
 
     "followedNotification": "{userName}からフォローされましてよ",
     "followRequestAcceptedNotification": "{userName}がフォローしてもよくってよとお聞きいたしましたわ",
@@ -105,6 +103,9 @@
     "pleaseSpecifyExpirationDuration": "投票期間を入れてくださいまし？",
     "cannotMentionToRemoteInLocalOnlyNote": "連合切られているのに他のサーバーの人がメンションに含まれているようですわ",
     "cannotPublicReplyToPrivateNote": "リプライが{visibility}のようでして……パブリックにはできませんこと",
+
+    "memoDescription": "メモしたいことをお書きくださいまし",
+    "confirmCreateBlock": "ブロックなさりますの？",
 
     "unsupportedFile": "対応してないファイルのようですわ",
     "failedFileSave": "ファイルの保存に失敗したようですわね…"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1005,6 +1005,12 @@
             }
         }
     },
-    "nonInvitedReversi": "招待はされとらへんみたいや"
+    "nonInvitedReversi": "招待はされとらへんみたいや",
+
+    "remoteServerWithoutLogin": "相手先のサーバー（ログインなし）",
+    "nothingHere": "なんもないで",
+
+    "deckMode": "デッキモード",
+    "enableDeckMode": "デッキモードにする"
 
 }

--- a/lib/view/common/account_select_dialog.dart
+++ b/lib/view/common/account_select_dialog.dart
@@ -48,7 +48,7 @@ class AccountSelectDialog extends HookConsumerWidget {
                   ),
                 _ => ListTile(
                     leading: const Icon(Icons.language),
-                    title: const Text("相手先のサーバー（ログインなし）"),
+                    title: Text(S.of(context).remoteServerWithoutLogin),
                     onTap: navigateAsRemote.executeOrNull,
                   ),
               },

--- a/lib/view/common/pushable_listview.dart
+++ b/lib/view/common/pushable_listview.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
+import "package:flutter_gen/gen_l10n/app_localizations.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:miria/model/general_settings.dart";
@@ -119,10 +120,10 @@ class PushableListView<T> extends HookConsumerWidget {
             }
 
             if (items.value.isEmpty && !hideIsEmpty) {
-              return const Center(
+              return Center(
                 child: Padding(
-                  padding: EdgeInsets.all(10),
-                  child: Text("なんもないで"),
+                  padding: const EdgeInsets.all(10),
+                  child: Text(S.of(context).nothingHere),
                 ),
               );
             }

--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -178,9 +178,9 @@ class GeneralSettingsPage extends HookConsumerWidget {
                         onChanged: (value) async =>
                             automaticPush.value = value ?? AutomaticPush.none,
                       ),
-                      const Text("デッキモード"), //TODO: localize
+                      Text(S.of(context).deckMode),
                       CheckboxListTile(
-                        title: const Text("デッキモードにします。"),
+                        title: Text(S.of(context).enableDeckMode),
                         value: isDeckMode.value,
                         onChanged: (value) => isDeckMode.value = value ?? false,
                       ),


### PR DESCRIPTION
- 重複した翻訳キーを削除しました
- 不足していたお嬢様語翻訳を追加しました
  - `"confirmCreateBlock": "ブロックなさりますの？",`など、翻訳として適切であるか不明な点があるため、最適な翻訳に置き換えてください
- 一部翻訳キーを追加しました