### PR TITLE
キャッシュクリア機能追加

### DIFF
--- a/lib/l10n/app_ja-oj.arb
+++ b/lib/l10n/app_ja-oj.arb
@@ -106,6 +106,9 @@
     "cannotMentionToRemoteInLocalOnlyNote": "連合切られているのに他のサーバーの人がメンションに含まれているようですわ",
     "cannotPublicReplyToPrivateNote": "リプライが{visibility}のようでして……パブリックにはできませんこと",
 
+    "cache": "キャッシュ",
+    "clearCache": "キャッシュとお別れいたしますわ",
+
     "unsupportedFile": "対応してないファイルのようですわ",
     "failedFileSave": "ファイルの保存に失敗したようですわね…"
 

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -826,6 +826,9 @@
     "fontSize": "フォントサイズ",
     "systemFont": "システム標準",
 
+    "cache": "キャッシュ",
+    "clearCache": "キャッシュをクリア",
+
     "selectFolder": "フォルダー選択",
     "settingsFileManagement": "設定ファイルの管理",
     "importAndExportSettingsDescription": "現在の設定から、アカウントのログイン情報を除くすべての設定を設定ファイルに出力して管理することができます。設定ファイルは、指定したアカウントの「ドライブ」内に保存されます。",

--- a/lib/l10n/app_zh-cn.arb
+++ b/lib/l10n/app_zh-cn.arb
@@ -773,6 +773,8 @@
     "fontFantasy": "字体 （适用于 $[font.fantasy ）",
     "fontSize": "字体大小",
     "systemFont": "系统标准",
+    "cache": "快取",
+    "clearCache": "清除快取",
     "selectFolder": "选择文件夹",
     "importSettings": "导入设置",
     "importSettingsDescription": "从驱动器加载配置文件。配置文件保存时会记录所有账号的配置信息，但只会加载登录本设备的账号的信息。",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -773,6 +773,8 @@
     "fontFantasy": "字体 （适用于 $[font.fantasy ）",
     "fontSize": "字体大小",
     "systemFont": "系统标准",
+    "cache": "快取",
+    "clearCache": "清除快取",
     "selectFolder": "选择文件夹",
     "importSettings": "导入设置",
     "importSettingsDescription": "从驱动器加载配置文件。配置文件保存时会记录所有账号的配置信息，但只会加载登录本设备的账号的信息。",

--- a/lib/util/cache_size.dart
+++ b/lib/util/cache_size.dart
@@ -2,69 +2,67 @@ import "dart:io";
 import "dart:math";
 import "package:path_provider/path_provider.dart";
 
+/// 単位付きのキャッシュサイズを取得する
 Future<String> getCacheSizeWithUnit() async {
   const unitArr = ["Byte", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
   // キャッシュサイズ
-  final cacheSizeByte = await getCacheSizeByte();
-
+  final cacheSizeByte = await _getCacheSizeByte();
+    
   // 単位
   final unitIndex = (cacheSizeByte.toString().length / 3).ceil() - 1;
   final unit = unitArr[unitIndex];
 
   // "00.0 GB"の形にする
   final cacheSizeStr = (cacheSizeByte / pow(1000, unitIndex)).toStringAsFixed(1);
+
   return "$cacheSizeStr $unit";
-}
-
-/// キャッシュサイズを取得する
-Future<int> getCacheSizeByte() async {
-  // キャッシュ格納ディレクトリを取得して
-  // 中身のファイルサイズを全て合計
-  final tempDir = await getTemporaryDirectory();
-  final tempDirSize = _getFileDirSize(tempDir);
-  return tempDirSize;
-}
-
-/// ファイルサイズを取得する
-int _getFileDirSize(FileSystemEntity file) {
-  if (file is File) {
-    // ファイルならファイルサイズを返却
-    return file.lengthSync();
-  } else if (file is Directory) {
-    // ディレクトリなら配下のファイルサイズの合計を返す
-    var sum = 0;
-    final children = file.listSync();
-    for (final child in children) {
-      sum += _getFileDirSize(child);
-    }
-    return sum;
-  }
-  return 0;
 }
 
 /// キャッシュをクリアする
 Future<String> clearCache() async {
-  // キャッシュ格納ディレクトリを取得して
-  // 配下のファイルを全て削除
-  final tempDir = await getTemporaryDirectory();
-  await deleteFile(tempDir);
+  // 画像キャッシュ格納ディレクトリを削除
+  final cacheDir = await _getLibCachedImageDataDir();
+  if (await cacheDir.exists()){
+    // ディレクトリが存在する場合のみ実行(ボタン連打対策)
+    await cacheDir.delete(recursive: true);
+  }
   final cacheSizeStr = await getCacheSizeWithUnit();
-
-  // キャッシュクリア後のキャッシュサイズを返す(0byteのはず)
+  
+  // キャッシュクリア後のキャッシュサイズを返す("0.0 Byte"のはず)
   return cacheSizeStr;
 }
 
-/// ファイルを削除する
-Future<void> deleteFile(FileSystemEntity file) async {
-  if (file is File) {
-    // ファイルならそのまま削除
-    file.deleteSync();
-  } else if (file is Directory) {
-    // ディレクトリなら配下のファイルを再起的に削除
-    final children = file.listSync();
-    for (final child in children) {
-        await deleteFile(child);
-    }
+/// キャッシュサイズを取得する
+Future<int> _getCacheSizeByte() async {
+  // キャッシュ格納ディレクトリを取得して
+  // 中身のファイルサイズを全て合計
+  final cacheDir = await _getLibCachedImageDataDir();
+  final cacheSize = await _getDirSize(cacheDir);
+  
+  return cacheSize;
+}
+
+/// ディレクトリ配下のファイルサイズ合計を取得する
+Future<int> _getDirSize(Directory dir) async {
+  // ディレクトリが存在しない場合は0を返却
+  if (!(await dir.exists())) {
+    return 0;
   }
+
+  // dir配下のファイル・ディレクトリをすべて取得してファイルサイズの合計を取得
+  final dirSize = dir
+  .list(recursive: true)
+  .fold<int>(0, (prev, element) => prev + element.statSync().size);
+
+  return dirSize;
+}
+
+/// libCachedImageDataのパスを取得する
+Future<Directory> _getLibCachedImageDataDir() async {
+  const libCachedImageDataPath = "libCachedImageData";
+  final tempDir = await getTemporaryDirectory();
+  final libCachedImageDataDir = Directory("${tempDir.path}/$libCachedImageDataPath");
+
+ return libCachedImageDataDir;
 }

--- a/lib/util/cache_size.dart
+++ b/lib/util/cache_size.dart
@@ -1,6 +1,5 @@
 import "dart:io";
 import "dart:math";
-import "package:flutter/material.dart";
 import "package:path_provider/path_provider.dart";
 
 Future<String> getCacheSizeWithUnit() async {

--- a/lib/util/cache_size.dart
+++ b/lib/util/cache_size.dart
@@ -59,7 +59,7 @@ Future<String> clearCache() async {
 /// ファイルを削除する
 Future<void> deleteFile(FileSystemEntity file) async {
   if (file is File) {
-    // ファイならそのまま削除
+    // ファイルならそのまま削除
     file.deleteSync();
   } else if (file is Directory) {
     // ディレクトリなら配下のファイルを再起的に削除

--- a/lib/util/cache_size.dart
+++ b/lib/util/cache_size.dart
@@ -1,0 +1,71 @@
+import "dart:io";
+import "dart:math";
+import "package:flutter/material.dart";
+import "package:path_provider/path_provider.dart";
+
+Future<String> getCacheSizeWithUnit() async {
+  const unitArr = ["Byte", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+  // キャッシュサイズ
+  final cacheSizeByte = await getCacheSizeByte();
+
+  // 単位
+  final unitIndex = (cacheSizeByte.toString().length / 3).ceil() - 1;
+  final unit = unitArr[unitIndex];
+
+  // "00.0 GB"の形にする
+  final cacheSizeStr = (cacheSizeByte / pow(1000, unitIndex)).toStringAsFixed(1);
+  return "$cacheSizeStr $unit";
+}
+
+/// キャッシュサイズを取得する
+Future<int> getCacheSizeByte() async {
+  // キャッシュ格納ディレクトリを取得して
+  // 中身のファイルサイズを全て合計
+  final tempDir = await getTemporaryDirectory();
+  final tempDirSize = _getFileDirSize(tempDir);
+  return tempDirSize;
+}
+
+/// ファイルサイズを取得する
+int _getFileDirSize(FileSystemEntity file) {
+  if (file is File) {
+    // ファイルならファイルサイズを返却
+    return file.lengthSync();
+  } else if (file is Directory) {
+    // ディレクトリなら配下のファイルサイズの合計を返す
+    var sum = 0;
+    final children = file.listSync();
+    for (final child in children) {
+      sum += _getFileDirSize(child);
+    }
+    return sum;
+  }
+  return 0;
+}
+
+/// キャッシュをクリアする
+Future<String> clearCache() async {
+  // キャッシュ格納ディレクトリを取得して
+  // 配下のファイルを全て削除
+  final tempDir = await getTemporaryDirectory();
+  await deleteFile(tempDir);
+  final cacheSizeStr = await getCacheSizeWithUnit();
+
+  // キャッシュクリア後のキャッシュサイズを返す(0byteのはず)
+  return cacheSizeStr;
+}
+
+/// ファイルを削除する
+Future<void> deleteFile(FileSystemEntity file) async {
+  if (file is File) {
+    // ファイならそのまま削除
+    file.deleteSync();
+  } else if (file is Directory) {
+    // ディレクトリなら配下のファイルを再起的に削除
+    final children = file.listSync();
+    for (final child in children) {
+        await deleteFile(child);
+    }
+  }
+}

--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -9,6 +9,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:miria/const.dart";
 import "package:miria/model/general_settings.dart";
 import "package:miria/providers.dart";
+import "package:miria/util/cache_size.dart";
 import "package:miria/view/themes/built_in_color_themes.dart";
 
 @RoutePage()
@@ -39,6 +40,7 @@ class GeneralSettingsPage extends HookConsumerWidget {
     final fantasyFontName = useState(settings.fantasyFontName);
     final language = useState(settings.languages);
     final isDeckMode = useState(settings.isDeckMode);
+    final cacheSize = useState<String>("");
 
     useMemoized(() {
       if (lightModeTheme.value.isEmpty) {
@@ -108,6 +110,13 @@ class GeneralSettingsPage extends HookConsumerWidget {
     );
 
     useMemoized(() => unawaited(save()), dependencies);
+
+    useEffect(() {
+      unawaited(getCacheSizeWithUnit().then((value) =>
+        cacheSize.value = value,
+      ),);
+      return null;
+    }, [], );
 
     return Scaffold(
       appBar: AppBar(title: Text(S.of(context).generalSettings)),
@@ -482,6 +491,33 @@ class GeneralSettingsPage extends HookConsumerWidget {
                         isExpanded: true,
                         onChanged: (item) =>
                             fantasyFontName.value = item?.actualName ?? "",
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(15),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.max,
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        S.of(context).cache,
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      ListTile(
+                        title: Text(cacheSize.value),
+                        trailing: ElevatedButton(
+                          onPressed: () async {
+                            await clearCache().then((value) => 
+                              cacheSize.value = value,
+                            );
+                          },
+                          child: Text(S.of(context).clearCache),
+                        ),
                       ),
                     ],
                   ),


### PR DESCRIPTION
#717
一時ファイルを削除するボタンを「設定>全般設定」の一番下に追加
キャッシュクリアに関するローカライゼーション用の文言の追加

【キャッシュクリア時のイメージ】
クリア前
![before](https://github.com/user-attachments/assets/0dbeafde-4619-460d-8b84-d99994efdf2c)

クリア後 (8~30MB程度 一時ファイル以外のデータが残る模様)
![after](https://github.com/user-attachments/assets/9b60b27b-ea4f-4622-99ef-a76c55a2c86e)
