### PR TITLE
アカウント設定の設定ボタンで全般設定に移動してしまう問題の修正

### DIFF
--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -351,7 +351,7 @@ class AccountRepository extends _$AccountRepository {
   }
 
   Future<void> reorder(int oldIndex, int newIndex) async {
-    final actualIndex = oldIndex < newIndex ? -1 : newIndex;
+    final actualIndex = newIndex - (oldIndex < newIndex ? 1 : 0);
     final newState = state.toList();
     final item = newState.removeAt(oldIndex);
     newState.insert(actualIndex, item);

--- a/lib/view/settings_page/account_settings_page/account_list.dart
+++ b/lib/view/settings_page/account_settings_page/account_list.dart
@@ -97,7 +97,7 @@ class AccountListItem extends ConsumerWidget {
             icon: const Icon(Icons.settings),
             onPressed: () {
               context.pushRoute(
-                SeveralAccountGeneralSettingsRoute(account: account),
+                SeveralAccountSettingsRoute(account: account),
               );
             },
           ),


### PR DESCRIPTION
- 「アカウントの全般設定」ではなく「アカウントの設定画面」に移動するように修正しました
- アカウントがうまく並び替えられないことがあるのを修正