### PR TITLE
fix: allowCompressionがDeprecatedになったため対応

### DIFF
--- a/lib/state_notifier/note_create_page/note_create_state_notifier.dart
+++ b/lib/state_notifier/note_create_page/note_create_state_notifier.dart
@@ -608,8 +608,9 @@ class NoteCreateNotifier extends _$NoteCreateNotifier {
       final result = await FilePicker.platform.pickFiles(
         type: FileType.image,
         allowMultiple: true,
-        allowCompression: Platform.isIOS, // v8.1.3ではiOS以外でこの値を使用していない
-        compressionQuality: 0, // Androidでは0にすることで圧縮パススルー
+        // iOSでは0の場合HEICファイルがJPEGに変換されないため
+        // Androidでは圧縮時に画像の向きがおかしくなることがあるため圧縮パススルー
+        compressionQuality: (Platform.isIOS) ? 95 : 0,
       );
       if (result == null || result.files.isEmpty) return;
 


### PR DESCRIPTION
allowCompressionがdeprecatedになっていたためiOSの場合には`compressionQuality`を95に（0より大きければなんでもよさそうなのでJPEG品質に）

ref: https://github.com/miguelpruivo/flutter_file_picker/blob/9e1ace52cf31c327c0b979c173f9b0fdd5647546/ios/file_picker/Sources/file_picker/FilePickerPlugin.m#L119