### PR TITLE
プロフィール編集ページの追加情報の項目をCardへ移動

### DIFF
--- a/lib/l10n/app_ja-oj.arb
+++ b/lib/l10n/app_ja-oj.arb
@@ -153,7 +153,7 @@
     "profileFromDrive": "ドライブから",
     "profileFieldName": "名前",
     "profileFieldValue": "内容",
-    "profileAddField": "追加",
+    "profileAddField": "項目を追加",
     "profileFollowedMessage": "フォローされたときのメッセージ",
 
     "noteBackgroundColor": "ノート背景色"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1077,7 +1077,7 @@
     "profileFromDrive": "ドライブから",
     "profileFieldName": "名前",
     "profileFieldValue": "内容",
-    "profileAddField": "追加",
+    "profileAddField": "項目を追加",
     "profileFollowedMessage": "フォローされたときのメッセージ"
 
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3447,7 +3447,7 @@ abstract class S {
   /// No description provided for @profileAddField.
   ///
   /// In ja, this message translates to:
-  /// **'追加'**
+  /// **'項目を追加'**
   String get profileAddField;
 
   /// No description provided for @profileFollowedMessage.

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1984,7 +1984,7 @@ class SJa extends S {
   String get profileFieldValue => '内容';
 
   @override
-  String get profileAddField => '追加';
+  String get profileAddField => '項目を追加';
 
   @override
   String get profileFollowedMessage => 'フォローされたときのメッセージ';
@@ -2378,7 +2378,7 @@ class SJaOj extends SJa {
   String get profileFieldValue => '内容';
 
   @override
-  String get profileAddField => '追加';
+  String get profileAddField => '項目を追加';
 
   @override
   String get profileFollowedMessage => 'フォローされたときのメッセージ';

--- a/lib/view/profile_edit_page/profile_edit_page.dart
+++ b/lib/view/profile_edit_page/profile_edit_page.dart
@@ -109,8 +109,10 @@ class _ProfileEditForm extends HookConsumerWidget {
         child: Padding(
           padding: const EdgeInsets.all(10),
           child: Column(
+            spacing: 16,
             children: [
               Row(
+                spacing: 16,
                 children: [
                   GestureDetector(
                     onTap: () async {
@@ -211,7 +213,6 @@ class _ProfileEditForm extends HookConsumerWidget {
                       ],
                     ),
                   ),
-                  const SizedBox(width: 16),
                   Expanded(
                     child: TextField(
                       controller: useTextEditingController(text: data.name),
@@ -221,7 +222,6 @@ class _ProfileEditForm extends HookConsumerWidget {
                   ),
                 ],
               ),
-              const SizedBox(height: 16),
               TextField(
                 controller: useTextEditingController(text: data.description),
                 maxLines: null,
@@ -257,58 +257,68 @@ class _ProfileEditForm extends HookConsumerWidget {
                   ),
                 ],
               ),
-              ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: data.fields.length,
-                itemBuilder: (context, index) {
-                  final field = data.fields[index];
-                  return HookBuilder(
-                    builder: (context) {
-                      final nameController = useTextEditingController(
-                        text: field.name,
-                      );
-                      final valueController = useTextEditingController(
-                        text: field.value,
-                      );
-                      return Row(
-                        children: [
-                          Expanded(
-                            child: TextField(
-                              controller: nameController,
-                              onChanged: (value) =>
-                                  notifier.updateField(index, name: value),
-                              decoration: InputDecoration(
-                                labelText: s.profileFieldName,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 10),
-                          Expanded(
-                            child: TextField(
-                              controller: valueController,
-                              onChanged: (value) =>
-                                  notifier.updateField(index, value: value),
-                              decoration: InputDecoration(
-                                labelText: s.profileFieldValue,
-                              ),
-                            ),
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.close),
-                            onPressed: () => notifier.removeField(index),
-                          ),
-                        ],
-                      );
-                    },
-                  );
-                },
-              ),
-              Align(
-                alignment: Alignment.centerLeft,
-                child: TextButton(
-                  onPressed: notifier.addField,
-                  child: Text(s.profileAddField),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(15),
+                  child: Column(
+                    children: [
+                      ListView.builder(
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        itemCount: data.fields.length,
+                        itemBuilder: (context, index) {
+                          final field = data.fields[index];
+                          return HookBuilder(
+                            builder: (context) {
+                              final nameController = useTextEditingController(
+                                text: field.name,
+                              );
+                              final valueController = useTextEditingController(
+                                text: field.value,
+                              );
+                              return Row(
+                                children: [
+                                  Expanded(
+                                    child: TextField(
+                                      controller: nameController,
+                                      onChanged: (value) => notifier
+                                          .updateField(index, name: value),
+                                      decoration: InputDecoration(
+                                        labelText: s.profileFieldName,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 10),
+                                  Expanded(
+                                    child: TextField(
+                                      controller: valueController,
+                                      onChanged: (value) => notifier
+                                          .updateField(index, value: value),
+                                      decoration: InputDecoration(
+                                        labelText: s.profileFieldValue,
+                                      ),
+                                    ),
+                                  ),
+                                  IconButton(
+                                    icon: const Icon(Icons.close),
+                                    onPressed: () =>
+                                        notifier.removeField(index),
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        },
+                      ),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: TextButton(
+                          onPressed: notifier.addField,
+                          child: Text(s.profileAddField),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
               TextField(


### PR DESCRIPTION
プロフィール編集画面において、どこからどこまでが追加情報のリストの編集領域かわかりにくく、「追加」ボタンが何か理解しにくかったため、Card内に移動し、「追加」を「項目を追加」に変更する提案です。
<img width="516" height="331" alt="Screenshot from 2025-07-18 00-30-21" src="https://github.com/user-attachments/assets/e1a52a54-7c9c-46d9-a14e-249f7ef1dce6" />
