### PR TITLE
build_runnerを実行済みか確認するジョブを追加

### DIFF
--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -16,32 +16,76 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  get-flutter-version:
+    runs-on: ubuntu-latest
+
+    outputs:
+      flutter-version: ${{ steps.get-flutter-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Flutter version from .fvmrc
+        id: get-flutter-version
+        run: echo "version=$(jq -r .flutter .fvmrc)" >> $GITHUB_OUTPUT
+
+  format:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
 
-      - name: Get Flutter version from .fvmrc
-        run:  echo "FLUTTER_FVM_VERSION=$(jq -r .flutter .fvmrc)" >> $GITHUB_ENV
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Format
+        run: dart format --output=none --set-exit-if-changed .
+
+  analyze:
+    if: false
+
+    runs-on: ubuntu-latest
+
+    needs: get-flutter-version
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: ${{ env.FLUTTER_FVM_VERSION }}
+          channel: 'stable'
+          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
           cache: true
-
-      - run: dart format --output=none --set-exit-if-changed .
 
       - name: Run flutter version
         run: flutter --version
 
       - name: Run flutter pub get
         run: flutter pub get
-      
-      # ゆくゆくは
-      # - run: flutter analyze --fatal-infos
+
+      - name: Analyze
+        run: flutter analyze --fatal-infos
+
+  test:
+    runs-on: ubuntu-latest
+
+    needs: get-flutter-version
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          cache: true
+
+      - name: Run flutter version
+        run: flutter --version
+
+      - name: Run flutter pub get
+        run: flutter pub get
 
       - name: Run flutter test with coverage
         run: flutter test --coverage --coverage-path=~/coverage/lcov.info

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -16,23 +16,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  get-flutter-version:
-    runs-on: ubuntu-latest
-
-    outputs:
-      flutter-version: ${{ steps.get-flutter-version.outputs.version }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get Flutter version from .fvmrc
-        id: get-flutter-version
-        run: echo "version=$(jq -r .flutter .fvmrc)" >> $GITHUB_OUTPUT
-
   format:
     runs-on: ubuntu-latest
-
-    needs: get-flutter-version
 
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +25,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
-          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          flutter-version-file: .fvmrc
           cache: true
 
       - name: Run flutter version
@@ -58,16 +42,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: get-flutter-version
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
-          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          flutter-version-file: .fvmrc
           cache: true
 
       - name: Run flutter version
@@ -82,15 +63,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    needs: get-flutter-version
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          flutter-version-file: .fvmrc
           cache: true
 
       - name: Run flutter version
@@ -110,16 +89,13 @@ jobs:
   check-build-diff:
     runs-on: ubuntu-latest
 
-    needs: get-flutter-version
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
-          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          flutter-version-file: .fvmrc
           cache: true
 
       - name: Run build_runner

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -94,3 +94,24 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ~/coverage/lcov.info
+
+  check-build-diff:
+    runs-on: ubuntu-latest
+
+    needs: get-flutter-version
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          cache: true
+
+      - name: Run build_runner
+        run: dart run build_runner build -d
+
+      - name: Check diff
+        run: git diff --exit-code

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -32,11 +32,23 @@ jobs:
   format:
     runs-on: ubuntu-latest
 
+    needs: get-flutter-version
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          cache: true
+
+      - name: Run flutter version
+        run: flutter --version
+
+      - name: Run flutter pub get
+        run: flutter pub get
 
       - name: Format
         run: dart format --output=none --set-exit-if-changed .


### PR DESCRIPTION
FreezedやRiverpod関連のクラスやルーターを変更した後は `dart run build_runner build -d` を実行しなければ生成されたファイルが更新されず不具合の原因になりますが、これは忘れやすいのでPR時にGitHub Actionsでbuild_runnerを実行して差分が発生しないか確認するようにしました。

また、build_runnerは時間がかかるのでtestと並列に実行するようにしました