### PR TITLE
perf: リアクションピッカーの動作速度の改善

### DIFF
--- a/lib/view/reaction_picker_dialog/reaction_picker_content.dart
+++ b/lib/view/reaction_picker_dialog/reaction_picker_content.dart
@@ -50,46 +50,44 @@ class ReactionPickerContentState extends ConsumerState<ReactionPickerContent> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: Column(
-        children: [
-          EmojiSearch(
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: EmojiSearch(
             onTap: widget.onTap,
             isAcceptSensitive: widget.isAcceptSensitive,
           ),
-          ListView.builder(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: categoryList.length,
-            itemBuilder: (context, index) => ExpansionTile(
-              title: Text(categoryList[index]),
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(10),
-                  child: Align(
-                    alignment: Alignment.topLeft,
-                    child: Wrap(
-                      spacing: 5,
-                      runSpacing: 5,
-                      crossAxisAlignment: WrapCrossAlignment.start,
-                      children: [
-                        for (final emoji in (emojiRepository.emoji ?? []).where(
-                          (element) => element.category == categoryList[index],
-                        ))
-                          EmojiButton(
-                            emoji: emoji.emoji,
-                            onTap: widget.onTap,
-                            isAcceptSensitive: widget.isAcceptSensitive,
-                          ),
-                      ],
-                    ),
+        ),
+        SliverList.builder(
+          itemCount: categoryList.length,
+          itemBuilder: (context, index) => ExpansionTile(
+            title: Text(categoryList[index]),
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(10),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Wrap(
+                    spacing: 5,
+                    runSpacing: 5,
+                    crossAxisAlignment: WrapCrossAlignment.start,
+                    children: [
+                      for (final emoji in (emojiRepository.emoji ?? []).where(
+                        (element) => element.category == categoryList[index],
+                      ))
+                        EmojiButton(
+                          emoji: emoji.emoji,
+                          onTap: widget.onTap,
+                          isAcceptSensitive: widget.isAcceptSensitive,
+                        ),
+                    ],
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
Androidでカテゴリーの多いサーバーで動作がだいぶ重たくなっていたので
`SingleChildScrollView`から`CustomScrollView`に変更しました