### PR TITLE
feat: mfmパッケージを1.0.8にアップデート

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1095,10 +1095,10 @@ packages:
     dependency: "direct main"
     description:
       name: mfm
-      sha256: "239bf1671acac3466e66dc4eb6b6e8ee3601cb138ce129bd7c192364e7633fd0"
+      sha256: cdfc10dfbb44fb3e42be68310722166d10e3f0aa51f2681b29bfffaee49605c2
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   mfm_parser:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     git: 
       url: https://github.com/shiosyakeyakini-info/misskey_dart.git
       ref: master
-  mfm: ^1.0.5
+  mfm: ^1.0.8
   tuple: ^2.0.1
   path_provider: ^2.0.14
   dio: ^5.1.1


### PR DESCRIPTION
## Summary
- mfmパッケージをv1.0.5からv1.0.8にアップデートしました
- pubspec.yamlとpubspec.lockファイルを更新しました

## Test plan
- [ ] ビルドが正常に完了することを確認
- [ ] 既存のMFMレンダリング機能に問題がないことを確認
- [ ] 新しいバージョンで追加された機能が適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)