### PR TITLE
「続きを読み込む」ボタンを横広に

### DIFF
--- a/lib/view/common/pushable_listview.dart
+++ b/lib/view/common/pushable_listview.dart
@@ -154,13 +154,12 @@ class PushableListView<T> extends HookConsumerWidget {
                           const SizedBox.shrink(),
                     ],
                   ),
-                Center(
-                  child: Padding(
-                    padding: const EdgeInsets.only(top: 10, bottom: 10),
-                    child: IconButton(
-                      onPressed: nextLoad,
-                      icon: const Icon(Icons.keyboard_arrow_down),
-                    ),
+                InkWell(
+                  onTap: nextLoad,
+                  child: Container(
+                    alignment: Alignment.center,
+                    height: 60,
+                    child: const Icon(Icons.keyboard_arrow_down),
                   ),
                 ),
               ],

--- a/lib/view/time_line_page/misskey_time_line.dart
+++ b/lib/view/time_line_page/misskey_time_line.dart
@@ -125,9 +125,14 @@ class MisskeyTimeline extends HookConsumerWidget {
             }
 
             return Center(
-              child: IconButton(
-                onPressed: downDirectionLoad,
-                icon: const Icon(Icons.keyboard_arrow_down),
+              child: InkWell(
+                onTap: downDirectionLoad,
+                child: Container(
+                  alignment: Alignment.center,
+                  constraints: const BoxConstraints(maxWidth: 800),
+                  height: 60,
+                  child: const Icon(Icons.keyboard_arrow_down),
+                ),
               ),
             );
           }

--- a/test/test_util/widget_tester_extension.dart
+++ b/test/test_util/widget_tester_extension.dart
@@ -15,8 +15,8 @@ extension WidgetTestExtension on WidgetTester {
     await tap(
       find.descendant(
         of: find.descendant(
-          of: find.byType(Center),
-          matching: find.byType(IconButton).hitTestable(),
+          of: find.byType(InkWell),
+          matching: find.byType(Container).hitTestable(),
         ),
         matching: find.byIcon(Icons.keyboard_arrow_down),
       ),


### PR DESCRIPTION
「続きを読み込む」ボタン(`keyboard_arrow_down`アイコン)を`Center(Padding(IconButton()))`から`InkWell(Container())`で横広に変更しました

（PRの背景：マウスでアイコン単体を選択するまでの距離が遠かったり、指でたまにタップしそこねるときがある）
![Screenshot from 2024-11-16 09-56-06](https://github.com/user-attachments/assets/8d732fd1-69a8-4bd0-b94f-361c4de05721)