### PR TITLE
fix: UIの細かな修正

### DIFF
--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -379,7 +379,7 @@ class GeneralSettingsPage extends HookConsumerWidget {
                           // ヘッダー
                           TableRow(
                             children: [
-                              SizedBox.shrink(),
+                              const SizedBox.shrink(),
                               Text(S.of(context).lightMode),
                               Text(S.of(context).darkMode),
                             ],
@@ -387,7 +387,11 @@ class GeneralSettingsPage extends HookConsumerWidget {
                           // パブリック
                           TableRow(
                             children: [
-                              Text(S.of(context).public),
+                              TableCell(
+                                verticalAlignment:
+                                    TableCellVerticalAlignment.middle,
+                                child: Text(S.of(context).public),
+                              ),
                               IconButton(
                                 icon: Container(
                                   width: 24,
@@ -443,7 +447,11 @@ class GeneralSettingsPage extends HookConsumerWidget {
                           // ホームのみ
                           TableRow(
                             children: [
-                              Text(S.of(context).homeOnly),
+                              TableCell(
+                                verticalAlignment:
+                                    TableCellVerticalAlignment.middle,
+                                child: Text(S.of(context).homeOnly),
+                              ),
                               IconButton(
                                 icon: Container(
                                   width: 24,
@@ -499,7 +507,11 @@ class GeneralSettingsPage extends HookConsumerWidget {
                           // フォロワーのみ
                           TableRow(
                             children: [
-                              Text(S.of(context).followersOnly),
+                              TableCell(
+                                verticalAlignment:
+                                    TableCellVerticalAlignment.middle,
+                                child: Text(S.of(context).followersOnly),
+                              ),
                               IconButton(
                                 icon: Container(
                                   width: 24,
@@ -555,7 +567,11 @@ class GeneralSettingsPage extends HookConsumerWidget {
                           // ダイレクト
                           TableRow(
                             children: [
-                              Text(S.of(context).direct),
+                              TableCell(
+                                verticalAlignment:
+                                    TableCellVerticalAlignment.middle,
+                                child: Text(S.of(context).direct),
+                              ),
                               IconButton(
                                 icon: Container(
                                   width: 24,

--- a/lib/view/settings_page/general_settings_page/general_settings_page.dart
+++ b/lib/view/settings_page/general_settings_page/general_settings_page.dart
@@ -379,7 +379,7 @@ class GeneralSettingsPage extends HookConsumerWidget {
                           // ヘッダー
                           TableRow(
                             children: [
-                              const SizedBox.shrink(),
+                              SizedBox.shrink(),
                               Text(S.of(context).lightMode),
                               Text(S.of(context).darkMode),
                             ],

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -243,7 +243,9 @@ class UserDetail extends ConsumerWidget {
                         Row(
                           children: [
                             const Icon(Icons.warning_amber_rounded),
-                            Text(S.of(context).remoteUserCaution),
+                            Expanded(
+                              child: Text(S.of(context).remoteUserCaution),
+                            ),
                           ],
                         ),
                         GestureDetector(


### PR DESCRIPTION
UIの細かい修正提案です。
- ノートの公開範囲背景色設定において、文字列と設定された色の表示窓の中心軸が揃うように`TableCell()`を用いて設定しました。
- リモートユーザーのユーザー詳細ページで表示されるメッセージ内容が折りたたまれるように設定しました。