### PR TITLE
[Linux] debパッケージビルドの修正

### DIFF
--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -113,14 +113,15 @@ jobs:
 
         - name: Prepare to build DEB
           run: |
-            echo "DESC=$(awk -F '=' '/^Comment=/{print $2}' ./snap/gui/miria.desktop)" >> $GITHUB_ENV
-            sed -i -E 's|^Version=.*|Version=${{ env.VERSION }}|g' ./snap/gui/miria.desktop
-            sed -i -E 's|^Icon=.*|Icon=/usr/share/pixmaps/miria.png|g' ./snap/gui/miria.desktop
-            sed -i -E 's|^Exec=.*|Exec=/opt/miria/miria|g' ./snap/gui/miria.desktop
-            mkdir -p .debpkg/opt/miria .debpkg/usr/share/applications .debpkg/usr/share/pixmaps
+            mkdir -p .debpkg/opt/miria .debpkg/usr/share/applications .debpkg/usr/share/pixmaps .debpkg/usr/bin
             cp -rp ./build/linux/x64/release/bundle/* .debpkg/opt/miria/
             cp ./snap/gui/miria.desktop .debpkg/usr/share/applications/
             cp ./assets/images/icon.png .debpkg/usr/share/pixmaps/miria.png
+            ln -s /opt/miria/miria .debpkg/usr/bin/miria
+            chmod a+x .debpkg/usr/bin/miria
+            sed -i -E 's|^Version=.*|Version=1.5|g' .debpkg/usr/share/applications/miria.desktop
+            sed -i -E 's|^Icon=.*|Icon=miria|g' .debpkg/usr/share/applications/miria.desktop
+            echo "DESC=$(awk -F '=' '/^Comment=/{print $2}' .debpkg/usr/share/applications/miria.desktop)" >> $GITHUB_ENV
 
         - name: Build DEB
           uses: jiro4989/build-deb-action@v3

--- a/snap/gui/miria.desktop
+++ b/snap/gui/miria.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0
+Version=1.1
 Name=Miria
 GenericName=Misskey Client App
 GenericName[ja]=Misskeyクライアントアプリ


### PR DESCRIPTION
debパッケージの生成手順に細かな修正を追加しました（※Ubuntu 22.04などで動作しない問題の修正は含まれていません）。
- `Version`を`1.5`に変更するようにしました
  - `Version`はデスクトップエントリファイルの記述方式についての表記であり、アプリのバージョン表記ではありません（現在の最新バージョンは`1.5`です）。
  - これに合わせてデスクトップエントリのバージョンを`1.1`（[Snapcraftでサポートされていることが明記されたバージョン](https://snapcraft.io/docs/desktop-menu-support)）に変更しました
- `Icon`を`miria`に変更するようにしました
  - `Version=1.1`では絶対パスで指定されたアイコンの使用、`Version=1.5`ではアイコンの検索が行われます
- `/usr/bin/miria`から実行できるようにしました