### PR TITLE
Enable AP inquiry from search

### DIFF
--- a/lib/l10n/app_ja-oj.arb
+++ b/lib/l10n/app_ja-oj.arb
@@ -111,7 +111,9 @@
     "unsupportedFileWithFilename": "{filename}は対応してないファイルのようですわ",
     "failedFileSave": "ファイルの保存に失敗したようですわね…",
 
-    "nothingHere": "ここには何もありませんわ"
+    "nothingHere": "ここには何もありませんわ",
+
+    "confirmApSearch": "照会を実行いたしますこと？"
 
 
 

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1011,6 +1011,8 @@
     "remoteServerWithoutLogin": "相手先のサーバー（ログインなし）",
     "nothingHere": "なんもないで",
 
+    "confirmApSearch": "照会を実行するか？",
+
     "deckMode": "デッキモード",
     "enableDeckMode": "デッキモードにする"
 

--- a/lib/l10n/app_zh-cn.arb
+++ b/lib/l10n/app_zh-cn.arb
@@ -939,5 +939,6 @@
             }
         }
     },
-    "nonInvitedReversi": "好像没有收到邀请"
+    "nonInvitedReversi": "好像没有收到邀请",
+    "confirmApSearch": "要执行照会吗？"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -939,5 +939,6 @@
             }
         }
     },
-    "nonInvitedReversi": "好像没有收到邀请"
+    "nonInvitedReversi": "好像没有收到邀请",
+    "confirmApSearch": "要执行照会吗？"
 }

--- a/lib/util/ap_query.dart
+++ b/lib/util/ap_query.dart
@@ -1,0 +1,28 @@
+
+/// Returns true if the text looks like a query for ActivityPub object.
+/// It matches strings that start with 'http://' or 'https://',
+/// or strings that start with '@' and contain another '@'.
+bool isApQuery(String text) {
+  final trimmed = text.trim();
+  return RegExp(r'^https?://').hasMatch(trimmed) ||
+      (trimmed.startsWith('@') && '@'.allMatches(trimmed).length >= 2);
+}
+
+/// Converts an AP query string to [Uri].
+/// If the input is a URL, it is returned directly.
+/// If the input is a handle like '@user@example.com',
+/// it will be converted to 'https://example.com/@user'.
+Uri apQueryToUri(String text) {
+  final trimmed = text.trim();
+  if (RegExp(r'^https?://').hasMatch(trimmed)) {
+    return Uri.parse(trimmed);
+  }
+  if (trimmed.startsWith('@') && '@'.allMatches(trimmed).length >= 2) {
+    final withoutAt = trimmed.substring(1);
+    final firstAt = withoutAt.indexOf('@');
+    final user = withoutAt.substring(0, firstAt);
+    final host = withoutAt.substring(firstAt + 1);
+    return Uri.parse('https://$host/@$user');
+  }
+  throw FormatException('Invalid AP query', text);
+}

--- a/lib/view/search_page/note_search.dart
+++ b/lib/view/search_page/note_search.dart
@@ -11,6 +11,7 @@ import "package:miria/view/common/misskey_notes/misskey_note.dart";
 import "package:miria/view/common/pushable_listview.dart";
 import "package:miria/view/user_page/user_list_item.dart";
 import "package:misskey_dart/misskey_dart.dart";
+import "package:miria/util/ap_query.dart";
 
 class NoteSearch extends HookConsumerWidget {
   final NoteSearchCondition? initialCondition;
@@ -50,7 +51,10 @@ class NoteSearch extends HookConsumerWidget {
                   focusNode: focusNode,
                   autofocus: true,
                   textInputAction: TextInputAction.done,
-                  onSubmitted: (value) => searchQuery.value = value,
+                  onSubmitted: (value) async {
+                    if (await _handleApSearch(context, ref, value)) return;
+                    searchQuery.value = value;
+                  },
                 ),
               ),
               IconButton(
@@ -262,4 +266,41 @@ class NoteSearchList extends ConsumerWidget {
       },
     );
   }
+}
+
+Future<bool> _handleApSearch(
+  BuildContext context,
+  WidgetRef ref,
+  String value,
+) async {
+  if (!isApQuery(value)) return false;
+  final dialogValue = await ref.read(dialogStateNotifierProvider.notifier).showDialog(
+        message: (c) => S.of(c).confirmApSearch,
+        actions: (c) => [S.of(c).done, S.of(c).cancel],
+      );
+  if (dialogValue != 0) return false;
+
+  final response = await ref.read(dialogStateNotifierProvider.notifier).guard(
+        () async => await ref
+            .read(misskeyGetContextProvider)
+            .ap
+            .show(ApShowRequest(uri: apQueryToUri(value))),
+      );
+  final res = response.valueOrNull;
+  if (res == null) return true;
+  if (res.type.toLowerCase() == 'note') {
+    final note = Note.fromJson(res.object);
+    await ref
+        .read(misskeyNoteNotifierProvider.notifier)
+        .navigateToNoteDetailPage(note);
+    return true;
+  }
+  if (res.type.toLowerCase() == 'user') {
+    final user = UserDetailed.fromJson(res.object);
+    await ref
+        .read(misskeyNoteNotifierProvider.notifier)
+        .navigateToUserPage(user);
+    return true;
+  }
+  return true;
 }

--- a/lib/view/user_select_dialog.dart
+++ b/lib/view/user_select_dialog.dart
@@ -8,6 +8,8 @@ import "package:miria/view/common/account_scope.dart";
 import "package:miria/view/common/pushable_listview.dart";
 import "package:miria/view/user_page/user_list_item.dart";
 import "package:misskey_dart/misskey_dart.dart";
+import "package:miria/util/ap_query.dart";
+import "package:miria/state_notifier/common/misskey_notes/misskey_note_notifier.dart";
 
 @RoutePage<User>()
 class UserSelectDialog extends StatelessWidget implements AutoRouteWrapper {
@@ -60,7 +62,10 @@ class UserSelectContent extends HookConsumerWidget {
           focusNode: focusNode,
           autofocus: true,
           decoration: const InputDecoration(prefixIcon: Icon(Icons.search)),
-          onSubmitted: (value) => searchQuery.value = value,
+          onSubmitted: (value) async {
+            if (await _handleApSearch(context, ref, value)) return;
+            searchQuery.value = value;
+          },
         ),
         const Padding(padding: EdgeInsets.only(bottom: 10)),
         LayoutBuilder(
@@ -153,4 +158,41 @@ class UsersSelectContentList extends ConsumerWidget {
       ),
     );
   }
+}
+
+Future<bool> _handleApSearch(
+  BuildContext context,
+  WidgetRef ref,
+  String value,
+) async {
+  if (!isApQuery(value)) return false;
+  final dialogValue = await ref.read(dialogStateNotifierProvider.notifier).showDialog(
+        message: (c) => S.of(c).confirmApSearch,
+        actions: (c) => [S.of(c).done, S.of(c).cancel],
+      );
+  if (dialogValue != 0) return false;
+
+  final response = await ref.read(dialogStateNotifierProvider.notifier).guard(
+        () async => await ref
+            .read(misskeyGetContextProvider)
+            .ap
+            .show(ApShowRequest(uri: apQueryToUri(value))),
+      );
+  final res = response.valueOrNull;
+  if (res == null) return true;
+  if (res.type.toLowerCase() == 'note') {
+    final note = Note.fromJson(res.object);
+    await ref
+        .read(misskeyNoteNotifierProvider.notifier)
+        .navigateToNoteDetailPage(note);
+    return true;
+  }
+  if (res.type.toLowerCase() == 'user') {
+    final user = UserDetailed.fromJson(res.object);
+    await ref
+        .read(misskeyNoteNotifierProvider.notifier)
+        .navigateToUserPage(user);
+    return true;
+  }
+  return true;
 }

--- a/test/util/ap_query_test.dart
+++ b/test/util/ap_query_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miria/util/ap_query.dart';
+
+void main() {
+  group('isApQuery', () {
+    test('returns true for url', () {
+      expect(isApQuery('https://example.com/note/1'), isTrue);
+    });
+
+    test('returns true for handle', () {
+      expect(isApQuery('@user@example.com'), isTrue);
+    });
+
+    test('returns false for normal text', () {
+      expect(isApQuery('hello'), isFalse);
+    });
+  });
+
+  group('apQueryToUri', () {
+    test('returns same url', () {
+      final uri = apQueryToUri('https://server/notes/1');
+      expect(uri.toString(), 'https://server/notes/1');
+    });
+
+    test('converts handle', () {
+      final uri = apQueryToUri('@name@example.com');
+      expect(uri.toString(), 'https://example.com/@name');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `apQuery` helper to detect and convert ActivityPub queries
- ask to run AP inquiry when submitting certain search terms
- fetch note or user via `ap/show` and open detail view
- localize confirmation message
- cover detection logic with tests

Fix #719

## Testing
- `flutter gen-l10n`
- `flutter test test/util/ap_query_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_685d186e2794832183fd19ec09c8834a