### PR TITLE
[Linux] (snap) core24のサポートとワークフローの更新

### DIFF
--- a/.github/workflows/linux_deploy.yml
+++ b/.github/workflows/linux_deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build Snap
         id: snapcraft
-        uses: diddlesnaps/snapcraft-multiarch-action@v1
+        uses: canonical/snapcraft-multiarch-action@v1
         with:
           architecture: ${{ matrix.platform }}
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ donation: https://shiosyakeyakini.fanbox.cc
 contact: sorairo@shiosyakeyakini.info
 icon: assets/images/icon.png
 adopt-info: miria
-base: core22
+base: core24
 grade: stable
 confinement: strict
 compression: lzo # 起動速度の向上（xz比）
@@ -42,9 +42,9 @@ apps:
       - audio-playback
       # 以下はユーザーが接続を許可するまで使用不可
       - removable-media # カメラのSDカードから直接取り込むユーザー向け
-      - password-manager-service # ログイン情報の保存＆読み込みのため必須
+      - password-manager-service # ログイン情報の保存＆読み込みのため必須 許可は不要
     environment:
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack
+      LD_LIBRARY_PATH: $SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
 parts:
   miria:
@@ -65,7 +65,7 @@ parts:
       - unzip
       - jq
     stage-packages:
-      - libmpv1
+      - libmpv2
       - libsecret-1-0
     override-pull: |
       craftctl default
@@ -73,15 +73,13 @@ parts:
     override-build: |
       # flutterプラグインの処理を代替
       set +e
-      rm -rf $CRAFT_PART_BUILD/FlutterSDK
       git clone --depth 1 -b $(jq -r .flutter .fvmrc) https://github.com/flutter/flutter.git $CRAFT_PART_BUILD/FlutterSDK
       flutter precache --linux
       flutter pub get
-      set -e
-      #flutter pub run build_runner build --delete-conflicting-outputs
+      set -eux
       flutter build linux --release --verbose --target lib/main.dart
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/
-      install -Dm644 LICENSE "$CRAFT_PART_INSTALL/usr/share/licenses/miria/LICENSE"
+      cp LICENSE $CRAFT_PART_INSTALL/
 
   zenity:
   # Integrate custom dialogs in your snap - doc - snapcraft.io
@@ -97,10 +95,10 @@ parts:
   cleanup:
     after: [miria, zenity]  # Make this part run last; list all your other parts here
     plugin: nil
-    build-snaps: [gnome-42-2204, gtk-common-themes, core22]  # List all content-snaps you're using here
+    build-snaps: [gnome-46-2404, gtk-common-themes, core24, mesa-2404]  # List all content-snaps you're using here
     override-prime: |
       set -eux
-      for snap in "gnome-42-2204" "gtk-common-themes" "core22"; do  # List all content-snaps you're using here
+      for snap in "gnome-46-2404" "gtk-common-themes" "core24" "mesa-2404"; do  # List all content-snaps you're using here
         cd "/snap/${snap}/current"
         find . -type f,l ! -xtype d -print0 > "/tmp/${snap}.log"
         cd "${SNAPCRAFT_PRIME}"
@@ -110,6 +108,11 @@ parts:
       done
 
 layout:
+  # Access ALSA library
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/alsa-lib:
+    bind: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/alsa-lib
+  /usr/share/alsa:
+    bind: $SNAP/gnome-platform/usr/share/alsa
   # Fix resource relocation problem of zenity part
   /usr/share/zenity:
     symlink: $SNAP/usr/share/zenity


### PR DESCRIPTION
Snapパッケージをcore22ベースからcore24ベースに移行する提案です。
また、ワークフローで使用されるパッケージがメンテナンスされなくなったことでcore22のビルドが不可能となっているため、Canonicalによるフォーク版へ移行を行います。