### PR TITLE
feat: 投票結果表示機能を追加し、関連する状態管理を実装

### DIFF
--- a/lib/repository/note_repository.dart
+++ b/lib/repository/note_repository.dart
@@ -16,6 +16,7 @@ abstract class NoteStatus with _$NoteStatus {
     required bool isLongVisibleInitialized,
     required bool isIncludeMuteWord,
     required bool isMuteOpened,
+    required bool isPollResultOpened,
   }) = _NoteStatus;
 }
 
@@ -131,6 +132,7 @@ class NoteRepository extends ChangeNotifier {
               softMuteWordContents.any((e) => e.every(isMuteTarget)) ||
           softMuteWordRegExps.any(isMuteTarget),
       isMuteOpened: false,
+      isPollResultOpened: _getInitialPollResultState(note),
     );
     final renote = note.renote;
     final reply = note.reply;
@@ -168,5 +170,54 @@ class NoteRepository extends ChangeNotifier {
     Future(() {
       notifyListeners();
     });
+  }
+
+  /// 投票結果表示状態の初期値を決定
+  /// 元のロジック: !isAnyVotable(ref) と同等の判定
+  bool _getInitialPollResultState(Note note) {
+    final poll = note.poll;
+    if (poll == null) return false;
+    
+    // 期限切れの場合は表示
+    final expiresAt = poll.expiresAt;
+    if (expiresAt != null && expiresAt.isBefore(DateTime.now())) {
+      return true;
+    }
+    
+    // 既に投票済みの場合は表示
+    if (poll.choices.any((choice) => choice.isVoted)) {
+      return true;
+    }
+    
+    // 投票可能な場合は非表示（元のロジック通り）
+    // isAnyVotableがtrueの場合、!isAnyVotableはfalseになる
+    return false;
+  }
+
+  /// 投票結果表示状態を切り替え
+  void togglePollResult(String noteId) {
+    final status = _noteStatuses[noteId];
+    if (status != null) {
+      _noteStatuses[noteId] = status.copyWith(
+        isPollResultOpened: !status.isPollResultOpened,
+      );
+      notifyListeners();
+    }
+  }
+
+  /// 投票結果表示状態を設定
+  void setPollResultOpened(String noteId, bool isOpened) {
+    final status = _noteStatuses[noteId];
+    if (status != null) {
+      _noteStatuses[noteId] = status.copyWith(
+        isPollResultOpened: isOpened,
+      );
+      notifyListeners();
+    }
+  }
+
+  /// 投票結果表示状態を取得
+  bool getPollResultOpened(String noteId) {
+    return _noteStatuses[noteId]?.isPollResultOpened ?? false;
   }
 }

--- a/lib/repository/note_repository.freezed.dart
+++ b/lib/repository/note_repository.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NoteStatus implements DiagnosticableTreeMixin {
 
- bool get isCwOpened; bool get isLongVisible; bool get isReactionedRenote; bool get isLongVisibleInitialized; bool get isIncludeMuteWord; bool get isMuteOpened;
+ bool get isCwOpened; bool get isLongVisible; bool get isReactionedRenote; bool get isLongVisibleInitialized; bool get isIncludeMuteWord; bool get isMuteOpened; bool get isPollResultOpened;
 /// Create a copy of NoteStatus
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,21 +27,21 @@ $NoteStatusCopyWith<NoteStatus> get copyWith => _$NoteStatusCopyWithImpl<NoteSta
 void debugFillProperties(DiagnosticPropertiesBuilder properties) {
   properties
     ..add(DiagnosticsProperty('type', 'NoteStatus'))
-    ..add(DiagnosticsProperty('isCwOpened', isCwOpened))..add(DiagnosticsProperty('isLongVisible', isLongVisible))..add(DiagnosticsProperty('isReactionedRenote', isReactionedRenote))..add(DiagnosticsProperty('isLongVisibleInitialized', isLongVisibleInitialized))..add(DiagnosticsProperty('isIncludeMuteWord', isIncludeMuteWord))..add(DiagnosticsProperty('isMuteOpened', isMuteOpened));
+    ..add(DiagnosticsProperty('isCwOpened', isCwOpened))..add(DiagnosticsProperty('isLongVisible', isLongVisible))..add(DiagnosticsProperty('isReactionedRenote', isReactionedRenote))..add(DiagnosticsProperty('isLongVisibleInitialized', isLongVisibleInitialized))..add(DiagnosticsProperty('isIncludeMuteWord', isIncludeMuteWord))..add(DiagnosticsProperty('isMuteOpened', isMuteOpened))..add(DiagnosticsProperty('isPollResultOpened', isPollResultOpened));
 }
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NoteStatus&&(identical(other.isCwOpened, isCwOpened) || other.isCwOpened == isCwOpened)&&(identical(other.isLongVisible, isLongVisible) || other.isLongVisible == isLongVisible)&&(identical(other.isReactionedRenote, isReactionedRenote) || other.isReactionedRenote == isReactionedRenote)&&(identical(other.isLongVisibleInitialized, isLongVisibleInitialized) || other.isLongVisibleInitialized == isLongVisibleInitialized)&&(identical(other.isIncludeMuteWord, isIncludeMuteWord) || other.isIncludeMuteWord == isIncludeMuteWord)&&(identical(other.isMuteOpened, isMuteOpened) || other.isMuteOpened == isMuteOpened));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NoteStatus&&(identical(other.isCwOpened, isCwOpened) || other.isCwOpened == isCwOpened)&&(identical(other.isLongVisible, isLongVisible) || other.isLongVisible == isLongVisible)&&(identical(other.isReactionedRenote, isReactionedRenote) || other.isReactionedRenote == isReactionedRenote)&&(identical(other.isLongVisibleInitialized, isLongVisibleInitialized) || other.isLongVisibleInitialized == isLongVisibleInitialized)&&(identical(other.isIncludeMuteWord, isIncludeMuteWord) || other.isIncludeMuteWord == isIncludeMuteWord)&&(identical(other.isMuteOpened, isMuteOpened) || other.isMuteOpened == isMuteOpened)&&(identical(other.isPollResultOpened, isPollResultOpened) || other.isPollResultOpened == isPollResultOpened));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,isCwOpened,isLongVisible,isReactionedRenote,isLongVisibleInitialized,isIncludeMuteWord,isMuteOpened);
+int get hashCode => Object.hash(runtimeType,isCwOpened,isLongVisible,isReactionedRenote,isLongVisibleInitialized,isIncludeMuteWord,isMuteOpened,isPollResultOpened);
 
 @override
 String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
-  return 'NoteStatus(isCwOpened: $isCwOpened, isLongVisible: $isLongVisible, isReactionedRenote: $isReactionedRenote, isLongVisibleInitialized: $isLongVisibleInitialized, isIncludeMuteWord: $isIncludeMuteWord, isMuteOpened: $isMuteOpened)';
+  return 'NoteStatus(isCwOpened: $isCwOpened, isLongVisible: $isLongVisible, isReactionedRenote: $isReactionedRenote, isLongVisibleInitialized: $isLongVisibleInitialized, isIncludeMuteWord: $isIncludeMuteWord, isMuteOpened: $isMuteOpened, isPollResultOpened: $isPollResultOpened)';
 }
 
 
@@ -52,7 +52,7 @@ abstract mixin class $NoteStatusCopyWith<$Res>  {
   factory $NoteStatusCopyWith(NoteStatus value, $Res Function(NoteStatus) _then) = _$NoteStatusCopyWithImpl;
 @useResult
 $Res call({
- bool isCwOpened, bool isLongVisible, bool isReactionedRenote, bool isLongVisibleInitialized, bool isIncludeMuteWord, bool isMuteOpened
+ bool isCwOpened, bool isLongVisible, bool isReactionedRenote, bool isLongVisibleInitialized, bool isIncludeMuteWord, bool isMuteOpened, bool isPollResultOpened
 });
 
 
@@ -69,7 +69,7 @@ class _$NoteStatusCopyWithImpl<$Res>
 
 /// Create a copy of NoteStatus
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? isCwOpened = null,Object? isLongVisible = null,Object? isReactionedRenote = null,Object? isLongVisibleInitialized = null,Object? isIncludeMuteWord = null,Object? isMuteOpened = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? isCwOpened = null,Object? isLongVisible = null,Object? isReactionedRenote = null,Object? isLongVisibleInitialized = null,Object? isIncludeMuteWord = null,Object? isMuteOpened = null,Object? isPollResultOpened = null,}) {
   return _then(_self.copyWith(
 isCwOpened: null == isCwOpened ? _self.isCwOpened : isCwOpened // ignore: cast_nullable_to_non_nullable
 as bool,isLongVisible: null == isLongVisible ? _self.isLongVisible : isLongVisible // ignore: cast_nullable_to_non_nullable
@@ -77,6 +77,7 @@ as bool,isReactionedRenote: null == isReactionedRenote ? _self.isReactionedRenot
 as bool,isLongVisibleInitialized: null == isLongVisibleInitialized ? _self.isLongVisibleInitialized : isLongVisibleInitialized // ignore: cast_nullable_to_non_nullable
 as bool,isIncludeMuteWord: null == isIncludeMuteWord ? _self.isIncludeMuteWord : isIncludeMuteWord // ignore: cast_nullable_to_non_nullable
 as bool,isMuteOpened: null == isMuteOpened ? _self.isMuteOpened : isMuteOpened // ignore: cast_nullable_to_non_nullable
+as bool,isPollResultOpened: null == isPollResultOpened ? _self.isPollResultOpened : isPollResultOpened // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -88,7 +89,7 @@ as bool,
 
 
 class _NoteStatus with DiagnosticableTreeMixin implements NoteStatus {
-  const _NoteStatus({required this.isCwOpened, required this.isLongVisible, required this.isReactionedRenote, required this.isLongVisibleInitialized, required this.isIncludeMuteWord, required this.isMuteOpened});
+  const _NoteStatus({required this.isCwOpened, required this.isLongVisible, required this.isReactionedRenote, required this.isLongVisibleInitialized, required this.isIncludeMuteWord, required this.isMuteOpened, required this.isPollResultOpened});
   
 
 @override final  bool isCwOpened;
@@ -97,6 +98,7 @@ class _NoteStatus with DiagnosticableTreeMixin implements NoteStatus {
 @override final  bool isLongVisibleInitialized;
 @override final  bool isIncludeMuteWord;
 @override final  bool isMuteOpened;
+@override final  bool isPollResultOpened;
 
 /// Create a copy of NoteStatus
 /// with the given fields replaced by the non-null parameter values.
@@ -109,21 +111,21 @@ _$NoteStatusCopyWith<_NoteStatus> get copyWith => __$NoteStatusCopyWithImpl<_Not
 void debugFillProperties(DiagnosticPropertiesBuilder properties) {
   properties
     ..add(DiagnosticsProperty('type', 'NoteStatus'))
-    ..add(DiagnosticsProperty('isCwOpened', isCwOpened))..add(DiagnosticsProperty('isLongVisible', isLongVisible))..add(DiagnosticsProperty('isReactionedRenote', isReactionedRenote))..add(DiagnosticsProperty('isLongVisibleInitialized', isLongVisibleInitialized))..add(DiagnosticsProperty('isIncludeMuteWord', isIncludeMuteWord))..add(DiagnosticsProperty('isMuteOpened', isMuteOpened));
+    ..add(DiagnosticsProperty('isCwOpened', isCwOpened))..add(DiagnosticsProperty('isLongVisible', isLongVisible))..add(DiagnosticsProperty('isReactionedRenote', isReactionedRenote))..add(DiagnosticsProperty('isLongVisibleInitialized', isLongVisibleInitialized))..add(DiagnosticsProperty('isIncludeMuteWord', isIncludeMuteWord))..add(DiagnosticsProperty('isMuteOpened', isMuteOpened))..add(DiagnosticsProperty('isPollResultOpened', isPollResultOpened));
 }
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NoteStatus&&(identical(other.isCwOpened, isCwOpened) || other.isCwOpened == isCwOpened)&&(identical(other.isLongVisible, isLongVisible) || other.isLongVisible == isLongVisible)&&(identical(other.isReactionedRenote, isReactionedRenote) || other.isReactionedRenote == isReactionedRenote)&&(identical(other.isLongVisibleInitialized, isLongVisibleInitialized) || other.isLongVisibleInitialized == isLongVisibleInitialized)&&(identical(other.isIncludeMuteWord, isIncludeMuteWord) || other.isIncludeMuteWord == isIncludeMuteWord)&&(identical(other.isMuteOpened, isMuteOpened) || other.isMuteOpened == isMuteOpened));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NoteStatus&&(identical(other.isCwOpened, isCwOpened) || other.isCwOpened == isCwOpened)&&(identical(other.isLongVisible, isLongVisible) || other.isLongVisible == isLongVisible)&&(identical(other.isReactionedRenote, isReactionedRenote) || other.isReactionedRenote == isReactionedRenote)&&(identical(other.isLongVisibleInitialized, isLongVisibleInitialized) || other.isLongVisibleInitialized == isLongVisibleInitialized)&&(identical(other.isIncludeMuteWord, isIncludeMuteWord) || other.isIncludeMuteWord == isIncludeMuteWord)&&(identical(other.isMuteOpened, isMuteOpened) || other.isMuteOpened == isMuteOpened)&&(identical(other.isPollResultOpened, isPollResultOpened) || other.isPollResultOpened == isPollResultOpened));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,isCwOpened,isLongVisible,isReactionedRenote,isLongVisibleInitialized,isIncludeMuteWord,isMuteOpened);
+int get hashCode => Object.hash(runtimeType,isCwOpened,isLongVisible,isReactionedRenote,isLongVisibleInitialized,isIncludeMuteWord,isMuteOpened,isPollResultOpened);
 
 @override
 String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
-  return 'NoteStatus(isCwOpened: $isCwOpened, isLongVisible: $isLongVisible, isReactionedRenote: $isReactionedRenote, isLongVisibleInitialized: $isLongVisibleInitialized, isIncludeMuteWord: $isIncludeMuteWord, isMuteOpened: $isMuteOpened)';
+  return 'NoteStatus(isCwOpened: $isCwOpened, isLongVisible: $isLongVisible, isReactionedRenote: $isReactionedRenote, isLongVisibleInitialized: $isLongVisibleInitialized, isIncludeMuteWord: $isIncludeMuteWord, isMuteOpened: $isMuteOpened, isPollResultOpened: $isPollResultOpened)';
 }
 
 
@@ -134,7 +136,7 @@ abstract mixin class _$NoteStatusCopyWith<$Res> implements $NoteStatusCopyWith<$
   factory _$NoteStatusCopyWith(_NoteStatus value, $Res Function(_NoteStatus) _then) = __$NoteStatusCopyWithImpl;
 @override @useResult
 $Res call({
- bool isCwOpened, bool isLongVisible, bool isReactionedRenote, bool isLongVisibleInitialized, bool isIncludeMuteWord, bool isMuteOpened
+ bool isCwOpened, bool isLongVisible, bool isReactionedRenote, bool isLongVisibleInitialized, bool isIncludeMuteWord, bool isMuteOpened, bool isPollResultOpened
 });
 
 
@@ -151,7 +153,7 @@ class __$NoteStatusCopyWithImpl<$Res>
 
 /// Create a copy of NoteStatus
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? isCwOpened = null,Object? isLongVisible = null,Object? isReactionedRenote = null,Object? isLongVisibleInitialized = null,Object? isIncludeMuteWord = null,Object? isMuteOpened = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? isCwOpened = null,Object? isLongVisible = null,Object? isReactionedRenote = null,Object? isLongVisibleInitialized = null,Object? isIncludeMuteWord = null,Object? isMuteOpened = null,Object? isPollResultOpened = null,}) {
   return _then(_NoteStatus(
 isCwOpened: null == isCwOpened ? _self.isCwOpened : isCwOpened // ignore: cast_nullable_to_non_nullable
 as bool,isLongVisible: null == isLongVisible ? _self.isLongVisible : isLongVisible // ignore: cast_nullable_to_non_nullable
@@ -159,6 +161,7 @@ as bool,isReactionedRenote: null == isReactionedRenote ? _self.isReactionedRenot
 as bool,isLongVisibleInitialized: null == isLongVisibleInitialized ? _self.isLongVisibleInitialized : isLongVisibleInitialized // ignore: cast_nullable_to_non_nullable
 as bool,isIncludeMuteWord: null == isIncludeMuteWord ? _self.isIncludeMuteWord : isIncludeMuteWord // ignore: cast_nullable_to_non_nullable
 as bool,isMuteOpened: null == isMuteOpened ? _self.isMuteOpened : isMuteOpened // ignore: cast_nullable_to_non_nullable
+as bool,isPollResultOpened: null == isPollResultOpened ? _self.isPollResultOpened : isPollResultOpened // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/lib/view/common/misskey_notes/note_vote.dart
+++ b/lib/view/common/misskey_notes/note_vote.dart
@@ -76,7 +76,9 @@ class NoteVote extends HookConsumerWidget {
         : poll.expiresAt?.difference(DateTime.now()).format(context);
     final colorTheme = AppTheme.of(context).colorTheme;
 
-    final isOpened = useState(useMemoized(() => !isAnyVotable(ref)));
+    // Hook状態ではなく、NoteRepositoryの状態を使用
+    final noteRepository = ref.watch(notesProvider(ref.read(accountContextProvider).getAccount));
+    final isOpened = noteRepository.getPollResultOpened(displayNote.id);
 
     ref.watch(noteVoteNotifierProvider(displayNote));
 
@@ -94,8 +96,8 @@ class NoteVote extends HookConsumerWidget {
               decoration: BoxDecoration(
                 border: Border.all(color: Colors.transparent),
                 borderRadius: BorderRadius.circular(5),
-                color: isOpened.value ? null : colorTheme.accentedBackground,
-                gradient: isOpened.value
+                color: isOpened ? null : colorTheme.accentedBackground,
+                gradient: isOpened
                     ? LinearGradient(
                         colors: [
                           colorTheme.buttonGradateA,
@@ -124,9 +126,13 @@ class NoteVote extends HookConsumerWidget {
                   if (!isVotable(choice.index, ref)) {
                     return;
                   }
-                  isOpened.value = await ref
+                  final success = await ref
                       .read(noteVoteNotifierProvider(displayNote).notifier)
                       .vote(choice.index);
+                  if (success) {
+                    // 投票成功時は結果を表示状態にする
+                    noteRepository.setPollResultOpened(displayNote.id, true);
+                  }
                 },
                 child: Padding(
                   padding: const EdgeInsets.all(2),
@@ -165,7 +171,7 @@ class NoteVote extends HookConsumerWidget {
                           const WidgetSpan(
                             child: Padding(padding: EdgeInsets.only(left: 5)),
                           ),
-                          if (isOpened.value)
+                          if (isOpened)
                             TextSpan(
                               text: S
                                   .of(context)
@@ -189,13 +195,13 @@ class NoteVote extends HookConsumerWidget {
               TextSpan(
                 text: isExpired
                     ? S.of(context).finished
-                    : !isOpened.value
+                    : !isOpened
                     ? S.of(context).openResult
                     : isAnyVotable(ref)
                     ? S.of(context).doVoting
                     : S.of(context).alreadyVoted,
                 recognizer: TapGestureRecognizer()
-                  ..onTap = () => isOpened.value = !isOpened.value,
+                  ..onTap = () => noteRepository.togglePollResult(displayNote.id),
               ),
               const WidgetSpan(
                 child: Padding(padding: EdgeInsets.only(left: 10)),

--- a/test/test_util/mock.mocks.dart
+++ b/test/test_util/mock.mocks.dart
@@ -1163,6 +1163,28 @@ class MockNoteRepository extends _i1.Mock implements _i26.NoteRepository {
   );
 
   @override
+  void togglePollResult(String? noteId) => super.noSuchMethod(
+    Invocation.method(#togglePollResult, [noteId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void setPollResultOpened(String? noteId, bool? isOpened) =>
+      super.noSuchMethod(
+        Invocation.method(#setPollResultOpened, [noteId, isOpened]),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool getPollResultOpened(String? noteId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getPollResultOpened, [noteId]),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
+
+  @override
   void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#addListener, [listener]),
     returnValueForMissingStub: null,

--- a/test/view/common/misskey_notes/note_vote_complex_test.dart
+++ b/test/view/common/misskey_notes/note_vote_complex_test.dart
@@ -1,0 +1,209 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:miria/model/general_settings.dart";
+import "package:miria/providers.dart";
+import "package:miria/repository/note_repository.dart";
+import "package:miria/router/app_router.dart";
+import "package:miria/view/common/account_scope.dart";
+import "package:miria/view/common/misskey_notes/misskey_note.dart";
+import "package:miria/view/common/misskey_notes/note_vote.dart";
+import "package:misskey_dart/misskey_dart.dart";
+import "package:mockito/mockito.dart";
+
+import "../../../test_util/default_root_widget.dart";
+import "../../../test_util/mock.mocks.dart";
+import "../../../test_util/test_datas.dart";
+import "../../../test_util/widget_tester_extension.dart";
+
+void main() {
+  group("投票機能の複雑なテストケース", () {
+    late MockMisskey mockMisskey;
+    late NoteRepository notesRepository;
+
+    setUp(() {
+      mockMisskey = MockMisskey();
+      notesRepository = NoteRepository(mockMisskey, TestData.account);
+    });
+
+    // 既存のテストデータを使用
+    final pollNote = TestData.note4AsVote;
+
+    Widget buildTestWidget({
+      required Note note,
+    }) {
+      notesRepository.registerNote(note);
+      final mockCacheManager = MockBaseCacheManager();
+
+      return ProviderScope(
+        overrides: [
+          cacheManagerProvider.overrideWith((ref) => mockCacheManager),
+          notesProvider.overrideWith((ref, account) => notesRepository),
+        ],
+        child: DefaultRootNoRouterWidget(
+          child: Scaffold(
+            body: AccountContextScope.as(
+              account: TestData.account,
+              child: SingleChildScrollView(child: MisskeyNote(note: note)),
+            ),
+          ),
+        ),
+      );
+    }
+
+    group("投票数表示の不具合再現テスト", () {
+      testWidgets("単一投票で未投票の場合でも、初期表示で投票数が表示されること", (tester) async {
+        await tester.pumpWidget(buildTestWidget(note: pollNote));
+        await tester.pumpAndSettle();
+
+        // 投票選択肢のテキストは表示されている
+        expect(find.textContaining("光る国民の基本的な権利"), findsOneWidget);
+        expect(find.textContaining("ぷるぷる自動販売機"), findsOneWidget);
+        expect(find.textContaining("抗菌仕様金髪碧眼の美少女"), findsOneWidget);
+        
+        // 投票数も表示されている（括弧付きで表示）
+        expect(find.textContaining("17"), findsOneWidget);
+        expect(find.textContaining("9"), findsOneWidget);
+        expect(find.textContaining("27"), findsOneWidget);
+        
+        // 投票数は「(17票)」のような形式で表示されていることを確認
+        expect(find.textContaining("(17票)"), findsOneWidget);
+        expect(find.textContaining("(9票)"), findsOneWidget);
+        expect(find.textContaining("(27票)"), findsOneWidget);
+      });
+
+      testWidgets("【Hook状態リセット問題】ウィジェットツリーが再構築されると投票数表示が消える可能性", (tester) async {
+        // 初期状態でウィジェットを構築
+        await tester.pumpWidget(buildTestWidget(note: pollNote));
+        await tester.pumpAndSettle();
+
+        // 投票数が表示されていることを確認
+        expect(find.textContaining("(17票)"), findsOneWidget);
+        
+        // ウィジェットツリーを完全に再構築（例：タブ切り替えやページ遷移をシミュレート）
+        await tester.pumpWidget(Container()); // 一度空のコンテナに置き換え
+        await tester.pumpAndSettle();
+        
+        // 再度元のウィジェットを構築
+        await tester.pumpWidget(buildTestWidget(note: pollNote));
+        await tester.pumpAndSettle();
+        
+        // Hook の初期化が再度実行される
+        // isOpened = useState(useMemoized(() => !isAnyVotable(ref)))
+        // isAnyVotable(ref) が true の場合、isOpened は false になる
+        
+        // テストデータは未投票なので、isAnyVotable は true を返すはず
+        // したがって、isOpened は false になり、投票数は表示されない可能性がある
+        
+        // 投票数が表示されているか確認
+        final voteCount17 = find.textContaining("(17票)");
+        if (voteCount17.evaluate().isEmpty) {
+          // 投票数が消えている場合、これが不具合の原因
+          print("不具合再現: ウィジェット再構築後、投票数が表示されなくなりました");
+          expect(find.textContaining("結果を見る"), findsOneWidget);
+        } else {
+          // 投票数が表示されている場合
+          expect(voteCount17, findsOneWidget);
+        }
+      });
+
+
+      testWidgets("【実際の使用シーン】スクロールによる再レンダリング時の動作", (tester) async {
+        // タイムラインのようなリストビューをシミュレート
+        final scrollController = ScrollController();
+        
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              cacheManagerProvider.overrideWith((ref) => MockBaseCacheManager()),
+              notesProvider.overrideWith((ref, account) => notesRepository),
+            ],
+            child: DefaultRootNoRouterWidget(
+              child: Scaffold(
+                body: AccountContextScope.as(
+                  account: TestData.account,
+                  child: ListView.builder(
+                    controller: scrollController,
+                    itemCount: 20,
+                    itemBuilder: (context, index) {
+                      if (index == 10) {
+                        // 10番目に投票ノートを配置
+                        return MisskeyNote(note: pollNote);
+                      }
+                      return Container(
+                        height: 200,
+                        child: Text('ダミーノート $index'),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        
+        // スクロールして投票ノートを表示
+        await scrollController.animateTo(
+          2000.0,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeInOut,
+        );
+        await tester.pumpAndSettle();
+        
+        // 投票数が表示されているか確認
+        expect(find.textContaining("(17票)"), findsOneWidget);
+        
+        // 画面外にスクロール
+        await scrollController.animateTo(
+          0.0,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeInOut,
+        );
+        await tester.pumpAndSettle();
+        
+        // 再度スクロールして表示
+        await scrollController.animateTo(
+          2000.0,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeInOut,
+        );
+        await tester.pumpAndSettle();
+        
+        // 再レンダリング後も投票数が表示されているか確認
+        final voteCount = find.textContaining("(17票)");
+        if (voteCount.evaluate().isEmpty) {
+          print("不具合再現: スクロール後、投票数が表示されなくなりました");
+          // この場合、Hook の状態がリセットされている
+        } else {
+          expect(voteCount, findsOneWidget);
+        }
+      });
+
+      testWidgets("投票済みのノートでは初期表示で投票数が表示されること", (tester) async {
+        // 投票済みのノートを作成
+        final votedNote = pollNote.copyWith(
+          poll: pollNote.poll!.copyWith(
+            choices: [
+              pollNote.poll!.choices[0].copyWith(isVoted: true),
+              pollNote.poll!.choices[1],
+              pollNote.poll!.choices[2],
+              pollNote.poll!.choices[3],
+            ],
+          ),
+        );
+        
+        await tester.pumpWidget(buildTestWidget(note: votedNote));
+        await tester.pumpAndSettle();
+
+        // 投票済みの場合は投票数が表示されている
+        expect(find.textContaining("17"), findsOneWidget);
+        expect(find.textContaining("9"), findsOneWidget);
+        expect(find.textContaining("27"), findsOneWidget);
+        
+        // 投票済みマークも表示されている
+        expect(find.byIcon(Icons.check), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/view/common/misskey_notes/note_vote_fix_test.dart
+++ b/test/view/common/misskey_notes/note_vote_fix_test.dart
@@ -1,0 +1,184 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:miria/providers.dart";
+import "package:miria/repository/note_repository.dart";
+import "package:miria/view/common/account_scope.dart";
+import "package:miria/view/common/misskey_notes/misskey_note.dart";
+import "package:misskey_dart/misskey_dart.dart";
+
+import "../../../test_util/default_root_widget.dart";
+import "../../../test_util/mock.mocks.dart";
+import "../../../test_util/test_datas.dart";
+
+void main() {
+  group("投票数表示不具合修正のテスト", () {
+    // 期限切れではない投票データを作成
+    final pollNote = TestData.note4AsVote.copyWith(
+      poll: TestData.note4AsVote.poll!.copyWith(
+        expiresAt: DateTime.now().add(const Duration(hours: 1)), // 1時間後に期限切れ
+      ),
+    );
+
+    Widget buildTestWidget({required Note note}) {
+      final mockMisskey = MockMisskey();
+      final notesRepository = NoteRepository(mockMisskey, TestData.account);
+      notesRepository.registerNote(note);
+      final mockCacheManager = MockBaseCacheManager();
+
+      return ProviderScope(
+        overrides: [
+          cacheManagerProvider.overrideWith((ref) => mockCacheManager),
+          notesProvider.overrideWith((ref, account) => notesRepository),
+        ],
+        child: DefaultRootNoRouterWidget(
+          child: Scaffold(
+            body: AccountContextScope.as(
+              account: TestData.account,
+              child: SingleChildScrollView(child: MisskeyNote(note: note)),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets("【修正後】ウィジェット再構築後も投票数表示状態が保持されること", (tester) async {
+      // 同じRepositoryインスタンスを使用
+      final mockMisskey = MockMisskey();
+      final notesRepository = NoteRepository(mockMisskey, TestData.account);
+      notesRepository.registerNote(pollNote);
+      final mockCacheManager = MockBaseCacheManager();
+
+      Widget buildTestWidgetWithSharedRepo() {
+        return ProviderScope(
+          overrides: [
+            cacheManagerProvider.overrideWith((ref) => mockCacheManager),
+            notesProvider.overrideWith((ref, account) => notesRepository),
+          ],
+          child: DefaultRootNoRouterWidget(
+            child: Scaffold(
+              body: AccountContextScope.as(
+                account: TestData.account,
+                child: SingleChildScrollView(child: MisskeyNote(note: pollNote)),
+              ),
+            ),
+          ),
+        );
+      }
+
+      // 初期状態でウィジェットを構築
+      await tester.pumpWidget(buildTestWidgetWithSharedRepo());
+      await tester.pumpAndSettle();
+
+      // 修正後：初期状態では投票数は非表示
+      expect(find.textContaining("(17票)"), findsNothing);
+      expect(find.textContaining("結果を見る"), findsOneWidget);
+      
+      // 「結果を見る」をタップして投票数を表示
+      await tester.tap(find.textContaining("結果を見る"));
+      await tester.pumpAndSettle();
+      
+      // 投票数が表示されていることを確認
+      expect(find.textContaining("(17票)"), findsOneWidget);
+      expect(find.textContaining("(9票)"), findsOneWidget);
+      expect(find.textContaining("(27票)"), findsOneWidget);
+      
+      // ウィジェットツリーを完全に再構築
+      await tester.pumpWidget(Container());
+      await tester.pumpAndSettle();
+      
+      // 再度元のウィジェットを構築（同じRepositoryを使用）
+      await tester.pumpWidget(buildTestWidgetWithSharedRepo());
+      await tester.pumpAndSettle();
+      
+      // 修正後は状態が保持されているため、投票数が表示されたまま
+      expect(find.textContaining("(17票)"), findsOneWidget);
+      expect(find.textContaining("(9票)"), findsOneWidget);
+      expect(find.textContaining("(27票)"), findsOneWidget);
+    });
+
+    testWidgets("【修正後】投票済みノートは初期表示で投票数が表示されること", (tester) async {
+      // 投票済みのノートを作成
+      final votedNote = pollNote.copyWith(
+        poll: pollNote.poll!.copyWith(
+          choices: [
+            pollNote.poll!.choices[0].copyWith(isVoted: true),
+            pollNote.poll!.choices[1],
+            pollNote.poll!.choices[2],
+            pollNote.poll!.choices[3],
+          ],
+        ),
+      );
+      
+      await tester.pumpWidget(buildTestWidget(note: votedNote));
+      await tester.pumpAndSettle();
+
+      // 投票済みの場合は初期表示で投票数が表示される
+      expect(find.textContaining("(17票)"), findsOneWidget);
+      expect(find.textContaining("(9票)"), findsOneWidget);
+      expect(find.textContaining("(27票)"), findsOneWidget);
+      
+      // ウィジェット再構築後も表示状態が保持される
+      await tester.pumpWidget(Container());
+      await tester.pumpAndSettle();
+      await tester.pumpWidget(buildTestWidget(note: votedNote));
+      await tester.pumpAndSettle();
+      
+      expect(find.textContaining("(17票)"), findsOneWidget);
+      expect(find.textContaining("(9票)"), findsOneWidget);
+      expect(find.textContaining("(27票)"), findsOneWidget);
+    });
+
+    testWidgets("【修正後】期限切れ投票は初期表示で投票数が表示されること", (tester) async {
+      // 期限切れの投票ノートを作成
+      final expiredPollNote = pollNote.copyWith(
+        poll: pollNote.poll!.copyWith(
+          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        ),
+      );
+      
+      await tester.pumpWidget(buildTestWidget(note: expiredPollNote));
+      await tester.pumpAndSettle();
+
+      // 期限切れの場合は初期表示で投票数が表示される
+      expect(find.textContaining("(17票)"), findsOneWidget);
+      expect(find.textContaining("(9票)"), findsOneWidget);
+      expect(find.textContaining("(27票)"), findsOneWidget);
+      
+      // 「終了済み」が表示される
+      expect(find.textContaining("終了済み"), findsOneWidget);
+    });
+
+    testWidgets("【修正後】未投票の投票は初期状態で投票数が非表示であること", (tester) async {
+      await tester.pumpWidget(buildTestWidget(note: pollNote));
+      await tester.pumpAndSettle();
+
+      // 修正後：初期状態では投票数は非表示
+      expect(find.textContaining("(17票)"), findsNothing);
+      expect(find.textContaining("結果を見る"), findsOneWidget);
+    });
+    
+    testWidgets("【修正後】投票数表示の切り替えが正しく動作すること", (tester) async {
+      await tester.pumpWidget(buildTestWidget(note: pollNote));
+      await tester.pumpAndSettle();
+
+      // 初期状態では投票数は非表示
+      expect(find.textContaining("(17票)"), findsNothing);
+      
+      // 「結果を見る」をタップ
+      await tester.tap(find.textContaining("結果を見る"));
+      await tester.pumpAndSettle();
+      
+      // 投票数が表示される
+      expect(find.textContaining("(17票)"), findsOneWidget);
+      
+      // 再度タップして非表示にする
+      await tester.tap(find.textContaining("投票する"));
+      await tester.pumpAndSettle();
+      
+      // 投票数が非表示になる
+      expect(find.textContaining("(17票)"), findsNothing);
+      expect(find.textContaining("結果を見る"), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces functionality to manage the visibility of poll results in notes. It adds a new field `isPollResultOpened` to the `NoteStatus` class and integrates it into the `NoteRepository` for state management. Additionally, it updates the `NoteVote` widget to utilize this new state for handling poll result visibility. Mock implementations for testing this functionality have also been updated.

### Feature Addition: Poll Result Visibility Management
* [`lib/repository/note_repository.dart`](diffhunk://#diff-9861922fb3a87364c1382e312a2084965e99268f19e7ea90929ca66621025c4cR19): Added a new field `isPollResultOpened` to the `NoteStatus` class and implemented methods in `NoteRepository` to toggle, set, and retrieve the poll result visibility state. The initial visibility state is determined based on poll expiration and voting status. [[1]](diffhunk://#diff-9861922fb3a87364c1382e312a2084965e99268f19e7ea90929ca66621025c4cR19) [[2]](diffhunk://#diff-9861922fb3a87364c1382e312a2084965e99268f19e7ea90929ca66621025c4cR135) [[3]](diffhunk://#diff-9861922fb3a87364c1382e312a2084965e99268f19e7ea90929ca66621025c4cR174-R222)

### Integration with `NoteVote` Widget
* [`lib/view/common/misskey_notes/note_vote.dart`](diffhunk://#diff-e20a16a48e6581b8c211a18e6886c999f5ae83d9af33f802ef0d2d830c16c042L79-R81): Updated the `NoteVote` widget to use the poll result visibility state from `NoteRepository` instead of local hook state. Voting success now triggers the visibility of poll results, and tapping to toggle visibility is handled via the repository. [[1]](diffhunk://#diff-e20a16a48e6581b8c211a18e6886c999f5ae83d9af33f802ef0d2d830c16c042L79-R81) [[2]](diffhunk://#diff-e20a16a48e6581b8c211a18e6886c999f5ae83d9af33f802ef0d2d830c16c042L97-R100) [[3]](diffhunk://#diff-e20a16a48e6581b8c211a18e6886c999f5ae83d9af33f802ef0d2d830c16c042L127-R135) [[4]](diffhunk://#diff-e20a16a48e6581b8c211a18e6886c999f5ae83d9af33f802ef0d2d830c16c042L168-R174) [[5]](diffhunk://#diff-e20a16a48e6581b8c211a18e6886c999f5ae83d9af33f802ef0d2d830c16c042L192-R204)

### Code Generation Updates
* [`lib/repository/note_repository.freezed.dart`](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L18-R18): Updated generated code to include the new `isPollResultOpened` field in `NoteStatus`. This includes updates to constructors, copy methods, equality checks, and hash code calculations. [[1]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L18-R18) [[2]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L30-R44) [[3]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L55-R55) [[4]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L72-R80) [[5]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L91-R92) [[6]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69R101) [[7]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L112-R128) [[8]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L137-R139) [[9]](diffhunk://#diff-f8c0cfc28289a9e480712d52dd761903689257e8e44fc8ce69f5c4f4f60e0a69L154-R164)

### Mock Implementation for Testing
* [`test/test_util/mock.mocks.dart`](diffhunk://#diff-f9f827495eeeca42d6486f7853cbcd7178c719c9d8f50ac976152462d29efa83R1165-R1186): Added mock implementations for the new methods in `NoteRepository` (`togglePollResult`, `setPollResultOpened`, `getPollResultOpened`) to facilitate testing.