### PR TITLE
fix: クリップ編集画面が開かない問題を修正 (#785)

### DIFF
--- a/lib/view/clip_list_page/clip_settings_dialog.dart
+++ b/lib/view/clip_list_page/clip_settings_dialog.dart
@@ -7,15 +7,15 @@ import "package:riverpod_annotation/riverpod_annotation.dart";
 
 part "clip_settings_dialog.g.dart";
 
-@riverpod
+@Riverpod(dependencies: [])
 GlobalKey<FormState> _formKey(Ref ref) => GlobalKey<FormState>();
 
-@riverpod
+@Riverpod(dependencies: [])
 ClipSettings _initialSettings(Ref ref) {
   throw UnimplementedError();
 }
 
-@riverpod
+@Riverpod(dependencies: [_initialSettings])
 class _ClipSettingsNotifier extends _$ClipSettingsNotifier {
   @override
   ClipSettings build() {

--- a/lib/view/clip_list_page/clip_settings_dialog.g.dart
+++ b/lib/view/clip_list_page/clip_settings_dialog.g.dart
@@ -24,8 +24,8 @@ final class _FormKeyProvider
         retry: null,
         name: r'_formKeyProvider',
         isAutoDispose: true,
-        dependencies: null,
-        $allTransitiveDependencies: null,
+        dependencies: const <ProviderOrFamily>[],
+        $allTransitiveDependencies: const <ProviderOrFamily>[],
       );
 
   @override
@@ -51,7 +51,7 @@ final class _FormKeyProvider
   }
 }
 
-String _$formKeyHash() => r'd50766db9667ea038f655d666e836a84897ee427';
+String _$formKeyHash() => r'd8a56e0366cb1a53da5331749cce00aef36862b1';
 
 @ProviderFor(_initialSettings)
 const _initialSettingsProvider = _InitialSettingsProvider._();
@@ -66,8 +66,8 @@ final class _InitialSettingsProvider
         retry: null,
         name: r'_initialSettingsProvider',
         isAutoDispose: true,
-        dependencies: null,
-        $allTransitiveDependencies: null,
+        dependencies: const <ProviderOrFamily>[],
+        $allTransitiveDependencies: const <ProviderOrFamily>[],
       );
 
   @override
@@ -92,7 +92,7 @@ final class _InitialSettingsProvider
   }
 }
 
-String _$initialSettingsHash() => r'f51f2ded589149448ba4ab01466f0672c334d0de';
+String _$initialSettingsHash() => r'5822fd6a8e4070e8a4da0c299a6149e49f7ef49e';
 
 @ProviderFor(_ClipSettingsNotifier)
 const _clipSettingsNotifierProvider = _ClipSettingsNotifierProvider._();
@@ -106,9 +106,13 @@ final class _ClipSettingsNotifierProvider
         retry: null,
         name: r'_clipSettingsNotifierProvider',
         isAutoDispose: true,
-        dependencies: null,
-        $allTransitiveDependencies: null,
+        dependencies: const <ProviderOrFamily>[_initialSettingsProvider],
+        $allTransitiveDependencies: const <ProviderOrFamily>[
+          _ClipSettingsNotifierProvider.$allTransitiveDependencies0,
+        ],
       );
+
+  static const $allTransitiveDependencies0 = _initialSettingsProvider;
 
   @override
   String debugGetCreateSourceHash() => _$clipSettingsNotifierHash();
@@ -127,7 +131,7 @@ final class _ClipSettingsNotifierProvider
 }
 
 String _$clipSettingsNotifierHash() =>
-    r'a31c8af941b36dbb6da351a2e072423b888c0daf';
+    r'004b0ddb0c4b37ca968f1da8c8390ef047727180';
 
 abstract class _$ClipSettingsNotifier extends $Notifier<ClipSettings> {
   ClipSettings build();

--- a/test/view/clip_detail_page/clip_settings_test.dart
+++ b/test/view/clip_detail_page/clip_settings_test.dart
@@ -1,0 +1,45 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:miria/l10n/app_localizations.dart";
+import "package:miria/model/clip_settings.dart";
+import "package:miria/view/clip_list_page/clip_settings_dialog.dart";
+
+void main() {
+  group("ClipSettingsDialog dependencies テスト", () {
+    testWidgets("dependenciesパラメーター追加後のProviderScopeが正しく動作すること", (tester) async {
+      const testSettings = ClipSettings(
+        name: "テストクリップ",
+        description: "テスト説明",
+        isPublic: true,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: S.localizationsDelegates,
+            supportedLocales: S.supportedLocales,
+            home: ClipSettingsDialog(
+              title: const Text("テスト"),
+              initialSettings: testSettings,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // ダイアログが表示されることを確認
+      expect(find.byType(AlertDialog), findsOneWidget);
+      
+      // 初期値が正しく表示されることを確認
+      expect(find.text("テストクリップ"), findsOneWidget);
+      
+      // パブリックチェックボックスが正しく設定されていることを確認
+      final checkbox = tester.widget<CheckboxListTile>(
+        find.byType(CheckboxListTile),
+      );
+      expect(checkbox.value, true);
+    });
+  });
+}

--- a/test/view/clip_detail_page/clip_settings_test.dart
+++ b/test/view/clip_detail_page/clip_settings_test.dart
@@ -7,7 +7,9 @@ import "package:miria/view/clip_list_page/clip_settings_dialog.dart";
 
 void main() {
   group("ClipSettingsDialog dependencies テスト", () {
-    testWidgets("dependenciesパラメーター追加後のProviderScopeが正しく動作すること", (tester) async {
+    testWidgets("dependenciesパラメーター追加後のProviderScopeが正しく動作すること", (
+      tester,
+    ) async {
       const testSettings = ClipSettings(
         name: "テストクリップ",
         description: "テスト説明",
@@ -31,10 +33,10 @@ void main() {
 
       // ダイアログが表示されることを確認
       expect(find.byType(AlertDialog), findsOneWidget);
-      
+
       // 初期値が正しく表示されることを確認
       expect(find.text("テストクリップ"), findsOneWidget);
-      
+
       // パブリックチェックボックスが正しく設定されていることを確認
       final checkbox = tester.widget<CheckboxListTile>(
         find.byType(CheckboxListTile),


### PR DESCRIPTION
## Summary
issue #785 「クリップ編集画面が開かない」問題を修正しました。

## 問題の原因
`@riverpod` アノテーションで `dependencies` パラメーターが不足していたため、Scoped Provider のProviderScope オーバーライドが正しく動作せず、`UnimplementedError` が発生していました。

## 修正内容
- `@riverpod` → `@Riverpod(dependencies: [])` に変更
- `_ClipSettingsNotifier` に `dependencies: [_initialSettings]` を追加  
- 他のScoped Provider実装（`users_list_settings_dialog.dart`）と同じパターンを適用
- 動作確認のためのテストを追加

## 動作確認
- ✅ ProviderScope のオーバーライドが正常動作
- ✅ クリップ編集ダイアログが正しく開く
- ✅ 初期値が適切に表示される
- ✅ テストが全て成功

## Test plan
- [x] 新しく追加したテストが成功することを確認
- [x] クリップ詳細ページでクリップ編集ボタンが表示されることを確認  
- [x] クリップ編集ダイアログが正常に開くことを確認
- [x] 初期値が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)