### PR TITLE
LTLが無効なサーバーのアカウントでタブ設定がエラー表示になることがあるのを修正

### DIFF
--- a/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
+++ b/lib/view/settings_page/tab_settings_page/tab_settings_page.dart
@@ -54,7 +54,10 @@ class TabSettingsPage extends HookConsumerWidget {
     final selectedTabType = useState<TabType?>(
       initialTabSetting != null && isTabTypeAvailable(initialTabSetting.tabType)
           ? initialTabSetting.tabType
-          : TabType.localTimeline,
+          : (selectedAccount.value != null &&
+                  selectedAccount.value!.i.policies.ltlAvailable
+              ? TabType.localTimeline
+              : TabType.homeTimeline),
     );
 
     final selectedRole = useState<RolesListResponse?>(null);


### PR DESCRIPTION
アカウント設定でLTLが無効なサーバーのアカウントが最上部にある場合、タブ設定でタブを追加しようとするとエラーが表示されてしまうのを修正しました