### PR TITLE
chore(CI): Linuxのビルド時間の短縮化

### DIFF
--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -128,11 +128,7 @@ jobs:
             docker exec debian bash -c '
                 rm -rf "${PKG_DIR}"
                 mkdir -p \
-                    "${PKG_DIR}/DEBIAN" \
                     "${PKG_DIR}/opt/miria" \
-                    "${PKG_DIR}/usr/share/applications" \
-                    "${PKG_DIR}/usr/share/pixmaps" \
-                    "${PKG_DIR}/usr/share/licenses/miria" \
                     "${PKG_DIR}/usr/bin"
                 
                 case "${ARCH}" in
@@ -140,14 +136,14 @@ jobs:
                   "arm64" ) cp -rp ./build/linux/arm64/release/bundle/* "${PKG_DIR}/opt/miria/" ;;
                 esac
 
-                cp ./snap/gui/miria.desktop "${PKG_DIR}/usr/share/applications/miria.desktop"
-                cp ./assets/images/icon.png "${PKG_DIR}/usr/share/pixmaps/miria.png"
-                cp ./LICENSE "${PKG_DIR}/usr/share/licenses/miria/LICENSE"
+                install -Dm 644 ./snap/gui/miria.desktop "${PKG_DIR}/usr/share/applications/miria.desktop"
+                install -Dm 644 ./assets/images/icon.png "${PKG_DIR}/usr/share/pixmaps/miria.png"
+                install -Dm 644 ./LICENSE "${PKG_DIR}/usr/share/licenses/miria/LICENSE"
                 ln -s /opt/miria/miria "${PKG_DIR}/usr/bin/miria"
                 sed -i -E "s|^Version=.*|Version=1.5|g" "${PKG_DIR}/usr/share/applications/miria.desktop"
                 sed -i -E "s|^Icon=.*|Icon=miria|g" "${PKG_DIR}/usr/share/applications/miria.desktop"
 
-                cp ./linux/debian/control "${PKG_DIR}/DEBIAN/control"
+                install -Dm 644 ./linux/debian/control "${PKG_DIR}/DEBIAN/control"
                 sed -i -E "s|^Version: .*|Version: ${VERSION}|g" "${PKG_DIR}/DEBIAN/control"
                 sed -i -E "s|^Architecture: .*|Architecture: ${ARCH}|g" "${PKG_DIR}/DEBIAN/control"
             '

--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -5,20 +5,21 @@ on:
   release:
     types: [published]
 
-env:
-  APP_NAME: 'miria'
-  MAINTAINER: 'sorairo <sorairo@shiosyakeyakini.info>'
-
 permissions:
   contents: write
 
 jobs:
   build-snap:
     name: ビルド（Snap）
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        platform: [amd64, arm64]
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.os }}
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
     steps:
@@ -56,85 +57,109 @@ jobs:
       #    snap: ${{ steps.snapcraft.outputs.snap }}
       #    release: stable
 
-
-  build-debs:
-    name: ビルド（Deb）
-    runs-on: ubuntu-latest
+  build-deb:
+    name: ビルド（deb）
     strategy:
+      fail-fast: false
       matrix:
-        platform: [amd64]
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.os }}
     steps:
         - name: Clone repository
           uses: actions/checkout@v4
 
-        - name: Get Flutter version from .fvmrc
-          run:  echo "FLUTTER_FVM_VERSION=$(jq -r .flutter .fvmrc)" >> $GITHUB_ENV
+        - name: Set up Docker
+          uses: docker/setup-buildx-action@v3
 
-        - name: Install Flutter
-          uses: subosito/flutter-action@v2
-          with:
-            flutter-version: ${{ env.FLUTTER_FVM_VERSION }}
-            cache: true
-
-        - name: Patch for linux build
+        - name: Set Environment Variables
           run: |
-            sudo apt-get update -y
-            sudo apt-get install -y ninja-build libgtk-3-dev libsecret-1-dev libstdc++-12-dev nasm
-            sudo pip3 install meson
+            NAME=$(yq -r '.name' pubspec.yaml)
+            VERSION=$(yq -r '.version' pubspec.yaml)
 
-        - name: Build libmpv
+            case "${{ runner.arch }}" in
+              "X64" ) arch="amd64" ;;
+              "ARM64" ) arch="arm64" ;;
+            esac
+
+            echo "PKG_DIR=${NAME}_${VERSION}_${arch}" >> $GITHUB_ENV
+            echo "ARCH=$arch" >> $GITHUB_ENV
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+        - name: Start Debian Build Container
           run: |
-            git clone https://github.com/mpv-player/mpv-build.git
-            cd mpv-build
-            sed -i 's|checkout_ffmpeg=master|checkout_ffmpeg=@dcdfd7fb62464beeeb03c24f21713bf3914b9ea4|g' update
-            sed -i 's|checkout_libplacebo=master|checkout_libplacebo=@ed29e541a55acf28022738440b2a925386292551|g' update
-            sed -i 's|checkout_mpv=master|checkout_mpv=@140ec21c89d671d392877a7f3b91d67e7d7b9239|g' update
-            sed -i 's|OPTIONS="--enable-static --disable-shared"|OPTIONS="--enable-shared"|g' scripts/libass-config
-            sed -i 's|--prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib"||g' scripts/libass-config
-            sed -i 's|^meson setup build.*||g' scripts/mpv-config
-            echo -e "\npython3 ./bootstrap.py\n./waf configure --disable-alsa --enable-libmpv-shared\n./waf build" >> scripts/mpv-config
-            ./update
-            ./scripts/libplacebo-config
-            ./scripts/libplacebo-build -j$(nproc)
-            ./scripts/libass-config
-            sudo make -C libass install -j$(nproc)
-            ./scripts/ffmpeg-config
-            ./scripts/ffmpeg-build -j$(nproc)
-            ./scripts/mpv-config
-            cd mpv
-            sudo ./waf install
+            docker run -dit --name debian \
+              -v "${PWD}:/workspace" \
+              -w /workspace \
+              -e PKG_DIR="$PKG_DIR" \
+              -e ARCH="$ARCH" \
+              -e VERSION="$VERSION" \
+              debian:bookworm \
+              bash
 
-        - run: flutter pub get
-#        - run: flutter test
-        - run: flutter build linux
-        - name: Get Build Version
+        - name: Install Build Dependencies
           run: |
-            echo "VERSION=$(yq -r '.version' pubspec.yaml)" >> $GITHUB_ENV
+            docker exec debian bash -c '
+                apt update
+                apt install -y curl git unzip ninja-build libgtk-3-dev libsecret-1-dev libstdc++-12-dev nasm cmake libmpv-dev clang
+                rm -rf /var/lib/apt/lists/*
+            '
 
-        - name: Prepare to build DEB
+        - name: Install FVM
           run: |
-            mkdir -p .debpkg/opt/miria .debpkg/usr/share/applications .debpkg/usr/share/pixmaps .debpkg/usr/bin
-            cp -rp ./build/linux/x64/release/bundle/* .debpkg/opt/miria/
-            cp ./snap/gui/miria.desktop .debpkg/usr/share/applications/
-            cp ./assets/images/icon.png .debpkg/usr/share/pixmaps/miria.png
-            ln -s /opt/miria/miria .debpkg/usr/bin/miria
-            sed -i -E 's|^Version=.*|Version=1.5|g' .debpkg/usr/share/applications/miria.desktop
-            sed -i -E 's|^Icon=.*|Icon=miria|g' .debpkg/usr/share/applications/miria.desktop
-            echo "DESC=$(awk -F '=' '/^Comment=/{print $2}' .debpkg/usr/share/applications/miria.desktop)" >> $GITHUB_ENV
+            docker exec debian bash -c 'curl -fsSL https://fvm.app/install.sh | bash'
 
-        - name: Build DEB
-          uses: jiro4989/build-deb-action@v3
-          with:
-            desc: '${{ env.DESC }}'
-            package: ${{ env.APP_NAME }}
-            maintainer: ${{ env.MAINTAINER }}
-            version: ${{ env.VERSION }}
-            arch: "amd64"
-            package_root: ".debpkg"
-            depends: "libgtk-3-0, libstdc++6, libx11-6, libmpv2, libsecret-1-0"
+        - name: Set up flutter
+          run: |
+            docker exec debian bash -c 'fvm install --setup'
+        
+        - name: Build
+          run: |
+            docker exec debian bash -c '
+                fvm flutter pub get
+                fvm flutter build linux --release
+            '
 
-        - name: Upload DEB
+        - name: Prepare Package
+          run: |
+            docker exec debian bash -c '
+                rm -rf "${PKG_DIR}"
+                mkdir -p \
+                    "${PKG_DIR}/DEBIAN" \
+                    "${PKG_DIR}/opt/miria" \
+                    "${PKG_DIR}/usr/share/applications" \
+                    "${PKG_DIR}/usr/share/pixmaps" \
+                    "${PKG_DIR}/usr/share/licenses/miria" \
+                    "${PKG_DIR}/usr/bin"
+                
+                case "${ARCH}" in
+                  "amd64" ) cp -rp ./build/linux/x64/release/bundle/* "${PKG_DIR}/opt/miria/" ;;
+                  "arm64" ) cp -rp ./build/linux/arm64/release/bundle/* "${PKG_DIR}/opt/miria/" ;;
+                esac
+
+                cp ./snap/gui/miria.desktop "${PKG_DIR}/usr/share/applications/miria.desktop"
+                cp ./assets/images/icon.png "${PKG_DIR}/usr/share/pixmaps/miria.png"
+                cp ./LICENSE "${PKG_DIR}/usr/share/licenses/miria/LICENSE"
+                ln -s /opt/miria/miria "${PKG_DIR}/usr/bin/miria"
+                sed -i -E "s|^Version=.*|Version=1.5|g" "${PKG_DIR}/usr/share/applications/miria.desktop"
+                sed -i -E "s|^Icon=.*|Icon=miria|g" "${PKG_DIR}/usr/share/applications/miria.desktop"
+
+                cp ./linux/debian/control "${PKG_DIR}/DEBIAN/control"
+                sed -i -E "s|^Version: .*|Version: ${VERSION}|g" "${PKG_DIR}/DEBIAN/control"
+                sed -i -E "s|^Architecture: .*|Architecture: ${ARCH}|g" "${PKG_DIR}/DEBIAN/control"
+            '
+        
+        - name: Generate .deb File
+          run: |
+            docker exec debian bash -c '
+                dpkg-deb --build "${PKG_DIR}"
+            '
+
+        - name: Upload .deb File
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
-            gh release upload v$VERSION ./miria_${{ env.VERSION }}_amd64.deb
+            gh release upload v$VERSION ./$PKG_DIR.deb

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -1,0 +1,8 @@
+Package: miria
+Version: 2.0.2+117
+Section: net
+Priority: optional
+Architecture: amd64
+Maintainer: sorairo <sorairo@shiosyakeyakini.info>
+Depends: libgtk-3-0, libstdc++6, libx11-6, libmpv2, libsecret-1-0
+Description: Misskey client app for mobile (Linux build)

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -4,5 +4,5 @@ Section: net
 Priority: optional
 Architecture: amd64
 Maintainer: sorairo <sorairo@shiosyakeyakini.info>
-Depends: libgtk-3-0, libstdc++6, libx11-6, libmpv2, libsecret-1-0
+Depends: libgtk-3-0, libstdc++6, libmpv2, libsecret-1-0
 Description: Misskey client app for mobile (Linux build)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,6 +81,7 @@ parts:
       #flutter pub run build_runner build --delete-conflicting-outputs
       flutter build linux --release --verbose --target lib/main.dart
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/
+      install -Dm644 LICENSE "$CRAFT_PART_INSTALL/usr/share/licenses/miria/LICENSE"
 
   zenity:
   # Integrate custom dialogs in your snap - doc - snapcraft.io


### PR DESCRIPTION
- debパッケージにarm64が増えました
- debパッケージをdocker上のdebian 12でビルドを行うようにしました
- snap(arm64)をarm64環境でビルドを行うように変更し、10分程度でビルドが完了するようになりました
- deb/snap両方にLICENSEファイルを追加するように

|Before|After|
|--|--|
|<img width="646" height="342" alt="image" src="https://github.com/user-attachments/assets/59e0385a-0e68-402f-899d-b2c8e0348e15" />|<img width="661" height="460" alt="image" src="https://github.com/user-attachments/assets/03dbf36f-4494-4fe8-a630-ebedfcea803c" />
