### PR TITLE
デプロイ前にバージョンの更新種類を選択できるように

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,18 @@
 name: デプロイ
 
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+    inputs:
+      bump_version:
+        description: 'Bump Version'
+        required: true
+        default: 'build'
+        type: choice
+        options:
+          - build
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -59,7 +71,7 @@ jobs:
 
         - name: Bump up version
           run: |
-            flutter pub run cider bump build --bump-build
+            flutter pub run cider bump ${{ inputs.bump_version }} --bump-build
             echo "BUMP_VERSION=$(flutter pub run cider version)" >> $GITHUB_ENV
 
         - name: Commit and push pubspec.yaml


### PR DESCRIPTION
デプロイ前にバージョンの更新種類を選択できるようにしました。デフォルトで`build`を選択しています。
![image](https://github.com/user-attachments/assets/ee32f472-4d27-44c8-8f82-3982f6e1c4fb)