### PR TITLE
fix: debパッケージ作成エラーの修正 & Windowsビルドで標準ISCCに切替

### DIFF
--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -118,7 +118,6 @@ jobs:
             cp ./snap/gui/miria.desktop .debpkg/usr/share/applications/
             cp ./assets/images/icon.png .debpkg/usr/share/pixmaps/miria.png
             ln -s /opt/miria/miria .debpkg/usr/bin/miria
-            chmod a+x .debpkg/usr/bin/miria
             sed -i -E 's|^Version=.*|Version=1.5|g' .debpkg/usr/share/applications/miria.desktop
             sed -i -E 's|^Icon=.*|Icon=miria|g' .debpkg/usr/share/applications/miria.desktop
             echo "DESC=$(awk -F '=' '/^Comment=/{print $2}' .debpkg/usr/share/applications/miria.desktop)" >> $GITHUB_ENV

--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -1,4 +1,4 @@
-name: デプロイ(windows zip)
+name: デプロイ(windows)
 
 on:
   workflow_dispatch:
@@ -47,10 +47,7 @@ jobs:
           curl -o ${{ env.builddir }}\ChineseSimplified.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl
 
       - name: Compile .ISS to .EXE Installer
-        uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
-        with:
-          path: windows/innosetup.iss
-          options: /dMyAppVersion="${{ env.version }}" /dMyWorkDir="${{ env.builddir }}" /Qp
+        run: iscc windows/innosetup.iss /dMyAppVersion="${{ env.version }}" /dMyWorkDir="${{ env.builddir }}" /Qp
 
       - name: Rename .EXE Installer
         run:  mv miria-installer.exe miria-installer_${env:version}_x64.exe


### PR DESCRIPTION
- debパッケージ作成時にエラーが発生するのを修正しました
- Windowsのexeを作成時のisccをビルドインのものに変更しました