### PR TITLE
[Windows] 同梱ライブラリ操作を更新

### DIFF
--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -46,6 +46,12 @@ jobs:
         run: |
           curl -o ${{ env.builddir }}\ChineseSimplified.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl
 
+      - name: Copy DLL
+        run: |
+          cp C:\Windows\System32\msvcp140.dll build\windows\x64\runner\Release\
+          cp C:\Windows\System32\vcruntime140.dll build\windows\x64\runner\Release\
+          cp C:\Windows\System32\vcruntime140_1.dll build\windows\x64\runner\Release\
+
       - name: Compile .ISS to .EXE Installer
         run: iscc windows/innosetup.iss /dMyAppVersion="${{ env.version }}" /dMyWorkDir="${{ env.builddir }}" /Qp
 

--- a/.github/workflows/windows_deploy.yml
+++ b/.github/workflows/windows_deploy.yml
@@ -38,10 +38,6 @@ jobs:
         run: |
           flutter build windows --release
 
-      - name: Delete unnecessary DLL
-        run: |
-          rm build\windows\x64\runner\Release\api-ms-*.dll
-
       - name: Get translation files for Inno Setup
         run: |
           curl -o ${{ env.builddir }}\ChineseSimplified.isl https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl


### PR DESCRIPTION
Related to #610 
`msvcp140.dll`など同梱するべきライブラリがビルド時に同梱されなくなったり`api-ms-*.dll`などの不要なライブラリがビルド時に同梱されていた問題が解消されたため、コミットのRevert操作などを行いました。