### PR TITLE
codecov-actionをv5に更新する

### DIFF
--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run flutter test with coverage
         run: flutter test --coverage --coverage-path=~/coverage/lcov.info
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ~/coverage/lcov.info
+          files: ~/coverage/lcov.info


### PR DESCRIPTION
dart_test actionで実行しているcodecov/codecov-actionのv5系が提供されたので、miriaで使っているワークフローもv5系に更新します。

https://github.com/codecov/codecov-action/releases/tag/v5.0.0
`file`パラメータが`files`パラメータに変更されているので、この部分も変更しています。