### PR TITLE
feat: 絵文字情報等の手動更新ボタンの追加

### DIFF
--- a/lib/l10n/app_ja-oj.arb
+++ b/lib/l10n/app_ja-oj.arb
@@ -119,7 +119,9 @@
     "invitedReversi": "{users}から招待されているようですわ",
     "nonInvitedReversi": "招待されていないようですわね…",
 
-    "nothingHere": "ここには何もありませんわ"
+    "nothingHere": "ここには何もありませんわ",
+    
+    "cacheManualUpdateCompleted": "情報の取得が完了しましたわ"
 
 
 

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1019,6 +1019,9 @@
 
     "remoteServerWithoutLogin": "相手先のサーバー（ログインなし）",
     "nothingHere": "なんもないで",
+    
+    "refresh": "更新",
+    "cacheManualUpdateCompleted": "情報の取得が完了したで",
 
     "deckMode": "デッキモード",
     "enableDeckMode": "デッキモードにする"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1019,8 +1019,8 @@
 
     "remoteServerWithoutLogin": "相手先のサーバー（ログインなし）",
     "nothingHere": "なんもないで",
-    
-    "refresh": "更新",
+
+    "cacheRefreshNow": "いますぐキャッシュを更新",
     "cacheManualUpdateCompleted": "情報の取得が完了したで",
 
     "deckMode": "デッキモード",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3216,6 +3216,18 @@ abstract class S {
   /// **'なんもないで'**
   String get nothingHere;
 
+  /// No description provided for @refresh.
+  ///
+  /// In ja, this message translates to:
+  /// **'更新'**
+  String get refresh;
+
+  /// No description provided for @cacheManualUpdateCompleted.
+  ///
+  /// In ja, this message translates to:
+  /// **'情報の取得が完了したで'**
+  String get cacheManualUpdateCompleted;
+
   /// No description provided for @deckMode.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3216,11 +3216,11 @@ abstract class S {
   /// **'なんもないで'**
   String get nothingHere;
 
-  /// No description provided for @refresh.
+  /// No description provided for @cacheRefreshNow.
   ///
   /// In ja, this message translates to:
-  /// **'更新'**
-  String get refresh;
+  /// **'いますぐキャッシュを更新'**
+  String get cacheRefreshNow;
 
   /// No description provided for @cacheManualUpdateCompleted.
   ///

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1862,6 +1862,12 @@ class SJa extends S {
   String get nothingHere => 'なんもないで';
 
   @override
+  String get refresh => '更新';
+
+  @override
+  String get cacheManualUpdateCompleted => '情報の取得が完了したで';
+
+  @override
   String get deckMode => 'デッキモード';
 
   @override
@@ -2202,4 +2208,7 @@ class SJaOj extends SJa {
 
   @override
   String get nothingHere => 'ここには何もありませんわ';
+
+  @override
+  String get cacheManualUpdateCompleted => '情報の取得が完了しましたわ';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1862,7 +1862,7 @@ class SJa extends S {
   String get nothingHere => 'なんもないで';
 
   @override
-  String get refresh => '更新';
+  String get cacheRefreshNow => 'いますぐキャッシュを更新';
 
   @override
   String get cacheManualUpdateCompleted => '情報の取得が完了したで';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1854,7 +1854,7 @@ class SZh extends S {
   String get nothingHere => 'なんもないで';
 
   @override
-  String get refresh => '更新';
+  String get cacheRefreshNow => 'いますぐキャッシュを更新';
 
   @override
   String get cacheManualUpdateCompleted => '情報の取得が完了したで';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1854,6 +1854,12 @@ class SZh extends S {
   String get nothingHere => 'なんもないで';
 
   @override
+  String get refresh => '更新';
+
+  @override
+  String get cacheManualUpdateCompleted => '情報の取得が完了したで';
+
+  @override
   String get deckMode => 'デッキモード';
 
   @override

--- a/lib/view/several_account_settings_page/cache_management_page/cache_management_page.dart
+++ b/lib/view/several_account_settings_page/cache_management_page/cache_management_page.dart
@@ -5,6 +5,7 @@ import "package:miria/l10n/app_localizations.dart";
 import "package:miria/model/account.dart";
 import "package:miria/model/account_settings.dart";
 import "package:miria/providers.dart";
+import "package:miria/repository/account_repository.dart";
 
 @RoutePage()
 class CacheManagementPage extends ConsumerStatefulWidget {
@@ -26,6 +27,8 @@ class CacheManagementPageState extends ConsumerState<CacheManagementPage> {
   CacheStrategy iCacheStrategy = CacheStrategy.whenTabChange;
   CacheStrategy emojisCacheStrategy = CacheStrategy.whenLaunch;
   CacheStrategy metaCacheStrategy = CacheStrategy.whenOneDay;
+
+  bool isRefreshing = false;
 
   @override
   void didChangeDependencies() {
@@ -65,6 +68,25 @@ class CacheManagementPageState extends ConsumerState<CacheManagementPage> {
                 emojiCacheStrategy: emojisCacheStrategy,
               ),
         );
+  }
+
+  Future<void> refresh() async {
+    setState(() {
+      isRefreshing = true;
+    });
+    await ref.read(emojiRepositoryProvider(widget.account)).loadFromSource();
+    await ref.read(accountRepositoryProvider.notifier).updateI(widget.account);
+    await ref
+        .read(accountRepositoryProvider.notifier)
+        .updateMeta(widget.account);
+    if (!context.mounted) return;
+    setState(() {
+      isRefreshing = false;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(S.of(context).cacheManualUpdateCompleted)),
+    );
   }
 
   @override
@@ -119,6 +141,43 @@ class CacheManagementPageState extends ConsumerState<CacheManagementPage> {
                   save();
                 }),
               ),
+              const Padding(padding: EdgeInsets.only(top: 20)),
+              if (isRefreshing)
+                OutlinedButton(
+                  onPressed: null,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.all(5),
+                    minimumSize: const Size(double.infinity, 0),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        width:
+                            Theme.of(context).textTheme.bodyMedium?.fontSize ??
+                            22,
+                        height:
+                            Theme.of(context).textTheme.bodyMedium?.fontSize ??
+                            22,
+                        child: const CircularProgressIndicator(),
+                      ),
+                      const SizedBox(width: 10),
+                      Text(S.of(context).refreshing),
+                    ],
+                  ),
+                )
+              else
+                ElevatedButton.icon(
+                  icon: const Icon(Icons.refresh),
+                  onPressed: refresh,
+                  label: Text(S.of(context).refresh),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.all(5),
+                    minimumSize: const Size(double.infinity, 0),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ),
             ],
           ),
         ),

--- a/lib/view/several_account_settings_page/cache_management_page/cache_management_page.dart
+++ b/lib/view/several_account_settings_page/cache_management_page/cache_management_page.dart
@@ -171,7 +171,7 @@ class CacheManagementPageState extends ConsumerState<CacheManagementPage> {
                 ElevatedButton.icon(
                   icon: const Icon(Icons.refresh),
                   onPressed: refresh,
-                  label: Text(S.of(context).refresh),
+                  label: Text(S.of(context).cacheRefreshNow),
                   style: ElevatedButton.styleFrom(
                     padding: const EdgeInsets.all(5),
                     minimumSize: const Size(double.infinity, 0),


### PR DESCRIPTION
キャッシュ設定画面内で「自分自身の情報 / 絵文字情報 / サーバーの情報」の更新を手動で行えるようにしました
![image](https://github.com/user-attachments/assets/ee7e50a1-a319-4f9e-9f88-ae732f5659ed)
