### PR TITLE
Fix page content type null handling

### DIFF
--- a/lib/view/misskey_page_page/misskey_page_page.dart
+++ b/lib/view/misskey_page_page/misskey_page_page.dart
@@ -272,6 +272,10 @@ class PageContent extends ConsumerWidget {
       );
     }
 
+    if (content.type == null) {
+      return const SizedBox.shrink();
+    }
+
     return SizedBox(
       width: double.infinity,
       child: Card(


### PR DESCRIPTION
## Summary
- return `SizedBox.shrink()` for null page content types to avoid showing the unsupported message

Fix #703

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_686343fb3db883219b6c48c95bf81c19