### PR TITLE
CWテキストをコピーできるように

### DIFF
--- a/lib/view/copy_modal_sheet/copy_note_modal_sheet.dart
+++ b/lib/view/copy_modal_sheet/copy_note_modal_sheet.dart
@@ -5,10 +5,12 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:miria/view/themes/app_theme.dart";
 
 class CopyNoteModalSheet extends ConsumerWidget {
-  final String note;
+  final String text;
+  final String? cw;
 
   const CopyNoteModalSheet({
-    required this.note,
+    required this.text,
+    this.cw,
     super.key,
   });
 
@@ -22,10 +24,11 @@ class CopyNoteModalSheet extends ConsumerWidget {
             ListTile(
               title: Text(S.of(context).detail),
               trailing: IconButton(
-                onPressed: () {
-                  Clipboard.setData(
-                    ClipboardData(text: note),
+                onPressed: () async {
+                  await Clipboard.setData(
+                    ClipboardData(text: text),
                   );
+                  if (!context.mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text(S.of(context).doneCopy),
@@ -37,11 +40,46 @@ class CopyNoteModalSheet extends ConsumerWidget {
                 tooltip: S.of(context).copyContents,
               ),
             ),
+            if (cw != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 5),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: Card(
+                        child: Padding(
+                          padding: const EdgeInsets.all(10),
+                          child: SelectableText(
+                            cw!,
+                            style: AppTheme.of(context).monospaceStyle,
+                          ),
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () async {
+                        await Clipboard.setData(
+                          ClipboardData(text: cw!),
+                        );
+                        if (!context.mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(S.of(context).doneCopy),
+                            duration: const Duration(seconds: 1),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.copy),
+                    ),
+                  ],
+                ),
+              ),
             Card(
               child: Padding(
                 padding: const EdgeInsets.all(10),
                 child: SelectableText(
-                  note,
+                  text,
                   style: AppTheme.of(context).monospaceStyle,
                 ),
               ),

--- a/lib/view/note_modal_sheet/note_modal_sheet.dart
+++ b/lib/view/note_modal_sheet/note_modal_sheet.dart
@@ -293,7 +293,8 @@ class NoteModalSheet extends ConsumerWidget implements AutoRouteWrapper {
               await showModalBottomSheet(
                 context: context,
                 builder: (context) => CopyNoteModalSheet(
-                  note: targetNote.text ?? "",
+                  text: targetNote.text ?? "",
+                  cw: targetNote.cw,
                 ),
               );
             },


### PR DESCRIPTION
CWテキストをコピーできる場所が無かったため、`copy_note_modal_sheel.dart`にCWテキストの項目を追加しました
![Screenshot from 2024-12-01 15-06-41](https://github.com/user-attachments/assets/1de58c37-6236-4089-a1a1-bd3ec9331ac1)
