### PR TITLE
[Windows] 削除されていたDLLファイルを一部削除しないように

### DIFF
--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -41,10 +41,6 @@ jobs:
       - name: Delete unnecessary DLL
         run: |
           rm build\windows\x64\runner\Release\api-ms-*.dll
-          rm build\windows\x64\runner\Release\concrt140.dll
-          rm build\windows\x64\runner\Release\msvcp*.dll
-          rm build\windows\x64\runner\Release\ucrtbas*.dll
-          rm build\windows\x64\runner\Release\vc*.dll
 
       - name: Get translation files for Inno Setup
         run: |

--- a/windows/innosetup.iss
+++ b/windows/innosetup.iss
@@ -59,7 +59,3 @@ Type: files; Name: {userappdata}\info.shiosyakeyakini\miria\*
 
 [InstallDelete]
 Type: files; Name: {app}/api-ms-*.dll
-Type: files; Name: {app}/concrt140.dll
-Type: files; Name: {app}/msvcp*.dll
-Type: files; Name: {app}/ucrtbas*.dll
-Type: files; Name: {app}/vc*.dll


### PR DESCRIPTION
```
msvcp*.dll
vc*.dll
concrt*.dll
ucrtbas*.dll
```
上記をWindows用インストーラー作成前に削除しないように修正しました

Related to #516
Related to #610