### PR TITLE
renoteが存在するか確認する

### DIFF
--- a/lib/view/common/misskey_notes/misskey_note.dart
+++ b/lib/view/common/misskey_notes/misskey_note.dart
@@ -700,8 +700,8 @@ class MisskeyNote extends HookConsumerWidget {
                                   host: displayNote.user.host,
                                 ),
                               ),
-                            if (displayNote.renoteId != null &&
-                                (recursive < 2 && !isForceUnvisibleRenote))
+                            if (displayNote.renote case final renote?
+                                when recursive < 2 && !isForceUnvisibleRenote)
                               Container(
                                 padding: const EdgeInsets.all(5),
                                 child: DottedBorder(
@@ -721,7 +721,7 @@ class MisskeyNote extends HookConsumerWidget {
                                     padding: const EdgeInsets.all(5),
                                   ),
                                   child: MisskeyNote(
-                                    note: displayNote.renote!,
+                                    note: renote,
                                     isDisplayBorder: false,
                                     recursive: recursive + 1,
                                   ),

--- a/test/view/common/misskey_notes/note_modal_sheet_test.dart
+++ b/test/view/common/misskey_notes/note_modal_sheet_test.dart
@@ -277,7 +277,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.tap(find.byIcon(Icons.more_horiz).at(0));
       await tester.pumpAndSettle();
 
       await tester.ensureVisible(find.text("削除", skipOffstage: false));
@@ -311,7 +311,9 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.ensureVisible(find.byIcon(Icons.more_horiz).at(0));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.more_horiz).at(0));
       await tester.pumpAndSettle();
 
       await tester.ensureVisible(find.text("削除", skipOffstage: false));
@@ -355,7 +357,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.tap(find.byIcon(Icons.more_horiz).at(0));
       await tester.pumpAndSettle();
 
       await tester.ensureVisible(find.text("削除", skipOffstage: false));
@@ -430,7 +432,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.tap(find.byIcon(Icons.more_horiz).at(0));
       await tester.pumpAndSettle();
 
       expect(find.text("リノートを解除する", skipOffstage: false), findsNothing);
@@ -460,7 +462,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.tap(find.byIcon(Icons.more_horiz).at(0));
       await tester.pumpAndSettle();
 
       expect(find.text("リノートを解除する", skipOffstage: false), findsNothing);
@@ -500,7 +502,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.tap(find.byIcon(Icons.more_horiz).at(0));
       await tester.pumpAndSettle();
 
       expect(find.text("リノートを解除する", skipOffstage: false), findsNothing);
@@ -530,7 +532,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.tap(find.byIcon(Icons.more_horiz).at(0));
       await tester.pumpAndSettle();
 
       expect(find.text("リノートを解除する", skipOffstage: false), findsNothing);


### PR DESCRIPTION
引用先のノートが削除されているときに `Null check operator used on a null value` が発生する問題を修正しました

| Misskey Web (2025.8.0-alpha.4) | Miria | 
| ---- | ---- |
| ![](https://github.com/user-attachments/assets/debdacf6-b80e-46cb-a770-62648ebe2647) | ![](https://github.com/user-attachments/assets/971619e9-bdba-4b5d-a961-4684bcc6000f) |

Fix #798 