### PR TITLE
公開範囲に応じた背景色の設定カードをテーブル表示に変更

### DIFF
--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -374,228 +374,223 @@ class GeneralSettingsPage extends HookConsumerWidget {
                         style: Theme.of(context).textTheme.titleLarge,
                       ),
                       const Padding(padding: EdgeInsets.only(top: 10)),
-                      Text(S.of(context).lightMode),
-                      Row(
+                      Table(
                         children: [
-                          Expanded(child: Text(S.of(context).public)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    lightNoteBgPublic.value ??
-                                    Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
-                                ),
-                              ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                lightNoteBgPublic.value = result;
-                              }
-                            },
+                          // ヘッダー
+                          TableRow(
+                            children: [
+                              Spacer(),
+                              Text(S.of(context).lightMode),
+                              Text(S.of(context).darkMode),
+                            ],
                           ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(child: Text(S.of(context).homeOnly)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    lightNoteBgHome.value ?? Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
+                          // パブリック
+                          TableRow(
+                            children: [
+                              Text(S.of(context).public),
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        lightNoteBgPublic.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
                                 ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    lightNoteBgPublic.value = result;
+                                  }
+                                },
                               ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                lightNoteBgHome.value = result;
-                              }
-                            },
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        darkNoteBgPublic.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
+                                ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    darkNoteBgPublic.value = result;
+                                  }
+                                },
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(child: Text(S.of(context).followersOnly)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    lightNoteBgFollowers.value ??
-                                    Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
+                          // ホームのみ
+                          TableRow(
+                            children: [
+                              Text(S.of(context).homeOnly),
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        lightNoteBgHome.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
                                 ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    lightNoteBgHome.value = result;
+                                  }
+                                },
                               ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                lightNoteBgFollowers.value = result;
-                              }
-                            },
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        darkNoteBgHome.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
+                                ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    darkNoteBgHome.value = result;
+                                  }
+                                },
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(child: Text(S.of(context).direct)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    lightNoteBgDirect.value ??
-                                    Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
+                          // フォロワーのみ
+                          TableRow(
+                            children: [
+                              Text(S.of(context).followersOnly),
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        lightNoteBgFollowers.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
                                 ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    lightNoteBgFollowers.value = result;
+                                  }
+                                },
                               ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                lightNoteBgDirect.value = result;
-                              }
-                            },
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        darkNoteBgFollowers.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
+                                ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    darkNoteBgFollowers.value = result;
+                                  }
+                                },
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                      const Padding(padding: EdgeInsets.only(top: 10)),
-                      Text(S.of(context).darkMode),
-                      Row(
-                        children: [
-                          Expanded(child: Text(S.of(context).public)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    darkNoteBgPublic.value ??
-                                    Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
+                          // ダイレクト
+                          TableRow(
+                            children: [
+                              Text(S.of(context).direct),
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        lightNoteBgDirect.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
                                 ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    lightNoteBgDirect.value = result;
+                                  }
+                                },
                               ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                darkNoteBgPublic.value = result;
-                              }
-                            },
-                          ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(child: Text(S.of(context).homeOnly)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    darkNoteBgHome.value ?? Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
+                              IconButton(
+                                icon: Container(
+                                  width: 24,
+                                  height: 24,
+                                  decoration: BoxDecoration(
+                                    color:
+                                        darkNoteBgDirect.value ??
+                                        Colors.transparent,
+                                    border: Border.all(
+                                      color: Theme.of(context).primaryColor,
+                                      width: 1.0,
+                                    ),
+                                  ),
                                 ),
+                                onPressed: () async {
+                                  final result = await context.pushRoute<Color>(
+                                    const ColorPickerRoute(),
+                                  );
+                                  if (result != null) {
+                                    darkNoteBgDirect.value = result;
+                                  }
+                                },
                               ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                darkNoteBgHome.value = result;
-                              }
-                            },
-                          ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(child: Text(S.of(context).followersOnly)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    darkNoteBgFollowers.value ??
-                                    Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
-                                ),
-                              ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                darkNoteBgFollowers.value = result;
-                              }
-                            },
-                          ),
-                        ],
-                      ),
-                      Row(
-                        children: [
-                          Expanded(child: Text(S.of(context).direct)),
-                          IconButton(
-                            icon: Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color:
-                                    darkNoteBgDirect.value ??
-                                    Colors.transparent,
-                                border: Border.all(
-                                  color: Theme.of(context).primaryColor,
-                                  width: 1.0,
-                                ),
-                              ),
-                            ),
-                            onPressed: () async {
-                              final result = await context.pushRoute<Color>(
-                                const ColorPickerRoute(),
-                              );
-                              if (result != null) {
-                                darkNoteBgDirect.value = result;
-                              }
-                            },
+                            ],
                           ),
                         ],
                       ),


### PR DESCRIPTION
公開範囲に応じた背景色の設定カードを、テーブル表示に変更する提案です。

|変更前|変更後|
|:-:|:-:|
|![Screenshot from 2025-07-06 15-51-19](https://github.com/user-attachments/assets/7be6dc2c-674a-42b0-a2f8-0647055a0956)|![Screenshot from 2025-07-06 15-50-44](https://github.com/user-attachments/assets/a9580085-60f7-4cf7-b25d-dc7d15d724d6)|