### PR TITLE
カラーピッカーで不透明度を指定できるように

### DIFF
--- a/lib/view/common/note_create/mfm_fn_keyboard.dart
+++ b/lib/view/common/note_create/mfm_fn_keyboard.dart
@@ -176,9 +176,15 @@ class MfmFnKeyboard extends ConsumerWidget {
         builder: (context) => const ColorPickerDialog(),
       );
       if (result != null) {
-        controller.insert(
-          ".color=${result.value.red.toRadixString(16).padLeft(2, "0")}${result.value.green.toRadixString(16).padLeft(2, "0")}${result.value.blue.toRadixString(16).padLeft(2, "0")} ",
-        );
+        if (result.value.alpha == 1) {
+          controller.insert(
+            ".color=${result.value.red.toRadixString(16).padLeft(2, "0")}${result.value.green.toRadixString(16).padLeft(2, "0")}${result.value.blue.toRadixString(16).padLeft(2, "0")} ",
+          );
+        } else {
+          controller.insert(
+            ".color=${(result.value.red / 16).toInt().toRadixString(16)}${(result.value.green / 16).toInt().toRadixString(16)}${(result.value.blue / 16).toInt().toRadixString(16)}${(result.value.alpha / 16).toInt().toRadixString(16)} ",
+          );
+        }
       } else {
         controller.insert(" ");
       }
@@ -219,9 +225,15 @@ class MfmFnKeyboard extends ConsumerWidget {
         builder: (context) => const ColorPickerDialog(),
       );
       if (result != null) {
-        controller.insert(
-          "=${result.value.red.toRadixString(16).padLeft(2, "0")}${result.value.green.toRadixString(16).padLeft(2, "0")}${result.value.blue.toRadixString(16).padLeft(2, "0")} ",
-        );
+        if (result.value.alpha == 1) {
+          controller.insert(
+            "=${result.value.red.toRadixString(16).padLeft(2, "0")}${result.value.green.toRadixString(16).padLeft(2, "0")}${result.value.blue.toRadixString(16).padLeft(2, "0")} ",
+          );
+        } else {
+          controller.insert(
+            "=${(result.value.red / 16).toInt().toRadixString(16)}${(result.value.green / 16).toInt().toRadixString(16)}${(result.value.blue / 16).toInt().toRadixString(16)}${(result.value.alpha / 16).toInt().toRadixString(16)} ",
+          );
+        }
       } else {
         controller.insert("=f00 ");
       }


### PR DESCRIPTION
カラーピッカーで不透明度（Alpha）が100%でないときに4桁のカラーコードで不透明度が使用されるようにしました。100%の場合はこれまで通り6桁のカラーコードが使用されます。