### PR TITLE
二重にTLを購読してしまうことがあるのを改善

### DIFF
--- a/lib/repository/socket_timeline_repository.dart
+++ b/lib/repository/socket_timeline_repository.dart
@@ -38,6 +38,7 @@ abstract class SocketTimelineRepository extends TimelineRepository {
   Map<String, dynamic> get parameters;
   String? timelineId;
   String? mainId;
+  List<String> subscribedIds = [];
   Ref ref;
   StreamSubscription<StreamingResponse>? timelineSubscription;
   StreamSubscription<StreamingResponse>? mainSubscription;
@@ -131,16 +132,14 @@ abstract class SocketTimelineRepository extends TimelineRepository {
 
   @override
   Future<void> disconnect() async {
-    final id = timelineId;
-    if (id != null) {
-      await streamingController?.removeChannel(id);
-      await timelineSubscription?.cancel();
+    if (streamingController != null) {
+      for (var i = subscribedIds.length - 1; i >= 0; i--) {
+        await streamingController!.removeChannel(subscribedIds[i]);
+        subscribedIds.removeAt(i);
+      }
     }
-    final id2 = mainId;
-    if (id2 != null) {
-      await streamingController?.removeChannel(id2);
-      await mainSubscription?.cancel();
-    }
+    await timelineSubscription?.cancel();
+    await mainSubscription?.cancel();
   }
 
   @override
@@ -194,13 +193,11 @@ abstract class SocketTimelineRepository extends TimelineRepository {
   void dispose() {
     super.dispose();
     unawaited(() async {
-      final id = timelineId;
-      if (id != null) {
-        await streamingController?.removeChannel(id);
-      }
-      final id2 = mainId;
-      if (id2 != null) {
-        await streamingController?.removeChannel(id2);
+      if (streamingController != null) {
+        for (var i = subscribedIds.length - 1; i >= 0; i--) {
+          await streamingController!.removeChannel(subscribedIds[i]);
+          subscribedIds.removeAt(i);
+        }
       }
     }());
   }
@@ -265,10 +262,19 @@ abstract class SocketTimelineRepository extends TimelineRepository {
   }
 
   Future<void> _listenStreaming() async {
+    // 特定条件下でuseEffect内でdisconnectが呼ばれないことがある。謎
+    if (subscribedIds.isNotEmpty) {
+      await disconnect();
+    }
+
     final generatedId = const Uuid().v4();
     timelineId = generatedId;
     final generatedId2 = const Uuid().v4();
     mainId = generatedId2;
+
+    subscribedIds
+      ..add(generatedId)
+      ..add(generatedId2);
 
     timelineSubscription = streamingController
         ?.addChannel(channel, parameters, generatedId)
@@ -323,6 +329,7 @@ abstract class SocketTimelineRepository extends TimelineRepository {
           case DeletedChannelEvent():
           case PollVotedChannelEvent():
           case UpdatedChannelEvent():
+            break;
           case NewChatMessageEvent():
             // TODO: Handle this case.
             throw UnimplementedError();
@@ -394,6 +401,7 @@ abstract class SocketTimelineRepository extends TimelineRepository {
           case ReadAntennaChannelEvent():
           case ReceiveFollowRequestChannelEvent():
           case FallbackChannelEvent():
+            break;
           case NewChatMessageEvent():
             // TODO: Handle this case.
             throw UnimplementedError();

--- a/lib/view/login_page/api_key_login.dart
+++ b/lib/view/login_page/api_key_login.dart
@@ -51,7 +51,9 @@ class APiKeyLoginState extends ConsumerState<ApiKeyLogin> {
     } catch (e) {
       rethrow;
     } finally {
-      IndicatorView.hideIndicator(context);
+      if (mounted) {
+        IndicatorView.hideIndicator(context);
+      }
     }
   }
 
@@ -119,31 +121,9 @@ class APiKeyLoginState extends ConsumerState<ApiKeyLogin> {
                   Padding(
                     padding: const EdgeInsets.only(top: 10),
                     child: ElevatedButton(
-                      onPressed: () async {
-                        IndicatorView.showIndicator(context);
-                        await ref
-                            .read(dialogStateNotifierProvider.notifier)
-                            .guard(() async {
-                              await ref
-                                  .read(accountRepositoryProvider.notifier)
-                                  .loginAsToken(
-                                    normalizeServer(serverController.text),
-                                    apiKeyController.text,
-                                  );
-
-                              if (!context.mounted) return;
-                              await context.pushRoute(
-                                TimeLineRoute(
-                                  initialTabSetting: ref
-                                      .read(tabSettingsRepositoryProvider)
-                                      .tabSettings
-                                      .first,
-                                ),
-                              );
-                            });
-                        if (!context.mounted) return;
-                        IndicatorView.hideIndicator(context);
-                      },
+                      onPressed: () async => ref
+                          .read(dialogStateNotifierProvider.notifier)
+                          .guard(() => login()),
                       child: Text(S.of(context).login),
                     ),
                   ),

--- a/lib/view/login_page/api_key_login.dart
+++ b/lib/view/login_page/api_key_login.dart
@@ -40,13 +40,9 @@ class APiKeyLoginState extends ConsumerState<ApiKeyLogin> {
           );
 
       if (!mounted) return;
-      await context.pushRoute(
-        TimeLineRoute(
-          initialTabSetting: ref
-              .read(tabSettingsRepositoryProvider)
-              .tabSettings
-              .first,
-        ),
+      await context.router.pushAndPopUntil(
+        const SplashRoute(),
+        predicate: (_) => false,
       );
     } catch (e) {
       rethrow;

--- a/lib/view/login_page/mi_auth_login.dart
+++ b/lib/view/login_page/mi_auth_login.dart
@@ -36,18 +36,16 @@ class MiAuthLoginState extends ConsumerState<MiAuthLogin> {
           .read(accountRepositoryProvider.notifier)
           .validateMiAuth(normalizeServer(serverController.text));
       if (!mounted) return;
-      await context.pushRoute(
-        TimeLineRoute(
-          initialTabSetting: ref
-              .read(tabSettingsRepositoryProvider)
-              .tabSettings
-              .first,
-        ),
+      await context.router.pushAndPopUntil(
+        const SplashRoute(),
+        predicate: (_) => false,
       );
     } catch (e) {
       rethrow;
     } finally {
-      IndicatorView.hideIndicator(context);
+      if (mounted) {
+        IndicatorView.hideIndicator(context);
+      }
     }
   }
 


### PR DESCRIPTION
**極端に不安定な環境では試せていないので完全に改善したかは不明**
- 稀にdisconnectが呼ばれないときがあるので、listenStreaming時に切断していないidが存在するなら切断するように（ もし二重化してもタブを切り替えれば切断されるはず…）

- ログイン認証後にTimeLineRouteではなくSplashRouteに遷移するように