### PR TITLE
fix: コードブロックの入力ボタンから改行を削除

### DIFF
--- a/lib/view/common/note_create/basic_keyboard.dart
+++ b/lib/view/common/note_create/basic_keyboard.dart
@@ -95,6 +95,7 @@ class BasicKeyboard extends StatelessWidget {
         CustomKeyboardButton(
           keyboard: "```\n",
           afterInsert: "\n```",
+          displayText: "```",
           controller: controller,
           focusNode: focusNode,
         ),


### PR DESCRIPTION
コードブロックの入力ボタンが改行により少しだけ高い位置に表示されていたため、`displayText`を設定して1行で表示されるように変更する提案です。
|変更前|変更後|
|:-:|:-:|
|![Screenshot from 2025-06-29 11-22-04](https://github.com/user-attachments/assets/47a77f0a-9ef2-4be7-9683-c083dc3a6f85)|![Screenshot from 2025-06-29 11-26-28](https://github.com/user-attachments/assets/7c8146a0-e274-48f0-9e7e-e80ba2859c6b)|
