### PR TITLE
feat: mfmパッケージを1.0.9にアップデートし、clips APIの変更に対応

### DIFF
--- a/lib/model/account.freezed.dart
+++ b/lib/model/account.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -95,6 +94,136 @@ $MetaResponseCopyWith<$Res>? get meta {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [Account].
+extension AccountPatterns on Account {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Account value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Account value)  $default,){
+final _that = this;
+switch (_that) {
+case _Account():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Account value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String host,  String userId,  MeDetailed i,  String? token,  MetaResponse? meta,  String? scheme,  int? port)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that.host,_that.userId,_that.i,_that.token,_that.meta,_that.scheme,_that.port);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String host,  String userId,  MeDetailed i,  String? token,  MetaResponse? meta,  String? scheme,  int? port)  $default,) {final _that = this;
+switch (_that) {
+case _Account():
+return $default(_that.host,_that.userId,_that.i,_that.token,_that.meta,_that.scheme,_that.port);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String host,  String userId,  MeDetailed i,  String? token,  MetaResponse? meta,  String? scheme,  int? port)?  $default,) {final _that = this;
+switch (_that) {
+case _Account() when $default != null:
+return $default(_that.host,_that.userId,_that.i,_that.token,_that.meta,_that.scheme,_that.port);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/account_settings.freezed.dart
+++ b/lib/model/account_settings.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -88,6 +87,136 @@ as bool,
 
 }
 
+
+/// Adds pattern-matching-related methods to [AccountSettings].
+extension AccountSettingsPatterns on AccountSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AccountSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AccountSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AccountSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _AccountSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AccountSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AccountSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String userId,  String host,  List<String> reactions,  List<String> mutedReactions,  NoteVisibility defaultNoteVisibility,  bool defaultIsLocalOnly,  ReactionAcceptance? defaultReactionAcceptance,  CacheStrategy iCacheStrategy,  DateTime? latestICached,  CacheStrategy emojiCacheStrategy,  DateTime? latestEmojiCached,  CacheStrategy metaChacheStrategy,  DateTime? latestMetaCached,  bool forceShowAd)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AccountSettings() when $default != null:
+return $default(_that.userId,_that.host,_that.reactions,_that.mutedReactions,_that.defaultNoteVisibility,_that.defaultIsLocalOnly,_that.defaultReactionAcceptance,_that.iCacheStrategy,_that.latestICached,_that.emojiCacheStrategy,_that.latestEmojiCached,_that.metaChacheStrategy,_that.latestMetaCached,_that.forceShowAd);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String userId,  String host,  List<String> reactions,  List<String> mutedReactions,  NoteVisibility defaultNoteVisibility,  bool defaultIsLocalOnly,  ReactionAcceptance? defaultReactionAcceptance,  CacheStrategy iCacheStrategy,  DateTime? latestICached,  CacheStrategy emojiCacheStrategy,  DateTime? latestEmojiCached,  CacheStrategy metaChacheStrategy,  DateTime? latestMetaCached,  bool forceShowAd)  $default,) {final _that = this;
+switch (_that) {
+case _AccountSettings():
+return $default(_that.userId,_that.host,_that.reactions,_that.mutedReactions,_that.defaultNoteVisibility,_that.defaultIsLocalOnly,_that.defaultReactionAcceptance,_that.iCacheStrategy,_that.latestICached,_that.emojiCacheStrategy,_that.latestEmojiCached,_that.metaChacheStrategy,_that.latestMetaCached,_that.forceShowAd);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String userId,  String host,  List<String> reactions,  List<String> mutedReactions,  NoteVisibility defaultNoteVisibility,  bool defaultIsLocalOnly,  ReactionAcceptance? defaultReactionAcceptance,  CacheStrategy iCacheStrategy,  DateTime? latestICached,  CacheStrategy emojiCacheStrategy,  DateTime? latestEmojiCached,  CacheStrategy metaChacheStrategy,  DateTime? latestMetaCached,  bool forceShowAd)?  $default,) {final _that = this;
+switch (_that) {
+case _AccountSettings() when $default != null:
+return $default(_that.userId,_that.host,_that.reactions,_that.mutedReactions,_that.defaultNoteVisibility,_that.defaultIsLocalOnly,_that.defaultReactionAcceptance,_that.iCacheStrategy,_that.latestICached,_that.emojiCacheStrategy,_that.latestEmojiCached,_that.metaChacheStrategy,_that.latestMetaCached,_that.forceShowAd);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/acct.freezed.dart
+++ b/lib/model/acct.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -72,6 +71,136 @@ as String,
 
 }
 
+
+/// Adds pattern-matching-related methods to [Acct].
+extension AcctPatterns on Acct {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Acct value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Acct() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Acct value)  $default,){
+final _that = this;
+switch (_that) {
+case _Acct():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Acct value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Acct() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String host,  String username)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Acct() when $default != null:
+return $default(_that.host,_that.username);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String host,  String username)  $default,) {final _that = this;
+switch (_that) {
+case _Acct():
+return $default(_that.host,_that.username);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String host,  String username)?  $default,) {final _that = this;
+switch (_that) {
+case _Acct() when $default != null:
+return $default(_that.host,_that.username);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/antenna_settings.freezed.dart
+++ b/lib/model/antenna_settings.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -82,6 +81,136 @@ as bool,
 
 }
 
+
+/// Adds pattern-matching-related methods to [AntennaSettings].
+extension AntennaSettingsPatterns on AntennaSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AntennaSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AntennaSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AntennaSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _AntennaSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AntennaSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AntennaSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  AntennaSource src,  String? userListId,  List<List<String>> keywords,  List<List<String>> excludeKeywords,  List<String> users,  bool caseSensitive,  bool withReplies,  bool withFile,  bool notify,  bool localOnly)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AntennaSettings() when $default != null:
+return $default(_that.name,_that.src,_that.userListId,_that.keywords,_that.excludeKeywords,_that.users,_that.caseSensitive,_that.withReplies,_that.withFile,_that.notify,_that.localOnly);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  AntennaSource src,  String? userListId,  List<List<String>> keywords,  List<List<String>> excludeKeywords,  List<String> users,  bool caseSensitive,  bool withReplies,  bool withFile,  bool notify,  bool localOnly)  $default,) {final _that = this;
+switch (_that) {
+case _AntennaSettings():
+return $default(_that.name,_that.src,_that.userListId,_that.keywords,_that.excludeKeywords,_that.users,_that.caseSensitive,_that.withReplies,_that.withFile,_that.notify,_that.localOnly);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  AntennaSource src,  String? userListId,  List<List<String>> keywords,  List<List<String>> excludeKeywords,  List<String> users,  bool caseSensitive,  bool withReplies,  bool withFile,  bool notify,  bool localOnly)?  $default,) {final _that = this;
+switch (_that) {
+case _AntennaSettings() when $default != null:
+return $default(_that.name,_that.src,_that.userListId,_that.keywords,_that.excludeKeywords,_that.users,_that.caseSensitive,_that.withReplies,_that.withFile,_that.notify,_that.localOnly);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/model/clip_settings.freezed.dart
+++ b/lib/model/clip_settings.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -74,6 +73,136 @@ as bool,
 
 }
 
+
+/// Adds pattern-matching-related methods to [ClipSettings].
+extension ClipSettingsPatterns on ClipSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ClipSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ClipSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ClipSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _ClipSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ClipSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ClipSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String? description,  bool isPublic)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ClipSettings() when $default != null:
+return $default(_that.name,_that.description,_that.isPublic);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String? description,  bool isPublic)  $default,) {final _that = this;
+switch (_that) {
+case _ClipSettings():
+return $default(_that.name,_that.description,_that.isPublic);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String? description,  bool isPublic)?  $default,) {final _that = this;
+switch (_that) {
+case _ClipSettings() when $default != null:
+return $default(_that.name,_that.description,_that.isPublic);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/model/color_theme.freezed.dart
+++ b/lib/model/color_theme.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -90,6 +89,136 @@ as Color,
 
 }
 
+
+/// Adds pattern-matching-related methods to [ColorTheme].
+extension ColorThemePatterns on ColorTheme {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ColorTheme value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ColorTheme() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ColorTheme value)  $default,){
+final _that = this;
+switch (_that) {
+case _ColorTheme():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ColorTheme value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ColorTheme() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  bool isDarkTheme,  Color primary,  Color primaryDarken,  Color primaryLighten,  Color accentedBackground,  Color background,  Color foreground,  Color renote,  Color mention,  Color hashtag,  Color link,  Color divider,  Color buttonBackground,  Color buttonGradateA,  Color buttonGradateB,  Color panel,  Color panelBackground)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ColorTheme() when $default != null:
+return $default(_that.id,_that.name,_that.isDarkTheme,_that.primary,_that.primaryDarken,_that.primaryLighten,_that.accentedBackground,_that.background,_that.foreground,_that.renote,_that.mention,_that.hashtag,_that.link,_that.divider,_that.buttonBackground,_that.buttonGradateA,_that.buttonGradateB,_that.panel,_that.panelBackground);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  bool isDarkTheme,  Color primary,  Color primaryDarken,  Color primaryLighten,  Color accentedBackground,  Color background,  Color foreground,  Color renote,  Color mention,  Color hashtag,  Color link,  Color divider,  Color buttonBackground,  Color buttonGradateA,  Color buttonGradateB,  Color panel,  Color panelBackground)  $default,) {final _that = this;
+switch (_that) {
+case _ColorTheme():
+return $default(_that.id,_that.name,_that.isDarkTheme,_that.primary,_that.primaryDarken,_that.primaryLighten,_that.accentedBackground,_that.background,_that.foreground,_that.renote,_that.mention,_that.hashtag,_that.link,_that.divider,_that.buttonBackground,_that.buttonGradateA,_that.buttonGradateB,_that.panel,_that.panelBackground);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  bool isDarkTheme,  Color primary,  Color primaryDarken,  Color primaryLighten,  Color accentedBackground,  Color background,  Color foreground,  Color renote,  Color mention,  Color hashtag,  Color link,  Color divider,  Color buttonBackground,  Color buttonGradateA,  Color buttonGradateB,  Color panel,  Color panelBackground)?  $default,) {final _that = this;
+switch (_that) {
+case _ColorTheme() when $default != null:
+return $default(_that.id,_that.name,_that.isDarkTheme,_that.primary,_that.primaryDarken,_that.primaryLighten,_that.accentedBackground,_that.background,_that.foreground,_that.renote,_that.mention,_that.hashtag,_that.link,_that.divider,_that.buttonBackground,_that.buttonGradateA,_that.buttonGradateB,_that.panel,_that.panelBackground);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/model/desktop_settings.freezed.dart
+++ b/lib/model/desktop_settings.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -84,6 +83,136 @@ $DesktopWindowSettingsCopyWith<$Res> get window {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [DesktopSettings].
+extension DesktopSettingsPatterns on DesktopSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DesktopSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DesktopSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DesktopSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _DesktopSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DesktopSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DesktopSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DesktopWindowSettings window)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DesktopSettings() when $default != null:
+return $default(_that.window);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DesktopWindowSettings window)  $default,) {final _that = this;
+switch (_that) {
+case _DesktopSettings():
+return $default(_that.window);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DesktopWindowSettings window)?  $default,) {final _that = this;
+switch (_that) {
+case _DesktopSettings() when $default != null:
+return $default(_that.window);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()
@@ -229,6 +358,136 @@ as double,
 
 }
 
+
+/// Adds pattern-matching-related methods to [DesktopWindowSettings].
+extension DesktopWindowSettingsPatterns on DesktopWindowSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DesktopWindowSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DesktopWindowSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DesktopWindowSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _DesktopWindowSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DesktopWindowSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DesktopWindowSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double? x,  double? y,  double w,  double h)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DesktopWindowSettings() when $default != null:
+return $default(_that.x,_that.y,_that.w,_that.h);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double? x,  double? y,  double w,  double h)  $default,) {final _that = this;
+switch (_that) {
+case _DesktopWindowSettings():
+return $default(_that.x,_that.y,_that.w,_that.h);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double? x,  double? y,  double w,  double h)?  $default,) {final _that = this;
+switch (_that) {
+case _DesktopWindowSettings() when $default != null:
+return $default(_that.x,_that.y,_that.w,_that.h);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/exported_setting.freezed.dart
+++ b/lib/model/exported_setting.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -86,6 +85,136 @@ $GeneralSettingsCopyWith<$Res> get generalSettings {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [ExportedSetting].
+extension ExportedSettingPatterns on ExportedSetting {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ExportedSetting value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ExportedSetting() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ExportedSetting value)  $default,){
+final _that = this;
+switch (_that) {
+case _ExportedSetting():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ExportedSetting value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ExportedSetting() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( GeneralSettings generalSettings,  List<AccountSettings> accountSettings,  List<TabSetting> tabSettings)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ExportedSetting() when $default != null:
+return $default(_that.generalSettings,_that.accountSettings,_that.tabSettings);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( GeneralSettings generalSettings,  List<AccountSettings> accountSettings,  List<TabSetting> tabSettings)  $default,) {final _that = this;
+switch (_that) {
+case _ExportedSetting():
+return $default(_that.generalSettings,_that.accountSettings,_that.tabSettings);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( GeneralSettings generalSettings,  List<AccountSettings> accountSettings,  List<TabSetting> tabSettings)?  $default,) {final _that = this;
+switch (_that) {
+case _ExportedSetting() when $default != null:
+return $default(_that.generalSettings,_that.accountSettings,_that.tabSettings);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/federation_data.freezed.dart
+++ b/lib/model/federation_data.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -105,6 +104,136 @@ $MetaResponseCopyWith<$Res>? get meta {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [FederationData].
+extension FederationDataPatterns on FederationData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _FederationData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _FederationData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _FederationData value)  $default,){
+final _that = this;
+switch (_that) {
+case _FederationData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _FederationData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _FederationData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isSupportedEmoji,  bool isSupportedAnnouncement,  bool isSupportedLocalTimeline,  String? bannerUrl,  String? faviconUrl,  String? tosUrl,  String? privacyPolicyUrl,  String? impressumUrl,  String? repositoryUrl,  List<String> serverRules,  String name,  String description,  String? maintainerName,  String? maintainerEmail,  int? usersCount,  int? notesCount,  int? reactionCount,  String softwareName,  String softwareVersion,  List<String> languages,  List<MetaAd> ads,  MetaResponse? meta)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _FederationData() when $default != null:
+return $default(_that.isSupportedEmoji,_that.isSupportedAnnouncement,_that.isSupportedLocalTimeline,_that.bannerUrl,_that.faviconUrl,_that.tosUrl,_that.privacyPolicyUrl,_that.impressumUrl,_that.repositoryUrl,_that.serverRules,_that.name,_that.description,_that.maintainerName,_that.maintainerEmail,_that.usersCount,_that.notesCount,_that.reactionCount,_that.softwareName,_that.softwareVersion,_that.languages,_that.ads,_that.meta);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isSupportedEmoji,  bool isSupportedAnnouncement,  bool isSupportedLocalTimeline,  String? bannerUrl,  String? faviconUrl,  String? tosUrl,  String? privacyPolicyUrl,  String? impressumUrl,  String? repositoryUrl,  List<String> serverRules,  String name,  String description,  String? maintainerName,  String? maintainerEmail,  int? usersCount,  int? notesCount,  int? reactionCount,  String softwareName,  String softwareVersion,  List<String> languages,  List<MetaAd> ads,  MetaResponse? meta)  $default,) {final _that = this;
+switch (_that) {
+case _FederationData():
+return $default(_that.isSupportedEmoji,_that.isSupportedAnnouncement,_that.isSupportedLocalTimeline,_that.bannerUrl,_that.faviconUrl,_that.tosUrl,_that.privacyPolicyUrl,_that.impressumUrl,_that.repositoryUrl,_that.serverRules,_that.name,_that.description,_that.maintainerName,_that.maintainerEmail,_that.usersCount,_that.notesCount,_that.reactionCount,_that.softwareName,_that.softwareVersion,_that.languages,_that.ads,_that.meta);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isSupportedEmoji,  bool isSupportedAnnouncement,  bool isSupportedLocalTimeline,  String? bannerUrl,  String? faviconUrl,  String? tosUrl,  String? privacyPolicyUrl,  String? impressumUrl,  String? repositoryUrl,  List<String> serverRules,  String name,  String description,  String? maintainerName,  String? maintainerEmail,  int? usersCount,  int? notesCount,  int? reactionCount,  String softwareName,  String softwareVersion,  List<String> languages,  List<MetaAd> ads,  MetaResponse? meta)?  $default,) {final _that = this;
+switch (_that) {
+case _FederationData() when $default != null:
+return $default(_that.isSupportedEmoji,_that.isSupportedAnnouncement,_that.isSupportedLocalTimeline,_that.bannerUrl,_that.faviconUrl,_that.tosUrl,_that.privacyPolicyUrl,_that.impressumUrl,_that.repositoryUrl,_that.serverRules,_that.name,_that.description,_that.maintainerName,_that.maintainerEmail,_that.usersCount,_that.notesCount,_that.reactionCount,_that.softwareName,_that.softwareVersion,_that.languages,_that.ads,_that.meta);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/model/general_settings.freezed.dart
+++ b/lib/model/general_settings.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -119,6 +118,136 @@ as Color?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [GeneralSettings].
+extension GeneralSettingsPatterns on GeneralSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GeneralSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GeneralSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GeneralSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _GeneralSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GeneralSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GeneralSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String lightColorThemeId,  String darkColorThemeId,  ThemeColorSystem themeColorSystem,  NSFWInherit nsfwInherit,  bool enableDirectReaction,  AutomaticPush automaticPush,  bool enableAnimatedMFM,  bool enableLongTextElipsed,  bool enableFavoritedRenoteElipsed,  TabPosition tabPosition,  double textScaleFactor,  EmojiType emojiType,  String defaultFontName,  String serifFontName,  String monospaceFontName,  String cursiveFontName,  String fantasyFontName,  Languages languages,  bool isDeckMode, @ColorConverter()  Color? lightNoteBackgroundPublic, @ColorConverter()  Color? lightNoteBackgroundHome, @ColorConverter()  Color? lightNoteBackgroundFollowers, @ColorConverter()  Color? lightNoteBackgroundDirect, @ColorConverter()  Color? darkNoteBackgroundPublic, @ColorConverter()  Color? darkNoteBackgroundHome, @ColorConverter()  Color? darkNoteBackgroundFollowers, @ColorConverter()  Color? darkNoteBackgroundDirect)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GeneralSettings() when $default != null:
+return $default(_that.lightColorThemeId,_that.darkColorThemeId,_that.themeColorSystem,_that.nsfwInherit,_that.enableDirectReaction,_that.automaticPush,_that.enableAnimatedMFM,_that.enableLongTextElipsed,_that.enableFavoritedRenoteElipsed,_that.tabPosition,_that.textScaleFactor,_that.emojiType,_that.defaultFontName,_that.serifFontName,_that.monospaceFontName,_that.cursiveFontName,_that.fantasyFontName,_that.languages,_that.isDeckMode,_that.lightNoteBackgroundPublic,_that.lightNoteBackgroundHome,_that.lightNoteBackgroundFollowers,_that.lightNoteBackgroundDirect,_that.darkNoteBackgroundPublic,_that.darkNoteBackgroundHome,_that.darkNoteBackgroundFollowers,_that.darkNoteBackgroundDirect);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String lightColorThemeId,  String darkColorThemeId,  ThemeColorSystem themeColorSystem,  NSFWInherit nsfwInherit,  bool enableDirectReaction,  AutomaticPush automaticPush,  bool enableAnimatedMFM,  bool enableLongTextElipsed,  bool enableFavoritedRenoteElipsed,  TabPosition tabPosition,  double textScaleFactor,  EmojiType emojiType,  String defaultFontName,  String serifFontName,  String monospaceFontName,  String cursiveFontName,  String fantasyFontName,  Languages languages,  bool isDeckMode, @ColorConverter()  Color? lightNoteBackgroundPublic, @ColorConverter()  Color? lightNoteBackgroundHome, @ColorConverter()  Color? lightNoteBackgroundFollowers, @ColorConverter()  Color? lightNoteBackgroundDirect, @ColorConverter()  Color? darkNoteBackgroundPublic, @ColorConverter()  Color? darkNoteBackgroundHome, @ColorConverter()  Color? darkNoteBackgroundFollowers, @ColorConverter()  Color? darkNoteBackgroundDirect)  $default,) {final _that = this;
+switch (_that) {
+case _GeneralSettings():
+return $default(_that.lightColorThemeId,_that.darkColorThemeId,_that.themeColorSystem,_that.nsfwInherit,_that.enableDirectReaction,_that.automaticPush,_that.enableAnimatedMFM,_that.enableLongTextElipsed,_that.enableFavoritedRenoteElipsed,_that.tabPosition,_that.textScaleFactor,_that.emojiType,_that.defaultFontName,_that.serifFontName,_that.monospaceFontName,_that.cursiveFontName,_that.fantasyFontName,_that.languages,_that.isDeckMode,_that.lightNoteBackgroundPublic,_that.lightNoteBackgroundHome,_that.lightNoteBackgroundFollowers,_that.lightNoteBackgroundDirect,_that.darkNoteBackgroundPublic,_that.darkNoteBackgroundHome,_that.darkNoteBackgroundFollowers,_that.darkNoteBackgroundDirect);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String lightColorThemeId,  String darkColorThemeId,  ThemeColorSystem themeColorSystem,  NSFWInherit nsfwInherit,  bool enableDirectReaction,  AutomaticPush automaticPush,  bool enableAnimatedMFM,  bool enableLongTextElipsed,  bool enableFavoritedRenoteElipsed,  TabPosition tabPosition,  double textScaleFactor,  EmojiType emojiType,  String defaultFontName,  String serifFontName,  String monospaceFontName,  String cursiveFontName,  String fantasyFontName,  Languages languages,  bool isDeckMode, @ColorConverter()  Color? lightNoteBackgroundPublic, @ColorConverter()  Color? lightNoteBackgroundHome, @ColorConverter()  Color? lightNoteBackgroundFollowers, @ColorConverter()  Color? lightNoteBackgroundDirect, @ColorConverter()  Color? darkNoteBackgroundPublic, @ColorConverter()  Color? darkNoteBackgroundHome, @ColorConverter()  Color? darkNoteBackgroundFollowers, @ColorConverter()  Color? darkNoteBackgroundDirect)?  $default,) {final _that = this;
+switch (_that) {
+case _GeneralSettings() when $default != null:
+return $default(_that.lightColorThemeId,_that.darkColorThemeId,_that.themeColorSystem,_that.nsfwInherit,_that.enableDirectReaction,_that.automaticPush,_that.enableAnimatedMFM,_that.enableLongTextElipsed,_that.enableFavoritedRenoteElipsed,_that.tabPosition,_that.textScaleFactor,_that.emojiType,_that.defaultFontName,_that.serifFontName,_that.monospaceFontName,_that.cursiveFontName,_that.fantasyFontName,_that.languages,_that.isDeckMode,_that.lightNoteBackgroundPublic,_that.lightNoteBackgroundHome,_that.lightNoteBackgroundFollowers,_that.lightNoteBackgroundDirect,_that.darkNoteBackgroundPublic,_that.darkNoteBackgroundHome,_that.darkNoteBackgroundFollowers,_that.darkNoteBackgroundDirect);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/misskey_theme.freezed.dart
+++ b/lib/model/misskey_theme.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -80,6 +79,136 @@ as String?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [MisskeyTheme].
+extension MisskeyThemePatterns on MisskeyTheme {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MisskeyTheme value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MisskeyTheme() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MisskeyTheme value)  $default,){
+final _that = this;
+switch (_that) {
+case _MisskeyTheme():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MisskeyTheme value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MisskeyTheme() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  Map<String, String> props,  String? author,  String? desc,  String? base)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MisskeyTheme() when $default != null:
+return $default(_that.id,_that.name,_that.props,_that.author,_that.desc,_that.base);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  Map<String, String> props,  String? author,  String? desc,  String? base)  $default,) {final _that = this;
+switch (_that) {
+case _MisskeyTheme():
+return $default(_that.id,_that.name,_that.props,_that.author,_that.desc,_that.base);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  Map<String, String> props,  String? author,  String? desc,  String? base)?  $default,) {final _that = this;
+switch (_that) {
+case _MisskeyTheme() when $default != null:
+return $default(_that.id,_that.name,_that.props,_that.author,_that.desc,_that.base);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/note_search_condition.freezed.dart
+++ b/lib/model/note_search_condition.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -87,6 +86,136 @@ $CommunityChannelCopyWith<$Res>? get channel {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [NoteSearchCondition].
+extension NoteSearchConditionPatterns on NoteSearchCondition {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NoteSearchCondition value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NoteSearchCondition() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NoteSearchCondition value)  $default,){
+final _that = this;
+switch (_that) {
+case _NoteSearchCondition():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NoteSearchCondition value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NoteSearchCondition() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NoteSearchCondition() when $default != null:
+return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly)  $default,) {final _that = this;
+switch (_that) {
+case _NoteSearchCondition():
+return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly)?  $default,) {final _that = this;
+switch (_that) {
+case _NoteSearchCondition() when $default != null:
+return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/model/server_preset.freezed.dart
+++ b/lib/model/server_preset.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -76,6 +75,136 @@ as List<TimelinePreset>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [ServerPresets].
+extension ServerPresetsPatterns on ServerPresets {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ServerPresets value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ServerPresets() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ServerPresets value)  $default,){
+final _that = this;
+switch (_that) {
+case _ServerPresets():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ServerPresets value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ServerPresets() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(fromJson: _limitedApiServersFromJson)  List<String> limitedApiServers,  List<TimelinePreset> particularTimelinePresets)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ServerPresets() when $default != null:
+return $default(_that.limitedApiServers,_that.particularTimelinePresets);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(fromJson: _limitedApiServersFromJson)  List<String> limitedApiServers,  List<TimelinePreset> particularTimelinePresets)  $default,) {final _that = this;
+switch (_that) {
+case _ServerPresets():
+return $default(_that.limitedApiServers,_that.particularTimelinePresets);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(fromJson: _limitedApiServersFromJson)  List<String> limitedApiServers,  List<TimelinePreset> particularTimelinePresets)?  $default,) {final _that = this;
+switch (_that) {
+case _ServerPresets() when $default != null:
+return $default(_that.limitedApiServers,_that.particularTimelinePresets);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()
@@ -227,6 +356,136 @@ as Map<String, dynamic>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [TimelinePreset].
+extension TimelinePresetPatterns on TimelinePreset {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TimelinePreset value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TimelinePreset() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TimelinePreset value)  $default,){
+final _that = this;
+switch (_that) {
+case _TimelinePreset():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TimelinePreset value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TimelinePreset() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String host,  String name,  String endpoint,  String websocketChannelName, @JsonKey(fromJson: _paramsFromJson, toJson: _paramsToJson)  Map<String, dynamic> parameters)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TimelinePreset() when $default != null:
+return $default(_that.host,_that.name,_that.endpoint,_that.websocketChannelName,_that.parameters);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String host,  String name,  String endpoint,  String websocketChannelName, @JsonKey(fromJson: _paramsFromJson, toJson: _paramsToJson)  Map<String, dynamic> parameters)  $default,) {final _that = this;
+switch (_that) {
+case _TimelinePreset():
+return $default(_that.host,_that.name,_that.endpoint,_that.websocketChannelName,_that.parameters);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String host,  String name,  String endpoint,  String websocketChannelName, @JsonKey(fromJson: _paramsFromJson, toJson: _paramsToJson)  Map<String, dynamic> parameters)?  $default,) {final _that = this;
+switch (_that) {
+case _TimelinePreset() when $default != null:
+return $default(_that.host,_that.name,_that.endpoint,_that.websocketChannelName,_that.parameters);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/summaly_result.freezed.dart
+++ b/lib/model/summaly_result.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -91,6 +90,136 @@ $PlayerCopyWith<$Res> get player {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [SummalyResult].
+extension SummalyResultPatterns on SummalyResult {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SummalyResult value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SummalyResult() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SummalyResult value)  $default,){
+final _that = this;
+switch (_that) {
+case _SummalyResult():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SummalyResult value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SummalyResult() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Player player,  String? title,  String? icon,  String? description,  String? thumbnail,  String? sitename,  bool? sensitive,  String? url)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SummalyResult() when $default != null:
+return $default(_that.player,_that.title,_that.icon,_that.description,_that.thumbnail,_that.sitename,_that.sensitive,_that.url);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Player player,  String? title,  String? icon,  String? description,  String? thumbnail,  String? sitename,  bool? sensitive,  String? url)  $default,) {final _that = this;
+switch (_that) {
+case _SummalyResult():
+return $default(_that.player,_that.title,_that.icon,_that.description,_that.thumbnail,_that.sitename,_that.sensitive,_that.url);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Player player,  String? title,  String? icon,  String? description,  String? thumbnail,  String? sitename,  bool? sensitive,  String? url)?  $default,) {final _that = this;
+switch (_that) {
+case _SummalyResult() when $default != null:
+return $default(_that.player,_that.title,_that.icon,_that.description,_that.thumbnail,_that.sitename,_that.sensitive,_that.url);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()
@@ -250,6 +379,136 @@ as List<String>?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [Player].
+extension PlayerPatterns on Player {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Player value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Player() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Player value)  $default,){
+final _that = this;
+switch (_that) {
+case _Player():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Player value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Player() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? url,  double? width,  double? height,  List<String>? allow)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Player() when $default != null:
+return $default(_that.url,_that.width,_that.height,_that.allow);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? url,  double? width,  double? height,  List<String>? allow)  $default,) {final _that = this;
+switch (_that) {
+case _Player():
+return $default(_that.url,_that.width,_that.height,_that.allow);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? url,  double? width,  double? height,  List<String>? allow)?  $default,) {final _that = this;
+switch (_that) {
+case _Player() when $default != null:
+return $default(_that.url,_that.width,_that.height,_that.allow);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/tab_icon.freezed.dart
+++ b/lib/model/tab_icon.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -76,6 +75,136 @@ as String?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [TabIcon].
+extension TabIconPatterns on TabIcon {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TabIcon value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TabIcon() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TabIcon value)  $default,){
+final _that = this;
+switch (_that) {
+case _TabIcon():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TabIcon value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TabIcon() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int? codePoint,  String? customEmojiName)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TabIcon() when $default != null:
+return $default(_that.codePoint,_that.customEmojiName);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int? codePoint,  String? customEmojiName)  $default,) {final _that = this;
+switch (_that) {
+case _TabIcon():
+return $default(_that.codePoint,_that.customEmojiName);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int? codePoint,  String? customEmojiName)?  $default,) {final _that = this;
+switch (_that) {
+case _TabIcon() when $default != null:
+return $default(_that.codePoint,_that.customEmojiName);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/tab_setting.freezed.dart
+++ b/lib/model/tab_setting.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -125,6 +124,136 @@ $AcctCopyWith<$Res> get acct {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [TabSetting].
+extension TabSettingPatterns on TabSetting {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TabSetting value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TabSetting() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TabSetting value)  $default,){
+final _that = this;
+switch (_that) {
+case _TabSetting():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TabSetting value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TabSetting() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@IconDataConverter()  TabIcon icon,  TabType tabType, @JsonKey(readValue: _readAcct)  Acct acct,  String? roleId,  String? channelId,  String? listId,  String? antennaId,  String? customChannelName,  String? customWebSocketPath,  String? customApiPath,  Map<String, dynamic>? customParameters,  bool isSubscribe,  bool isIncludeReplies,  bool isMediaOnly,  String? name,  bool renoteDisplay)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TabSetting() when $default != null:
+return $default(_that.icon,_that.tabType,_that.acct,_that.roleId,_that.channelId,_that.listId,_that.antennaId,_that.customChannelName,_that.customWebSocketPath,_that.customApiPath,_that.customParameters,_that.isSubscribe,_that.isIncludeReplies,_that.isMediaOnly,_that.name,_that.renoteDisplay);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@IconDataConverter()  TabIcon icon,  TabType tabType, @JsonKey(readValue: _readAcct)  Acct acct,  String? roleId,  String? channelId,  String? listId,  String? antennaId,  String? customChannelName,  String? customWebSocketPath,  String? customApiPath,  Map<String, dynamic>? customParameters,  bool isSubscribe,  bool isIncludeReplies,  bool isMediaOnly,  String? name,  bool renoteDisplay)  $default,) {final _that = this;
+switch (_that) {
+case _TabSetting():
+return $default(_that.icon,_that.tabType,_that.acct,_that.roleId,_that.channelId,_that.listId,_that.antennaId,_that.customChannelName,_that.customWebSocketPath,_that.customApiPath,_that.customParameters,_that.isSubscribe,_that.isIncludeReplies,_that.isMediaOnly,_that.name,_that.renoteDisplay);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@IconDataConverter()  TabIcon icon,  TabType tabType, @JsonKey(readValue: _readAcct)  Acct acct,  String? roleId,  String? channelId,  String? listId,  String? antennaId,  String? customChannelName,  String? customWebSocketPath,  String? customApiPath,  Map<String, dynamic>? customParameters,  bool isSubscribe,  bool isIncludeReplies,  bool isMediaOnly,  String? name,  bool renoteDisplay)?  $default,) {final _that = this;
+switch (_that) {
+case _TabSetting() when $default != null:
+return $default(_that.icon,_that.tabType,_that.acct,_that.roleId,_that.channelId,_that.listId,_that.antennaId,_that.customChannelName,_that.customWebSocketPath,_that.customApiPath,_that.customParameters,_that.isSubscribe,_that.isIncludeReplies,_that.isMediaOnly,_that.name,_that.renoteDisplay);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/unicode_emoji.freezed.dart
+++ b/lib/model/unicode_emoji.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -78,6 +77,136 @@ as List<String>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [UnicodeEmoji].
+extension UnicodeEmojiPatterns on UnicodeEmoji {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UnicodeEmoji value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UnicodeEmoji() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UnicodeEmoji value)  $default,){
+final _that = this;
+switch (_that) {
+case _UnicodeEmoji():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UnicodeEmoji value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UnicodeEmoji() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String category,  String char,  String name,  List<String> keywords)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UnicodeEmoji() when $default != null:
+return $default(_that.category,_that.char,_that.name,_that.keywords);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String category,  String char,  String name,  List<String> keywords)  $default,) {final _that = this;
+switch (_that) {
+case _UnicodeEmoji():
+return $default(_that.category,_that.char,_that.name,_that.keywords);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String category,  String char,  String name,  List<String> keywords)?  $default,) {final _that = this;
+switch (_that) {
+case _UnicodeEmoji() when $default != null:
+return $default(_that.category,_that.char,_that.name,_that.keywords);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/model/users_list_settings.freezed.dart
+++ b/lib/model/users_list_settings.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -73,6 +72,136 @@ as bool,
 
 }
 
+
+/// Adds pattern-matching-related methods to [UsersListSettings].
+extension UsersListSettingsPatterns on UsersListSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UsersListSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UsersListSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UsersListSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _UsersListSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UsersListSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UsersListSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  bool isPublic)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UsersListSettings() when $default != null:
+return $default(_that.name,_that.isPublic);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  bool isPublic)  $default,) {final _that = this;
+switch (_that) {
+case _UsersListSettings():
+return $default(_that.name,_that.isPublic);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  bool isPublic)?  $default,) {final _that = this;
+switch (_that) {
+case _UsersListSettings() when $default != null:
+return $default(_that.name,_that.isPublic);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/providers.freezed.dart
+++ b/lib/providers.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -92,6 +91,136 @@ $AccountCopyWith<$Res> get postAccount {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [AccountContext].
+extension AccountContextPatterns on AccountContext {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AccountContext value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AccountContext() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AccountContext value)  $default,){
+final _that = this;
+switch (_that) {
+case _AccountContext():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AccountContext value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AccountContext() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Account getAccount,  Account postAccount)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AccountContext() when $default != null:
+return $default(_that.getAccount,_that.postAccount);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Account getAccount,  Account postAccount)  $default,) {final _that = this;
+switch (_that) {
+case _AccountContext():
+return $default(_that.getAccount,_that.postAccount);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Account getAccount,  Account postAccount)?  $default,) {final _that = this;
+switch (_that) {
+case _AccountContext() when $default != null:
+return $default(_that.getAccount,_that.postAccount);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/repository/note_repository.freezed.dart
+++ b/lib/repository/note_repository.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -83,6 +82,136 @@ as bool,
 
 }
 
+
+/// Adds pattern-matching-related methods to [NoteStatus].
+extension NoteStatusPatterns on NoteStatus {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NoteStatus value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NoteStatus() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NoteStatus value)  $default,){
+final _that = this;
+switch (_that) {
+case _NoteStatus():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NoteStatus value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NoteStatus() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isCwOpened,  bool isLongVisible,  bool isReactionedRenote,  bool isLongVisibleInitialized,  bool isIncludeMuteWord,  bool isMuteOpened)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NoteStatus() when $default != null:
+return $default(_that.isCwOpened,_that.isLongVisible,_that.isReactionedRenote,_that.isLongVisibleInitialized,_that.isIncludeMuteWord,_that.isMuteOpened);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isCwOpened,  bool isLongVisible,  bool isReactionedRenote,  bool isLongVisibleInitialized,  bool isIncludeMuteWord,  bool isMuteOpened)  $default,) {final _that = this;
+switch (_that) {
+case _NoteStatus():
+return $default(_that.isCwOpened,_that.isLongVisible,_that.isReactionedRenote,_that.isLongVisibleInitialized,_that.isIncludeMuteWord,_that.isMuteOpened);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isCwOpened,  bool isLongVisible,  bool isReactionedRenote,  bool isLongVisibleInitialized,  bool isIncludeMuteWord,  bool isMuteOpened)?  $default,) {final _that = this;
+switch (_that) {
+case _NoteStatus() when $default != null:
+return $default(_that.isCwOpened,_that.isLongVisible,_that.isReactionedRenote,_that.isLongVisibleInitialized,_that.isIncludeMuteWord,_that.isMuteOpened);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/state_notifier/chat_input_state_notifier.freezed.dart
+++ b/lib/state_notifier/chat_input_state_notifier.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -72,6 +71,136 @@ as List<MisskeyPostFile>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [ChatInputState].
+extension ChatInputStatePatterns on ChatInputState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChatInputState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChatInputState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChatInputState value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChatInputState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChatInputState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChatInputState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<MisskeyPostFile> files)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChatInputState() when $default != null:
+return $default(_that.files);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<MisskeyPostFile> files)  $default,) {final _that = this;
+switch (_that) {
+case _ChatInputState():
+return $default(_that.files);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<MisskeyPostFile> files)?  $default,) {final _that = this;
+switch (_that) {
+case _ChatInputState() when $default != null:
+return $default(_that.files);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/state_notifier/clip_list_page/clips_notifier.dart
+++ b/lib/state_notifier/clip_list_page/clips_notifier.dart
@@ -11,7 +11,7 @@ part "clips_notifier.g.dart";
 class ClipsNotifier extends _$ClipsNotifier {
   @override
   Future<List<Clip>> build() async {
-    final response = await ref.read(misskeyPostContextProvider).clips.list();
+    final response = await ref.read(misskeyPostContextProvider).clips.list(const ClipsListRequest());
     return response.toList();
   }
 

--- a/lib/state_notifier/clip_list_page/clips_notifier.dart
+++ b/lib/state_notifier/clip_list_page/clips_notifier.dart
@@ -15,9 +15,10 @@ class ClipsNotifier extends _$ClipsNotifier {
   }
 
   Future<List<Clip>> loadClips({String? untilId, int limit = 10}) async {
-    final response = await ref.read(misskeyPostContextProvider).clips.list(
-      ClipsListRequest(untilId: untilId, limit: limit),
-    );
+    final response = await ref
+        .read(misskeyPostContextProvider)
+        .clips
+        .list(ClipsListRequest(untilId: untilId, limit: limit));
     return response.toList();
   }
 

--- a/lib/state_notifier/clip_list_page/clips_notifier.dart
+++ b/lib/state_notifier/clip_list_page/clips_notifier.dart
@@ -11,7 +11,13 @@ part "clips_notifier.g.dart";
 class ClipsNotifier extends _$ClipsNotifier {
   @override
   Future<List<Clip>> build() async {
-    final response = await ref.read(misskeyPostContextProvider).clips.list(const ClipsListRequest());
+    return [];
+  }
+
+  Future<List<Clip>> loadClips({String? untilId, int limit = 10}) async {
+    final response = await ref.read(misskeyPostContextProvider).clips.list(
+      ClipsListRequest(untilId: untilId, limit: limit),
+    );
     return response.toList();
   }
 

--- a/lib/state_notifier/clip_list_page/clips_notifier.g.dart
+++ b/lib/state_notifier/clip_list_page/clips_notifier.g.dart
@@ -37,7 +37,7 @@ final class ClipsNotifierProvider
   ClipsNotifier create() => ClipsNotifier();
 }
 
-String _$clipsNotifierHash() => r'202d19ed62fe947ddcd7ae6d0a79f0a98b37c962';
+String _$clipsNotifierHash() => r'0e8ca51be868e20c4934937e235f836d5668655c';
 
 abstract class _$ClipsNotifier extends $AsyncNotifier<List<Clip>> {
   FutureOr<List<Clip>> build();

--- a/lib/state_notifier/clip_list_page/clips_notifier.g.dart
+++ b/lib/state_notifier/clip_list_page/clips_notifier.g.dart
@@ -37,7 +37,7 @@ final class ClipsNotifierProvider
   ClipsNotifier create() => ClipsNotifier();
 }
 
-String _$clipsNotifierHash() => r'd2e5c8f6a083dbe75bb63070550f16728c7dde5d';
+String _$clipsNotifierHash() => r'202d19ed62fe947ddcd7ae6d0a79f0a98b37c962';
 
 abstract class _$ClipsNotifier extends $AsyncNotifier<List<Clip>> {
   FutureOr<List<Clip>> build();

--- a/lib/state_notifier/note_create_page/note_create_state_notifier.freezed.dart
+++ b/lib/state_notifier/note_create_page/note_create_state_notifier.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -131,6 +130,136 @@ $NoteCopyWith<$Res>? get renote {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [NoteCreate].
+extension NoteCreatePatterns on NoteCreate {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NoteCreate value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NoteCreate() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NoteCreate value)  $default,){
+final _that = this;
+switch (_that) {
+case _NoteCreate():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NoteCreate value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NoteCreate() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( NoteVisibility noteVisibility,  bool localOnly,  ReactionAcceptance? reactionAcceptance,  List<User> replyTo,  List<MisskeyPostFile> files,  NoteCreateChannel? channel,  Note? reply,  Note? renote,  bool isCw,  String cwText,  String text,  bool isTextFocused,  NoteSendStatus? isNoteSending,  bool isVote,  List<String> voteContent,  int voteContentCount,  VoteExpireType voteExpireType,  bool isVoteMultiple,  DateTime? voteDate,  int? voteDuration,  VoteExpireDurationType voteDurationType,  NoteCreationMode? noteCreationMode,  String? noteId,  String? selectedDraftId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NoteCreate() when $default != null:
+return $default(_that.noteVisibility,_that.localOnly,_that.reactionAcceptance,_that.replyTo,_that.files,_that.channel,_that.reply,_that.renote,_that.isCw,_that.cwText,_that.text,_that.isTextFocused,_that.isNoteSending,_that.isVote,_that.voteContent,_that.voteContentCount,_that.voteExpireType,_that.isVoteMultiple,_that.voteDate,_that.voteDuration,_that.voteDurationType,_that.noteCreationMode,_that.noteId,_that.selectedDraftId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( NoteVisibility noteVisibility,  bool localOnly,  ReactionAcceptance? reactionAcceptance,  List<User> replyTo,  List<MisskeyPostFile> files,  NoteCreateChannel? channel,  Note? reply,  Note? renote,  bool isCw,  String cwText,  String text,  bool isTextFocused,  NoteSendStatus? isNoteSending,  bool isVote,  List<String> voteContent,  int voteContentCount,  VoteExpireType voteExpireType,  bool isVoteMultiple,  DateTime? voteDate,  int? voteDuration,  VoteExpireDurationType voteDurationType,  NoteCreationMode? noteCreationMode,  String? noteId,  String? selectedDraftId)  $default,) {final _that = this;
+switch (_that) {
+case _NoteCreate():
+return $default(_that.noteVisibility,_that.localOnly,_that.reactionAcceptance,_that.replyTo,_that.files,_that.channel,_that.reply,_that.renote,_that.isCw,_that.cwText,_that.text,_that.isTextFocused,_that.isNoteSending,_that.isVote,_that.voteContent,_that.voteContentCount,_that.voteExpireType,_that.isVoteMultiple,_that.voteDate,_that.voteDuration,_that.voteDurationType,_that.noteCreationMode,_that.noteId,_that.selectedDraftId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( NoteVisibility noteVisibility,  bool localOnly,  ReactionAcceptance? reactionAcceptance,  List<User> replyTo,  List<MisskeyPostFile> files,  NoteCreateChannel? channel,  Note? reply,  Note? renote,  bool isCw,  String cwText,  String text,  bool isTextFocused,  NoteSendStatus? isNoteSending,  bool isVote,  List<String> voteContent,  int voteContentCount,  VoteExpireType voteExpireType,  bool isVoteMultiple,  DateTime? voteDate,  int? voteDuration,  VoteExpireDurationType voteDurationType,  NoteCreationMode? noteCreationMode,  String? noteId,  String? selectedDraftId)?  $default,) {final _that = this;
+switch (_that) {
+case _NoteCreate() when $default != null:
+return $default(_that.noteVisibility,_that.localOnly,_that.reactionAcceptance,_that.replyTo,_that.files,_that.channel,_that.reply,_that.renote,_that.isCw,_that.cwText,_that.text,_that.isTextFocused,_that.isNoteSending,_that.isVote,_that.voteContent,_that.voteContentCount,_that.voteExpireType,_that.isVoteMultiple,_that.voteDate,_that.voteDuration,_that.voteDurationType,_that.noteCreationMode,_that.noteId,_that.selectedDraftId);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 
@@ -359,6 +488,136 @@ as String,
 
 }
 
+
+/// Adds pattern-matching-related methods to [NoteCreateChannel].
+extension NoteCreateChannelPatterns on NoteCreateChannel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NoteCreateChannel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NoteCreateChannel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NoteCreateChannel value)  $default,){
+final _that = this;
+switch (_that) {
+case _NoteCreateChannel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NoteCreateChannel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NoteCreateChannel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NoteCreateChannel() when $default != null:
+return $default(_that.id,_that.name);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name)  $default,) {final _that = this;
+switch (_that) {
+case _NoteCreateChannel():
+return $default(_that.id,_that.name);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name)?  $default,) {final _that = this;
+switch (_that) {
+case _NoteCreateChannel() when $default != null:
+return $default(_that.id,_that.name);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/state_notifier/note_file_dialog/image_viewer_info_notifier.freezed.dart
+++ b/lib/state_notifier/note_file_dialog/image_viewer_info_notifier.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -76,6 +75,136 @@ as Offset?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [ImageViewerInfo].
+extension ImageViewerInfoPatterns on ImageViewerInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ImageViewerInfo value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ImageViewerInfo() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ImageViewerInfo value)  $default,){
+final _that = this;
+switch (_that) {
+case _ImageViewerInfo():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ImageViewerInfo value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ImageViewerInfo() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double scale,  double lastScale,  int pointersCount,  bool isDoubleTap,  Offset? lastTapLocalPosition)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ImageViewerInfo() when $default != null:
+return $default(_that.scale,_that.lastScale,_that.pointersCount,_that.isDoubleTap,_that.lastTapLocalPosition);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double scale,  double lastScale,  int pointersCount,  bool isDoubleTap,  Offset? lastTapLocalPosition)  $default,) {final _that = this;
+switch (_that) {
+case _ImageViewerInfo():
+return $default(_that.scale,_that.lastScale,_that.pointersCount,_that.isDoubleTap,_that.lastTapLocalPosition);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double scale,  double lastScale,  int pointersCount,  bool isDoubleTap,  Offset? lastTapLocalPosition)?  $default,) {final _that = this;
+switch (_that) {
+case _ImageViewerInfo() when $default != null:
+return $default(_that.scale,_that.lastScale,_that.pointersCount,_that.isDoubleTap,_that.lastTapLocalPosition);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/state_notifier/photo_edit_page/image_meta_dialog.freezed.dart
+++ b/lib/state_notifier/photo_edit_page/image_meta_dialog.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -74,6 +73,136 @@ as String,
 
 }
 
+
+/// Adds pattern-matching-related methods to [ImageMeta].
+extension ImageMetaPatterns on ImageMeta {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ImageMeta value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ImageMeta() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ImageMeta value)  $default,){
+final _that = this;
+switch (_that) {
+case _ImageMeta():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ImageMeta value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ImageMeta() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String fileName,  bool isNsfw,  String caption)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ImageMeta() when $default != null:
+return $default(_that.fileName,_that.isNsfw,_that.caption);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String fileName,  bool isNsfw,  String caption)  $default,) {final _that = this;
+switch (_that) {
+case _ImageMeta():
+return $default(_that.fileName,_that.isNsfw,_that.caption);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String fileName,  bool isNsfw,  String caption)?  $default,) {final _that = this;
+switch (_that) {
+case _ImageMeta() when $default != null:
+return $default(_that.fileName,_that.isNsfw,_that.caption);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/state_notifier/photo_edit_page/photo_edit_state_notifier.freezed.dart
+++ b/lib/state_notifier/photo_edit_page/photo_edit_state_notifier.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -85,6 +84,136 @@ as int?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [PhotoEdit].
+extension PhotoEditPatterns on PhotoEdit {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PhotoEdit value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PhotoEdit() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PhotoEdit value)  $default,){
+final _that = this;
+switch (_that) {
+case _PhotoEdit():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PhotoEdit value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PhotoEdit() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool clipMode,  bool colorFilterMode,  List<ColorFilterPreview> colorFilterPreviewImages,  List<String> adaptivePresets,  bool isInitialized,  Uint8List? initialImage,  Uint8List? editedImage,  Offset cropOffset,  Size cropSize,  Size defaultSize,  Size actualSize,  int angle,  List<EditedEmojiData> emojis,  int? selectedEmojiIndex)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PhotoEdit() when $default != null:
+return $default(_that.clipMode,_that.colorFilterMode,_that.colorFilterPreviewImages,_that.adaptivePresets,_that.isInitialized,_that.initialImage,_that.editedImage,_that.cropOffset,_that.cropSize,_that.defaultSize,_that.actualSize,_that.angle,_that.emojis,_that.selectedEmojiIndex);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool clipMode,  bool colorFilterMode,  List<ColorFilterPreview> colorFilterPreviewImages,  List<String> adaptivePresets,  bool isInitialized,  Uint8List? initialImage,  Uint8List? editedImage,  Offset cropOffset,  Size cropSize,  Size defaultSize,  Size actualSize,  int angle,  List<EditedEmojiData> emojis,  int? selectedEmojiIndex)  $default,) {final _that = this;
+switch (_that) {
+case _PhotoEdit():
+return $default(_that.clipMode,_that.colorFilterMode,_that.colorFilterPreviewImages,_that.adaptivePresets,_that.isInitialized,_that.initialImage,_that.editedImage,_that.cropOffset,_that.cropSize,_that.defaultSize,_that.actualSize,_that.angle,_that.emojis,_that.selectedEmojiIndex);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool clipMode,  bool colorFilterMode,  List<ColorFilterPreview> colorFilterPreviewImages,  List<String> adaptivePresets,  bool isInitialized,  Uint8List? initialImage,  Uint8List? editedImage,  Offset cropOffset,  Size cropSize,  Size defaultSize,  Size actualSize,  int angle,  List<EditedEmojiData> emojis,  int? selectedEmojiIndex)?  $default,) {final _that = this;
+switch (_that) {
+case _PhotoEdit() when $default != null:
+return $default(_that.clipMode,_that.colorFilterMode,_that.colorFilterPreviewImages,_that.adaptivePresets,_that.isInitialized,_that.initialImage,_that.editedImage,_that.cropOffset,_that.cropSize,_that.defaultSize,_that.actualSize,_that.angle,_that.emojis,_that.selectedEmojiIndex);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 
@@ -258,6 +387,136 @@ as Uint8List?,
 }
 
 
+/// Adds pattern-matching-related methods to [ColorFilterPreview].
+extension ColorFilterPreviewPatterns on ColorFilterPreview {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ColorFilterPreview value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ColorFilterPreview() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ColorFilterPreview value)  $default,){
+final _that = this;
+switch (_that) {
+case _ColorFilterPreview():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ColorFilterPreview value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ColorFilterPreview() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  Uint8List? image)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ColorFilterPreview() when $default != null:
+return $default(_that.name,_that.image);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  Uint8List? image)  $default,) {final _that = this;
+switch (_that) {
+case _ColorFilterPreview():
+return $default(_that.name,_that.image);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  Uint8List? image)?  $default,) {final _that = this;
+switch (_that) {
+case _ColorFilterPreview() when $default != null:
+return $default(_that.name,_that.image);case _:
+  return null;
+
+}
+}
+
+}
+
 /// @nodoc
 
 
@@ -389,6 +648,136 @@ as double,
 
 }
 
+
+/// Adds pattern-matching-related methods to [EditedEmojiData].
+extension EditedEmojiDataPatterns on EditedEmojiData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EditedEmojiData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EditedEmojiData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EditedEmojiData value)  $default,){
+final _that = this;
+switch (_that) {
+case _EditedEmojiData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EditedEmojiData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EditedEmojiData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( MisskeyEmojiData emoji,  double scale,  Offset position,  double angle)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EditedEmojiData() when $default != null:
+return $default(_that.emoji,_that.scale,_that.position,_that.angle);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( MisskeyEmojiData emoji,  double scale,  Offset position,  double angle)  $default,) {final _that = this;
+switch (_that) {
+case _EditedEmojiData():
+return $default(_that.emoji,_that.scale,_that.position,_that.angle);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( MisskeyEmojiData emoji,  double scale,  Offset position,  double angle)?  $default,) {final _that = this;
+switch (_that) {
+case _EditedEmojiData() when $default != null:
+return $default(_that.emoji,_that.scale,_that.position,_that.angle);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/antenna_page/antenna_settings_dialog.g.dart
+++ b/lib/view/antenna_page/antenna_settings_dialog.g.dart
@@ -25,7 +25,7 @@ final class _InitialSettingsProvider
       );
 
   @override
-  String debugGetCreateSourceHash() => _$initialSettingsHash();
+  String debugGetCreateSourceHash() => _$_initialSettingsHash();
 
   @$internal
   @override
@@ -46,7 +46,7 @@ final class _InitialSettingsProvider
   }
 }
 
-String _$initialSettingsHash() => r'5e44622c97f922cd7aa8410ac695fa6f5f3351b0';
+String _$_initialSettingsHash() => r'5e44622c97f922cd7aa8410ac695fa6f5f3351b0';
 
 @ProviderFor(_AntennaSettingsNotifier)
 const _antennaSettingsNotifierProvider = _AntennaSettingsNotifierProvider._();
@@ -69,7 +69,7 @@ final class _AntennaSettingsNotifierProvider
   static const $allTransitiveDependencies0 = _initialSettingsProvider;
 
   @override
-  String debugGetCreateSourceHash() => _$antennaSettingsNotifierHash();
+  String debugGetCreateSourceHash() => _$_antennaSettingsNotifierHash();
 
   @$internal
   @override
@@ -84,7 +84,7 @@ final class _AntennaSettingsNotifierProvider
   }
 }
 
-String _$antennaSettingsNotifierHash() =>
+String _$_antennaSettingsNotifierHash() =>
     r'a33758bbcc3f54c6eb50d2176d6ed1ce7b54f9b5';
 
 abstract class _$AntennaSettingsNotifier extends $Notifier<AntennaSettings> {
@@ -136,7 +136,7 @@ final class _UsersListListProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$usersListListHash();
+  String debugGetCreateSourceHash() => _$_usersListListHash();
 
   @$internal
   @override
@@ -150,7 +150,7 @@ final class _UsersListListProvider
   }
 }
 
-String _$usersListListHash() => r'038d168265d5f26396ee6dd063774e9b55055283';
+String _$_usersListListHash() => r'038d168265d5f26396ee6dd063774e9b55055283';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/channels_page/channel_detail_info.freezed.dart
+++ b/lib/view/channels_page/channel_detail_info.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -83,6 +82,136 @@ $CommunityChannelCopyWith<$Res> get channel {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [ChannelDetailState].
+extension ChannelDetailStatePatterns on ChannelDetailState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChannelDetailState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChannelDetailState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChannelDetailState value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelDetailState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChannelDetailState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChannelDetailState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( CommunityChannel channel,  AsyncValue<void>? follow,  AsyncValue<void>? favorite)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChannelDetailState() when $default != null:
+return $default(_that.channel,_that.follow,_that.favorite);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( CommunityChannel channel,  AsyncValue<void>? follow,  AsyncValue<void>? favorite)  $default,) {final _that = this;
+switch (_that) {
+case _ChannelDetailState():
+return $default(_that.channel,_that.follow,_that.favorite);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( CommunityChannel channel,  AsyncValue<void>? follow,  AsyncValue<void>? favorite)?  $default,) {final _that = this;
+switch (_that) {
+case _ChannelDetailState() when $default != null:
+return $default(_that.channel,_that.follow,_that.favorite);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/chat_page/pending_chat_message_item.freezed.dart
+++ b/lib/view/chat_page/pending_chat_message_item.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -75,6 +74,130 @@ as String?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [PendingChatMessage].
+extension PendingChatMessagePatterns on PendingChatMessage {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PendingChatMessage value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PendingChatMessage() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PendingChatMessage value)  $default,){
+final _that = this;
+switch (_that) {
+case _PendingChatMessage():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PendingChatMessage value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PendingChatMessage() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String tempId,  String text,  DateTime createdAt,  String? fileId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PendingChatMessage() when $default != null:
+return $default(_that.tempId,_that.text,_that.createdAt,_that.fileId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String tempId,  String text,  DateTime createdAt,  String? fileId)  $default,) {final _that = this;
+switch (_that) {
+case _PendingChatMessage():
+return $default(_that.tempId,_that.text,_that.createdAt,_that.fileId);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String tempId,  String text,  DateTime createdAt,  String? fileId)?  $default,) {final _that = this;
+switch (_that) {
+case _PendingChatMessage() when $default != null:
+return $default(_that.tempId,_that.text,_that.createdAt,_that.fileId);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/chat_page/room_chat.freezed.dart
+++ b/lib/view/chat_page/room_chat.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -74,6 +73,130 @@ as List<PendingChatMessage>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [RoomChatState].
+extension RoomChatStatePatterns on RoomChatState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RoomChatState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RoomChatState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RoomChatState value)  $default,){
+final _that = this;
+switch (_that) {
+case _RoomChatState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RoomChatState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RoomChatState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<ChatMessage> messages,  bool hasMoreMessages,  List<PendingChatMessage> pendingMessages)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RoomChatState() when $default != null:
+return $default(_that.messages,_that.hasMoreMessages,_that.pendingMessages);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<ChatMessage> messages,  bool hasMoreMessages,  List<PendingChatMessage> pendingMessages)  $default,) {final _that = this;
+switch (_that) {
+case _RoomChatState():
+return $default(_that.messages,_that.hasMoreMessages,_that.pendingMessages);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<ChatMessage> messages,  bool hasMoreMessages,  List<PendingChatMessage> pendingMessages)?  $default,) {final _that = this;
+switch (_that) {
+case _RoomChatState() when $default != null:
+return $default(_that.messages,_that.hasMoreMessages,_that.pendingMessages);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/chat_page/user_chat.freezed.dart
+++ b/lib/view/chat_page/user_chat.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -74,6 +73,130 @@ as List<PendingChatMessage>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [UserChatState].
+extension UserChatStatePatterns on UserChatState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserChatState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserChatState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserChatState value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserChatState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserChatState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserChatState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<ChatMessage> messages,  bool hasMoreMessages,  List<PendingChatMessage> pendingMessages)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserChatState() when $default != null:
+return $default(_that.messages,_that.hasMoreMessages,_that.pendingMessages);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<ChatMessage> messages,  bool hasMoreMessages,  List<PendingChatMessage> pendingMessages)  $default,) {final _that = this;
+switch (_that) {
+case _UserChatState():
+return $default(_that.messages,_that.hasMoreMessages,_that.pendingMessages);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<ChatMessage> messages,  bool hasMoreMessages,  List<PendingChatMessage> pendingMessages)?  $default,) {final _that = this;
+switch (_that) {
+case _UserChatState() when $default != null:
+return $default(_that.messages,_that.hasMoreMessages,_that.pendingMessages);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/clip_list_page/clip_list_page.dart
+++ b/lib/view/clip_list_page/clip_list_page.dart
@@ -9,7 +9,8 @@ import "package:miria/router/app_router.dart";
 import "package:miria/state_notifier/clip_list_page/clips_notifier.dart";
 import "package:miria/view/common/account_scope.dart";
 import "package:miria/view/common/clip_item.dart";
-import "package:miria/view/common/error_detail.dart";
+import "package:miria/view/common/pushable_listview.dart";
+import "package:misskey_dart/misskey_dart.dart";
 
 @RoutePage()
 class ClipListPage extends ConsumerWidget implements AutoRouteWrapper {
@@ -23,8 +24,6 @@ class ClipListPage extends ConsumerWidget implements AutoRouteWrapper {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final clips = ref.watch(clipsNotifierProvider);
-
     return Scaffold(
       appBar: AppBar(
         title: Text(S.of(context).clip),
@@ -42,24 +41,21 @@ class ClipListPage extends ConsumerWidget implements AutoRouteWrapper {
           ),
         ],
       ),
-      body: switch (clips) {
-        AsyncLoading() => const Center(
-          child: CircularProgressIndicator.adaptive(),
+      body: PushableListView<Clip>(
+        listKey: "clips_list",
+        initializeFuture: () async {
+          return await ref.read(clipsNotifierProvider.notifier).loadClips();
+        },
+        nextFuture: (lastItem, _) async {
+          return await ref.read(clipsNotifierProvider.notifier).loadClips(
+            untilId: lastItem.id,
+          );
+        },
+        itemBuilder: (context, clip) => ClipItem(
+          clip: clip,
+          trailing: _RemoveButton(id: clip.id),
         ),
-        AsyncError(:final error, :final stackTrace) => Center(
-          child: ErrorDetail(error: error, stackTrace: stackTrace),
-        ),
-        AsyncData(:final value) => ListView.builder(
-          itemCount: value.length,
-          itemBuilder: (context, index) {
-            final clip = value[index];
-            return ClipItem(
-              clip: clip,
-              trailing: _RemoveButton(id: clip.id),
-            );
-          },
-        ),
-      },
+      ),
     );
   }
 }

--- a/lib/view/clip_list_page/clip_list_page.dart
+++ b/lib/view/clip_list_page/clip_list_page.dart
@@ -47,9 +47,9 @@ class ClipListPage extends ConsumerWidget implements AutoRouteWrapper {
           return await ref.read(clipsNotifierProvider.notifier).loadClips();
         },
         nextFuture: (lastItem, _) async {
-          return await ref.read(clipsNotifierProvider.notifier).loadClips(
-            untilId: lastItem.id,
-          );
+          return await ref
+              .read(clipsNotifierProvider.notifier)
+              .loadClips(untilId: lastItem.id);
         },
         itemBuilder: (context, clip) => ClipItem(
           clip: clip,

--- a/lib/view/clip_list_page/clip_settings_dialog.g.dart
+++ b/lib/view/clip_list_page/clip_settings_dialog.g.dart
@@ -29,7 +29,7 @@ final class _FormKeyProvider
       );
 
   @override
-  String debugGetCreateSourceHash() => _$formKeyHash();
+  String debugGetCreateSourceHash() => _$_formKeyHash();
 
   @$internal
   @override
@@ -51,7 +51,7 @@ final class _FormKeyProvider
   }
 }
 
-String _$formKeyHash() => r'd8a56e0366cb1a53da5331749cce00aef36862b1';
+String _$_formKeyHash() => r'd8a56e0366cb1a53da5331749cce00aef36862b1';
 
 @ProviderFor(_initialSettings)
 const _initialSettingsProvider = _InitialSettingsProvider._();
@@ -71,7 +71,7 @@ final class _InitialSettingsProvider
       );
 
   @override
-  String debugGetCreateSourceHash() => _$initialSettingsHash();
+  String debugGetCreateSourceHash() => _$_initialSettingsHash();
 
   @$internal
   @override
@@ -92,7 +92,7 @@ final class _InitialSettingsProvider
   }
 }
 
-String _$initialSettingsHash() => r'5822fd6a8e4070e8a4da0c299a6149e49f7ef49e';
+String _$_initialSettingsHash() => r'5822fd6a8e4070e8a4da0c299a6149e49f7ef49e';
 
 @ProviderFor(_ClipSettingsNotifier)
 const _clipSettingsNotifierProvider = _ClipSettingsNotifierProvider._();
@@ -115,7 +115,7 @@ final class _ClipSettingsNotifierProvider
   static const $allTransitiveDependencies0 = _initialSettingsProvider;
 
   @override
-  String debugGetCreateSourceHash() => _$clipSettingsNotifierHash();
+  String debugGetCreateSourceHash() => _$_clipSettingsNotifierHash();
 
   @$internal
   @override
@@ -130,7 +130,7 @@ final class _ClipSettingsNotifierProvider
   }
 }
 
-String _$clipSettingsNotifierHash() =>
+String _$_clipSettingsNotifierHash() =>
     r'004b0ddb0c4b37ca968f1da8c8390ef047727180';
 
 abstract class _$ClipSettingsNotifier extends $Notifier<ClipSettings> {

--- a/lib/view/clip_modal_sheet/clip_modal_sheet.g.dart
+++ b/lib/view/clip_modal_sheet/clip_modal_sheet.g.dart
@@ -27,7 +27,7 @@ final class _NotesClipsNotifierProvider
       MisskeyPostContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$notesClipsNotifierHash();
+  String debugGetCreateSourceHash() => _$_notesClipsNotifierHash();
 
   @override
   String toString() {
@@ -51,7 +51,7 @@ final class _NotesClipsNotifierProvider
   }
 }
 
-String _$notesClipsNotifierHash() =>
+String _$_notesClipsNotifierHash() =>
     r'ac73f5e5d6dcc731e9c023a03e84eb10fd14de9c';
 
 final class _NotesClipsNotifierFamily extends $Family
@@ -129,7 +129,7 @@ final class _ClipModalSheetNotifierProvider
   static const $allTransitiveDependencies3 = _notesClipsNotifierProvider;
 
   @override
-  String debugGetCreateSourceHash() => _$clipModalSheetNotifierHash();
+  String debugGetCreateSourceHash() => _$_clipModalSheetNotifierHash();
 
   @override
   String toString() {
@@ -154,7 +154,7 @@ final class _ClipModalSheetNotifierProvider
   }
 }
 
-String _$clipModalSheetNotifierHash() =>
+String _$_clipModalSheetNotifierHash() =>
     r'0751058a13d6c6ff7714eeef4110d399970c5b46';
 
 final class _ClipModalSheetNotifierFamily extends $Family

--- a/lib/view/common/dialog/dialog_state.freezed.dart
+++ b/lib/view/common/dialog/dialog_state.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -78,6 +77,136 @@ as List<DialogData>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [DialogsState].
+extension DialogsStatePatterns on DialogsState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DialogsState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DialogsState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DialogsState value)  $default,){
+final _that = this;
+switch (_that) {
+case _DialogsState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DialogsState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DialogsState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<DialogData> dialogs)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DialogsState() when $default != null:
+return $default(_that.dialogs);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<DialogData> dialogs)  $default,) {final _that = this;
+switch (_that) {
+case _DialogsState():
+return $default(_that.dialogs);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<DialogData> dialogs)?  $default,) {final _that = this;
+switch (_that) {
+case _DialogsState() when $default != null:
+return $default(_that.dialogs);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 
@@ -239,6 +368,136 @@ $AccountContextCopyWith<$Res>? get accountContext {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [DialogData].
+extension DialogDataPatterns on DialogData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DialogData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DialogData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DialogData value)  $default,){
+final _that = this;
+switch (_that) {
+case _DialogData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DialogData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DialogData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String Function(BuildContext context) message,  List<String> Function(BuildContext context) actions,  Completer<int> completer, @Assert("!isMFM || isMFM && accountContext != null", "account context must not be null when isMFM is true")  AccountContext? accountContext,  bool isMFM)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DialogData() when $default != null:
+return $default(_that.message,_that.actions,_that.completer,_that.accountContext,_that.isMFM);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String Function(BuildContext context) message,  List<String> Function(BuildContext context) actions,  Completer<int> completer, @Assert("!isMFM || isMFM && accountContext != null", "account context must not be null when isMFM is true")  AccountContext? accountContext,  bool isMFM)  $default,) {final _that = this;
+switch (_that) {
+case _DialogData():
+return $default(_that.message,_that.actions,_that.completer,_that.accountContext,_that.isMFM);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String Function(BuildContext context) message,  List<String> Function(BuildContext context) actions,  Completer<int> completer, @Assert("!isMFM || isMFM && accountContext != null", "account context must not be null when isMFM is true")  AccountContext? accountContext,  bool isMFM)?  $default,) {final _that = this;
+switch (_that) {
+case _DialogData() when $default != null:
+return $default(_that.message,_that.actions,_that.completer,_that.accountContext,_that.isMFM);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/common/note_create/hashtag_keyboard.g.dart
+++ b/lib/view/common/note_create/hashtag_keyboard.g.dart
@@ -23,7 +23,7 @@ final class _HashtagsSearchProvider
        );
 
   @override
-  String debugGetCreateSourceHash() => _$hashtagsSearchHash();
+  String debugGetCreateSourceHash() => _$_hashtagsSearchHash();
 
   @override
   String toString() {
@@ -47,7 +47,7 @@ final class _HashtagsSearchProvider
   }
 }
 
-String _$hashtagsSearchHash() => r'33995ae8bae76065902a767060f73a587cb7664a';
+String _$_hashtagsSearchHash() => r'33995ae8bae76065902a767060f73a587cb7664a';
 
 final class _HashtagsSearchFamily extends $Family
     with

--- a/lib/view/explore_page/explore_users.g.dart
+++ b/lib/view/explore_page/explore_users.g.dart
@@ -38,7 +38,7 @@ final class _PinnedUserProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$pinnedUserHash();
+  String debugGetCreateSourceHash() => _$_pinnedUserHash();
 
   @$internal
   @override
@@ -52,7 +52,7 @@ final class _PinnedUserProvider
   }
 }
 
-String _$pinnedUserHash() => r'bc9d937e7e437c825d643641c24715a4d5762f89';
+String _$_pinnedUserHash() => r'bc9d937e7e437c825d643641c24715a4d5762f89';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/games_page/misskey_games_page.g.dart
+++ b/lib/view/games_page/misskey_games_page.g.dart
@@ -36,7 +36,7 @@ final class _FetchReversiDataProvider
       MisskeyPostContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$fetchReversiDataHash();
+  String debugGetCreateSourceHash() => _$_fetchReversiDataHash();
 
   @$internal
   @override
@@ -49,7 +49,7 @@ final class _FetchReversiDataProvider
   }
 }
 
-String _$fetchReversiDataHash() => r'c83ae0f4b7d51c2f9b8d800e959556517d4a8839';
+String _$_fetchReversiDataHash() => r'c83ae0f4b7d51c2f9b8d800e959556517d4a8839';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/misskey_page_page/misskey_page_notifier.freezed.dart
+++ b/lib/view/misskey_page_page/misskey_page_notifier.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -82,6 +81,136 @@ $PageCopyWith<$Res> get page {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [MisskeyPageNotifierState].
+extension MisskeyPageNotifierStatePatterns on MisskeyPageNotifierState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MisskeyPageNotifierState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MisskeyPageNotifierState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MisskeyPageNotifierState value)  $default,){
+final _that = this;
+switch (_that) {
+case _MisskeyPageNotifierState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MisskeyPageNotifierState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MisskeyPageNotifierState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Page page,  AsyncValue<void>? likeOr)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MisskeyPageNotifierState() when $default != null:
+return $default(_that.page,_that.likeOr);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Page page,  AsyncValue<void>? likeOr)  $default,) {final _that = this;
+switch (_that) {
+case _MisskeyPageNotifierState():
+return $default(_that.page,_that.likeOr);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Page page,  AsyncValue<void>? likeOr)?  $default,) {final _that = this;
+switch (_that) {
+case _MisskeyPageNotifierState() when $default != null:
+return $default(_that.page,_that.likeOr);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/note_detail_page/note_detail_page.g.dart
+++ b/lib/view/note_detail_page/note_detail_page.g.dart
@@ -29,7 +29,7 @@ final class _NotesShowProvider
   static const $allTransitiveDependencies2 = notesWithProvider;
 
   @override
-  String debugGetCreateSourceHash() => _$notesShowHash();
+  String debugGetCreateSourceHash() => _$_notesShowHash();
 
   @override
   String toString() {
@@ -60,7 +60,7 @@ final class _NotesShowProvider
   }
 }
 
-String _$notesShowHash() => r'69e8ff0eaa98e6a6047750a22d7fdacc566a28af';
+String _$_notesShowHash() => r'69e8ff0eaa98e6a6047750a22d7fdacc566a28af';
 
 final class _NotesShowFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<Note>, String> {
@@ -115,7 +115,7 @@ final class _ConversationProvider
   static const $allTransitiveDependencies2 = notesWithProvider;
 
   @override
-  String debugGetCreateSourceHash() => _$conversationHash();
+  String debugGetCreateSourceHash() => _$_conversationHash();
 
   @override
   String toString() {
@@ -146,7 +146,7 @@ final class _ConversationProvider
   }
 }
 
-String _$conversationHash() => r'b69ce226a89b66118fb9eb993e16b802e9c6210d';
+String _$_conversationHash() => r'b69ce226a89b66118fb9eb993e16b802e9c6210d';
 
 final class _ConversationFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<Note>>, String> {

--- a/lib/view/note_modal_sheet/note_modal_sheet.freezed.dart
+++ b/lib/view/note_modal_sheet/note_modal_sheet.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -83,6 +82,136 @@ as AsyncValue<void>?,
 
 }
 
+
+/// Adds pattern-matching-related methods to [NoteModalSheetState].
+extension NoteModalSheetStatePatterns on NoteModalSheetState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NoteModalSheetState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NoteModalSheetState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NoteModalSheetState value)  $default,){
+final _that = this;
+switch (_that) {
+case _NoteModalSheetState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NoteModalSheetState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NoteModalSheetState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AsyncValue<NotesStateResponse>? noteState,  bool isSharingMode,  AsyncValue<UserDetailed>? user,  AsyncValue<void>? delete,  AsyncValue<void>? deleteRecreate,  AsyncValue<void>? favorite)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NoteModalSheetState() when $default != null:
+return $default(_that.noteState,_that.isSharingMode,_that.user,_that.delete,_that.deleteRecreate,_that.favorite);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AsyncValue<NotesStateResponse>? noteState,  bool isSharingMode,  AsyncValue<UserDetailed>? user,  AsyncValue<void>? delete,  AsyncValue<void>? deleteRecreate,  AsyncValue<void>? favorite)  $default,) {final _that = this;
+switch (_that) {
+case _NoteModalSheetState():
+return $default(_that.noteState,_that.isSharingMode,_that.user,_that.delete,_that.deleteRecreate,_that.favorite);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AsyncValue<NotesStateResponse>? noteState,  bool isSharingMode,  AsyncValue<UserDetailed>? user,  AsyncValue<void>? delete,  AsyncValue<void>? deleteRecreate,  AsyncValue<void>? favorite)?  $default,) {final _that = this;
+switch (_that) {
+case _NoteModalSheetState() when $default != null:
+return $default(_that.noteState,_that.isSharingMode,_that.user,_that.delete,_that.deleteRecreate,_that.favorite);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/photo_edit_page/license_confirm_dialog.g.dart
+++ b/lib/view/photo_edit_page/license_confirm_dialog.g.dart
@@ -33,7 +33,7 @@ final class _EmojiProvider
       MisskeyPostContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$emojiHash();
+  String debugGetCreateSourceHash() => _$_emojiHash();
 
   @override
   String toString() {
@@ -65,7 +65,7 @@ final class _EmojiProvider
   }
 }
 
-String _$emojiHash() => r'4d613b2d1965a683c3d159578f812609b9f6cbd1';
+String _$_emojiHash() => r'4d613b2d1965a683c3d159578f812609b9f6cbd1';
 
 final class _EmojiFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<EmojiResponse>, String> {

--- a/lib/view/profile_edit_page/edit_profile_state_notifier.freezed.dart
+++ b/lib/view/profile_edit_page/edit_profile_state_notifier.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -74,6 +73,136 @@ as String,
 
 }
 
+
+/// Adds pattern-matching-related methods to [EditUserField].
+extension EditUserFieldPatterns on EditUserField {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EditUserField value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EditUserField() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EditUserField value)  $default,){
+final _that = this;
+switch (_that) {
+case _EditUserField():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EditUserField value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EditUserField() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String value)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EditUserField() when $default != null:
+return $default(_that.id,_that.name,_that.value);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String value)  $default,) {final _that = this;
+switch (_that) {
+case _EditUserField():
+return $default(_that.id,_that.name,_that.value);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String value)?  $default,) {final _that = this;
+switch (_that) {
+case _EditUserField() when $default != null:
+return $default(_that.id,_that.name,_that.value);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 
@@ -216,6 +345,130 @@ as bool,
 
 }
 
+
+/// Adds pattern-matching-related methods to [EditProfileState].
+extension EditProfileStatePatterns on EditProfileState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EditProfileState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EditProfileState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EditProfileState value)  $default,){
+final _that = this;
+switch (_that) {
+case _EditProfileState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EditProfileState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EditProfileState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String description,  String location,  DateTime? birthday,  List<EditUserField> fields,  String followedMessage,  String? avatarDriveId,  ({Uint8List data, String name})? avatarFile,  Uri? currentAvatarUrl,  Uri? selectedDriveFileUrl,  bool isLoading,  bool isSubmitting)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EditProfileState() when $default != null:
+return $default(_that.name,_that.description,_that.location,_that.birthday,_that.fields,_that.followedMessage,_that.avatarDriveId,_that.avatarFile,_that.currentAvatarUrl,_that.selectedDriveFileUrl,_that.isLoading,_that.isSubmitting);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String description,  String location,  DateTime? birthday,  List<EditUserField> fields,  String followedMessage,  String? avatarDriveId,  ({Uint8List data, String name})? avatarFile,  Uri? currentAvatarUrl,  Uri? selectedDriveFileUrl,  bool isLoading,  bool isSubmitting)  $default,) {final _that = this;
+switch (_that) {
+case _EditProfileState():
+return $default(_that.name,_that.description,_that.location,_that.birthday,_that.fields,_that.followedMessage,_that.avatarDriveId,_that.avatarFile,_that.currentAvatarUrl,_that.selectedDriveFileUrl,_that.isLoading,_that.isSubmitting);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String description,  String location,  DateTime? birthday,  List<EditUserField> fields,  String followedMessage,  String? avatarDriveId,  ({Uint8List data, String name})? avatarFile,  Uri? currentAvatarUrl,  Uri? selectedDriveFileUrl,  bool isLoading,  bool isSubmitting)?  $default,) {final _that = this;
+switch (_that) {
+case _EditProfileState() when $default != null:
+return $default(_that.name,_that.description,_that.location,_that.birthday,_that.fields,_that.followedMessage,_that.avatarDriveId,_that.avatarFile,_that.currentAvatarUrl,_that.selectedDriveFileUrl,_that.isLoading,_that.isSubmitting);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/profile_edit_page/edit_profile_state_notifier.g.dart
+++ b/lib/view/profile_edit_page/edit_profile_state_notifier.g.dart
@@ -43,7 +43,7 @@ final class EditProfileStateNotifierProvider
 }
 
 String _$editProfileStateNotifierHash() =>
-    r'1c988afcb710ffd97d1a56cf0e17bf9a5f323677';
+    r'8c9aad09d8919bd4d4af1d04613ad6259794d272';
 
 abstract class _$EditProfileStateNotifier
     extends $AsyncNotifier<EditProfileState> {

--- a/lib/view/server_detail_dialog.g.dart
+++ b/lib/view/server_detail_dialog.g.dart
@@ -31,7 +31,7 @@ final class _OnlineCountsProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$onlineCountsHash();
+  String debugGetCreateSourceHash() => _$_onlineCountsHash();
 
   @$internal
   @override
@@ -44,7 +44,7 @@ final class _OnlineCountsProvider
   }
 }
 
-String _$onlineCountsHash() => r'948bcc533f8c06ee79935fc5386ad67051c03bb9';
+String _$_onlineCountsHash() => r'948bcc533f8c06ee79935fc5386ad67051c03bb9';
 
 @ProviderFor(_totalMemories)
 const _totalMemoriesProvider = _TotalMemoriesProvider._();
@@ -71,7 +71,7 @@ final class _TotalMemoriesProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$totalMemoriesHash();
+  String debugGetCreateSourceHash() => _$_totalMemoriesHash();
 
   @$internal
   @override
@@ -84,7 +84,7 @@ final class _TotalMemoriesProvider
   }
 }
 
-String _$totalMemoriesHash() => r'd7f5bc52076ca1a74f8cdf65938cff571a92acd8';
+String _$_totalMemoriesHash() => r'd7f5bc52076ca1a74f8cdf65938cff571a92acd8';
 
 @ProviderFor(_ping)
 const _pingProvider = _PingProvider._();
@@ -111,7 +111,7 @@ final class _PingProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$pingHash();
+  String debugGetCreateSourceHash() => _$_pingHash();
 
   @$internal
   @override
@@ -124,7 +124,7 @@ final class _PingProvider
   }
 }
 
-String _$pingHash() => r'3e002e48252dd1158c3ecdf4c6c4a635c5bc80fa';
+String _$_pingHash() => r'3e002e48252dd1158c3ecdf4c6c4a635c5bc80fa';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/settings_page/tab_settings_page/antenna_select_dialog.g.dart
+++ b/lib/view/settings_page/tab_settings_page/antenna_select_dialog.g.dart
@@ -36,7 +36,7 @@ final class _AntennasProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$antennasHash();
+  String debugGetCreateSourceHash() => _$_antennasHash();
 
   @$internal
   @override
@@ -50,7 +50,7 @@ final class _AntennasProvider
   }
 }
 
-String _$antennasHash() => r'789e8f8a722a66e9c9270594c9307d9257a14936';
+String _$_antennasHash() => r'789e8f8a722a66e9c9270594c9307d9257a14936';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/settings_page/tab_settings_page/role_select_dialog.g.dart
+++ b/lib/view/settings_page/tab_settings_page/role_select_dialog.g.dart
@@ -38,7 +38,7 @@ final class _RolesProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$rolesHash();
+  String debugGetCreateSourceHash() => _$_rolesHash();
 
   @$internal
   @override
@@ -52,7 +52,7 @@ final class _RolesProvider
   }
 }
 
-String _$rolesHash() => r'c10d381c1a9041d45d7197d476ce56705dd16100';
+String _$_rolesHash() => r'c10d381c1a9041d45d7197d476ce56705dd16100';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/settings_page/tab_settings_page/user_list_select_dialog.g.dart
+++ b/lib/view/settings_page/tab_settings_page/user_list_select_dialog.g.dart
@@ -36,7 +36,7 @@ final class _UsersListProvider
       MisskeyGetContextProvider.$allTransitiveDependencies0;
 
   @override
-  String debugGetCreateSourceHash() => _$usersListHash();
+  String debugGetCreateSourceHash() => _$_usersListHash();
 
   @$internal
   @override
@@ -50,7 +50,7 @@ final class _UsersListProvider
   }
 }
 
-String _$usersListHash() => r'd7fab580bf6bc18fc282743de3d482f5d1d62a49';
+String _$_usersListHash() => r'd7fab580bf6bc18fc282743de3d482f5d1d62a49';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/view/share_extension_page/share_extension_page.freezed.dart
+++ b/lib/view/share_extension_page/share_extension_page.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -76,6 +75,136 @@ as List<SharedFiles>,
 
 }
 
+
+/// Adds pattern-matching-related methods to [ShareExtensionData].
+extension ShareExtensionDataPatterns on ShareExtensionData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ShareExtensionData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ShareExtensionData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ShareExtensionData value)  $default,){
+final _that = this;
+switch (_that) {
+case _ShareExtensionData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ShareExtensionData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ShareExtensionData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<String> text,  List<SharedFiles> files)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ShareExtensionData() when $default != null:
+return $default(_that.text,_that.files);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<String> text,  List<SharedFiles> files)  $default,) {final _that = this;
+switch (_that) {
+case _ShareExtensionData():
+return $default(_that.text,_that.files);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<String> text,  List<SharedFiles> files)?  $default,) {final _that = this;
+switch (_that) {
+case _ShareExtensionData() when $default != null:
+return $default(_that.text,_that.files);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()
@@ -224,6 +353,136 @@ as int,
 
 }
 
+
+/// Adds pattern-matching-related methods to [SharedFiles].
+extension SharedFilesPatterns on SharedFiles {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SharedFiles value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SharedFiles() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SharedFiles value)  $default,){
+final _that = this;
+switch (_that) {
+case _SharedFiles():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SharedFiles value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SharedFiles() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String path,  int type)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SharedFiles() when $default != null:
+return $default(_that.path,_that.type);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String path,  int type)  $default,) {final _that = this;
+switch (_that) {
+case _SharedFiles():
+return $default(_that.path,_that.type);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String path,  int type)?  $default,) {final _that = this;
+switch (_that) {
+case _SharedFiles() when $default != null:
+return $default(_that.path,_that.type);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 @JsonSerializable()

--- a/lib/view/user_page/user_info_notifier.freezed.dart
+++ b/lib/view/user_page/user_info_notifier.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -88,6 +87,136 @@ $MetaResponseCopyWith<$Res>? get metaResponse {
 }
 }
 
+
+/// Adds pattern-matching-related methods to [UserInfo].
+extension UserInfoPatterns on UserInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserInfo value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserInfo() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserInfo value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserInfo():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserInfo value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserInfo() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String userId,  UserDetailed response,  String? remoteUserId,  UserDetailed? remoteResponse,  MetaResponse? metaResponse)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserInfo() when $default != null:
+return $default(_that.userId,_that.response,_that.remoteUserId,_that.remoteResponse,_that.metaResponse);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String userId,  UserDetailed response,  String? remoteUserId,  UserDetailed? remoteResponse,  MetaResponse? metaResponse)  $default,) {final _that = this;
+switch (_that) {
+case _UserInfo():
+return $default(_that.userId,_that.response,_that.remoteUserId,_that.remoteResponse,_that.metaResponse);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String userId,  UserDetailed response,  String? remoteUserId,  UserDetailed? remoteResponse,  MetaResponse? metaResponse)?  $default,) {final _that = this;
+switch (_that) {
+case _UserInfo() when $default != null:
+return $default(_that.userId,_that.response,_that.remoteUserId,_that.remoteResponse,_that.metaResponse);case _:
+  return null;
+
+}
+}
+
+}
 
 /// @nodoc
 

--- a/lib/view/users_list_page/users_list_detail_page.g.dart
+++ b/lib/view/users_list_page/users_list_detail_page.g.dart
@@ -23,7 +23,7 @@ final class _UsersListNotifierProvider
        );
 
   @override
-  String debugGetCreateSourceHash() => _$usersListNotifierHash();
+  String debugGetCreateSourceHash() => _$_usersListNotifierHash();
 
   @override
   String toString() {
@@ -47,7 +47,8 @@ final class _UsersListNotifierProvider
   }
 }
 
-String _$usersListNotifierHash() => r'c51fadbf7615f1343297d33391c16f5ef99d84d8';
+String _$_usersListNotifierHash() =>
+    r'c51fadbf7615f1343297d33391c16f5ef99d84d8';
 
 final class _UsersListNotifierFamily extends $Family
     with
@@ -114,7 +115,7 @@ final class _UsersListUsersProvider
        );
 
   @override
-  String debugGetCreateSourceHash() => _$usersListUsersHash();
+  String debugGetCreateSourceHash() => _$_usersListUsersHash();
 
   @override
   String toString() {
@@ -138,7 +139,7 @@ final class _UsersListUsersProvider
   }
 }
 
-String _$usersListUsersHash() => r'd4f5066da6faec88593e8f35da198edb0b3150a4';
+String _$_usersListUsersHash() => r'd4f5066da6faec88593e8f35da198edb0b3150a4';
 
 final class _UsersListUsersFamily extends $Family
     with

--- a/lib/view/users_list_page/users_list_settings_dialog.g.dart
+++ b/lib/view/users_list_page/users_list_settings_dialog.g.dart
@@ -29,7 +29,7 @@ final class _InitialSettingsProvider
       );
 
   @override
-  String debugGetCreateSourceHash() => _$initialSettingsHash();
+  String debugGetCreateSourceHash() => _$_initialSettingsHash();
 
   @$internal
   @override
@@ -51,7 +51,7 @@ final class _InitialSettingsProvider
   }
 }
 
-String _$initialSettingsHash() => r'3dec59c0d7a3e36d255b82bfd7ea8eda758e9cf3';
+String _$_initialSettingsHash() => r'3dec59c0d7a3e36d255b82bfd7ea8eda758e9cf3';
 
 @ProviderFor(_UsersListSettingsNotifier)
 const _usersListSettingsNotifierProvider =
@@ -75,7 +75,7 @@ final class _UsersListSettingsNotifierProvider
   static const $allTransitiveDependencies0 = _initialSettingsProvider;
 
   @override
-  String debugGetCreateSourceHash() => _$usersListSettingsNotifierHash();
+  String debugGetCreateSourceHash() => _$_usersListSettingsNotifierHash();
 
   @$internal
   @override
@@ -90,7 +90,7 @@ final class _UsersListSettingsNotifierProvider
   }
 }
 
-String _$usersListSettingsNotifierHash() =>
+String _$_usersListSettingsNotifierHash() =>
     r'6e354936966b2a1d0e0c4dca6d41e74ff0ccb243';
 
 abstract class _$UsersListSettingsNotifier

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,26 +181,26 @@ packages:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      sha256: "4a5d8d2c728b0f3d0245f69f921d7be90cae4c2fd5288f773088672c0893f819"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.0"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
-      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      sha256: ff0c949e323d2a1b52be73acce5b4a7b04063e61414c8ca542dbba47281630a7
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.0"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      sha256: "6322dde7a5ad92202e64df659241104a43db20ed594c41ca18de1014598d7996"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   change:
     dependency: transitive
     description:
@@ -1096,18 +1096,18 @@ packages:
     dependency: "direct main"
     description:
       name: mfm
-      sha256: cdfc10dfbb44fb3e42be68310722166d10e3f0aa51f2681b29bfffaee49605c2
+      sha256: "1e7f9e02eb7536d5bd127ba19da568262cb064ea79bf461e11257930d53c5528"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   mfm_parser:
     dependency: "direct main"
     description:
       name: mfm_parser
-      sha256: ab52b5dfb5f5ebd54d9f1d8745a596a9fb7ba0e1b13e7d66984456f199143c09
+      sha256: "733a69d14f75c8c15c5b961f2428bd42c7118bbe0b271c03666a7941435fb691"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   mime:
     dependency: "direct main"
     description:
@@ -1121,7 +1121,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "279e1e390e89182e38004363fe894e02841cb5f2"
+      resolved-ref: dbe7da3cf3ee391b1df5b2464d8357bb530d4af1
       url: "https://github.com/shiosyakeyakini-info/misskey_dart.git"
     source: git
     version: "1.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: e55636ed79578b9abca5fecf9437947798f5ef7456308b5cb85720b793eac92f
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
       url: "https://pub.dev"
     source: hosted
-    version: "82.0.0"
+    version: "85.0.0"
   aes256:
     dependency: transitive
     description:
@@ -21,18 +21,18 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "904ae5bb474d32c38fb9482e2d925d5454cda04ddd0e55d2e6826bc72f6ba8c0"
+      sha256: f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.5"
+    version: "7.6.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: ee188b6df6c85f1441497c7171c84f1392affadc0384f71089cb10a3bc508cef
+      sha256: a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.13.4"
   ansicolor:
     dependency: transitive
     description:
@@ -77,18 +77,18 @@ packages:
     dependency: "direct main"
     description:
       name: auto_route
-      sha256: b8c036fa613a98a759cf0fdcba26e62f4985dcbff01a5e760ab411e8554bbaf0
+      sha256: c820e918863a03544aac68eaf61e17c8a6126b663d7cad24a8fd3657a1e6be61
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0+1"
+    version: "10.1.2"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      sha256: "2a5b5bf9c55d4a2098931037dac90921a4663808aed494bb4f134d82d46cb8ec"
+      sha256: ed4b65e85b4b2b00b06ef1e44c8623985c52c32d05d72147e3201257aa70a115
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.3"
+    version: "10.2.4"
   badges:
     dependency: "direct main"
     description:
@@ -117,18 +117,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: "6439a9c71a4e6eca8d9490c1b380a25b02675aa688137dfbe66d2062884a23ac"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
@@ -141,26 +141,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      sha256: "2b21a125d66a86b9511cc3fb6c668c42e9a1185083922bf60e46d483a81a9712"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: fd3c09f4bbff7fa6e8d8ef688a0b2e8a6384e6483a25af0dac75fef362bcfe6f
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.7.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      sha256: ab27e46c8aa233e610cf6084ee6d8a22c6f873a0a9929241d8855b7a72978ae7
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.2"
+    version: "9.3.0"
   built_collection:
     dependency: transitive
     description:
@@ -173,34 +173,34 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      sha256: ba95c961bafcd8686d1cf63be864eb59447e795e124d98d6a27d91fcd13602fb
       url: "https://pub.dev"
     source: hosted
-    version: "8.10.1"
+    version: "8.11.1"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: "4a5d8d2c728b0f3d0245f69f921d7be90cae4c2fd5288f773088672c0893f819"
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.1"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
-      sha256: ff0c949e323d2a1b52be73acce5b4a7b04063e61414c8ca542dbba47281630a7
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.1.1"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: "6322dde7a5ad92202e64df659241104a43db20ed594c41ca18de1014598d7996"
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   change:
     dependency: transitive
     description:
@@ -229,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: checks
-      sha256: aad431b45a8ae2fa26db8c22e385b9cdec73f72986a1d9d9f2017f4c39ecf5c9
+      sha256: "016871c84732c1ac9856b8940236d5a5802ba638b3bd3e0ea7027b51a35f7aa7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   ci:
     dependency: transitive
     description:
@@ -317,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.1"
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -349,42 +349,42 @@ packages:
     dependency: transitive
     description:
       name: custom_lint
-      sha256: "409c485fd14f544af1da965d5a0d160ee57cd58b63eeaa7280a4f28cf5bda7f1"
+      sha256: "78085fbe842de7c5bef92de811ca81536968dbcbbcdac5c316711add2d15e796"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "0.8.0"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: "107e0a43606138015777590ee8ce32f26ba7415c25b722ff0908a6f5d7a4c228"
+      sha256: cc5532d5733d4eccfccaaec6070a1926e9f21e613d93ad0927fad020b95c9e52
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "0.8.0"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be"
+      sha256: cc4684d22ca05bf0a4a51127e19a8aea576b42079ed2bc9e956f11aaebe35dd1
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "0.8.0"
   custom_lint_visitor:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: cba5b6d7a6217312472bf4468cdf68c949488aed7ffb0eab792cd0b6c435054d
+      sha256: "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+7.4.5"
+    version: "1.0.0+7.7.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   dbus:
     dependency: transitive
     description:
@@ -413,10 +413,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -429,10 +429,10 @@ packages:
     dependency: "direct main"
     description:
       name: dotted_border
-      sha256: "878eb25e76cac65b822ca920ff91f2c414c0993bc596fa055fec0d005f527b2d"
+      sha256: "99b091ec6891ba0c5331fdc2b502993c7c108f898995739a73c6845d71dad70c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   encrypt:
     dependency: transitive
     description:
@@ -477,10 +477,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ef9908739bdd9c476353d6adff72e88fd00c625f5b959ae23f7567bd5137db0a
+      sha256: e7e16c9d15c36330b94ca0e2ad8cb61f93cd5282d0158c09805aed13b5452f22
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.3.2"
   fixnum:
     dependency: transitive
     description:
@@ -531,10 +531,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_hooks
-      sha256: b772e710d16d7a20c0740c4f855095026b31c7eb5ba3ab67d2bd52021cd9461d
+      sha256: "8ae1f090e5f4ef5cfa6670ce1ab5dddadd33f3533a7f9ba19d9f958aa2a89f42"
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.2"
+    version: "0.21.3+1"
   flutter_html:
     dependency: "direct main"
     description:
@@ -624,18 +624,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      sha256: "6382ce712ff69b0f719640ce957559dde459e55ecd433c767e06d139ddf16cab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.28"
+    version: "2.0.29"
   flutter_riverpod:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: cab35f90d35d556374dd63754984e0558722894400e3d1f66fb7b9a3052e971e
+      sha256: "56c3cc75d04c34fc824ce1d52ec9076c431e3c47ed55fd8cbf9756ca6d50479e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.16"
+    version: "3.0.0-dev.17"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -688,10 +688,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
+      sha256: de82e6bf958cec7190fbc1c5298282c851228e35ae2b14e2b103e7f777818c64
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.0.13"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -701,10 +701,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_twemoji
-      sha256: "82d88c8df300f133dcc02a97829537b0861527d6d2f3315ed20c7b735b7b30ff"
+      sha256: "366cdf5f0406f7f477bbcdf45b23aa7d671a1f939bde9b115280b0981669e41f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -714,18 +714,18 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "6022db4c7bfa626841b2a10f34dd1e1b68e8f8f9650db6112dcdeeca45ca793c"
+      sha256: da32f8ba8cfcd4ec71d9decc8cbf28bd2c31b5283d9887eb51eb4a0659d8110c
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.2.0"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -746,10 +746,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      sha256: df9763500dadba0155373e9cb44e202ce21bd9ed5de6bdbd05c5854e86839cb8
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "6.3.0"
   graphs:
     dependency: transitive
     description:
@@ -770,10 +770,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: f66daa922c607734af491260c1516e4a5b5f496756b4e4d0fb1aa1b529705dd7
+      sha256: "16e514994ac265fcbd082966b027ebbab70f028d0d7003191febfad3a66b3300"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.16"
+    version: "3.0.0-dev.17"
   hotreloader:
     dependency: transitive
     description:
@@ -794,10 +794,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -910,10 +910,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: ce2cf974ccdee13be2a510832d7fba0b94b364e0b0395dee42abaa51b855be27
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.10.0"
   kana_kit:
     dependency: "direct main"
     description:
@@ -950,10 +950,10 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: dca2165cfe681c69ae903a0880cab90ee93d730777605a0f44c9dd08cec7e1b9
+      sha256: "3d3a04c9dda8ced6b2a48d23aaf98ef5aa32f68f9c62da1b6c6d45bf03aa8164"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0-alpha.13"
+    version: "0.1.1"
   lints:
     dependency: transitive
     description:
@@ -1121,7 +1121,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: dbe7da3cf3ee391b1df5b2464d8357bb530d4af1
+      resolved-ref: e9d396e8c7e8d9091e3aecdd8b004745b852428c
       url: "https://github.com/shiosyakeyakini-info/misskey_dart.git"
     source: git
     version: "1.0.0"
@@ -1129,10 +1129,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "4546eac99e8967ea91bae633d2ca7698181d008e95fa4627330cf903d573277a"
+      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.6"
+    version: "5.5.0"
   node_preamble:
     dependency: transitive
     description:
@@ -1161,18 +1161,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "8.3.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:
@@ -1181,14 +1181,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  path_drawing:
-    dependency: transitive
-    description:
-      name: path_drawing
-      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
@@ -1217,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1257,10 +1249,10 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "2d070d8684b68efb580a5997eb62f675e8a885ef0be6e754fb9ef489c177470f"
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0+1"
+    version: "12.0.1"
   permission_handler_android:
     dependency: transitive
     description:
@@ -1305,10 +1297,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -1402,42 +1394,42 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "0aa816ffc79f9762de33ee771f5bedd0bbc8a3dd7960f4893cfde1d18d628f31"
+      sha256: "82507cfb140c044f12e929c054dcdfc478359f473bcd2976af26908318e91b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.16"
+    version: "3.0.0-dev.17"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "1f317be230a2064e1366432204933277ce0978cde860d6f5f39478fc054439ad"
+      sha256: ce9dfa8dccc5029535a09d1582681c894c8853613aaca5869d372348cf432114
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.3"
+    version: "1.0.0-dev.4"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: ecb1da536670eedf6006a7b144c0eb27318943b9c9463815d6297123a629e683
+      sha256: d4449ce911fe1e211a2f6fbc110c907859b01419f720f604791fe8583a06620e
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.16"
+    version: "3.0.0-dev.17"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "0c7939c2c8ca9425f6075d871d6fc61fe25591d0e82ec46d70c158f4ad2f0317"
+      sha256: "16569af989111e5087da6cfd71660eb0dbcfb87e5395cfa5181ce089ff4f7729"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.16"
+    version: "3.0.0-dev.17"
   riverpod_lint:
     dependency: "direct dev"
     description:
       name: riverpod_lint
-      sha256: "153e751ee2977f91970ada7069387b5fcd91541b16682ebda6a82bc86b6c3b19"
+      sha256: f9403db89a399bbdf50a56883cf0eaa42b69e3fef005cd967ff5072d7e90b838
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.16"
+    version: "3.0.0-dev.17"
   rxdart:
     dependency: transitive
     description:
@@ -1506,18 +1498,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: b2961506569e28948d75ec346c28775bb111986bb69dc6a20754a457e3d97fa0
+      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "11.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "1032d392bc5d2095a77447a805aa3f804d2ae6a4d5eef5e6ebb3bd94c1bc19ef"
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   shared_preference_app_group:
     dependency: "direct main"
     description:
@@ -1538,10 +1530,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      sha256: "5bcf0772a761b04f8c6bf814721713de6f3e5d9d89caf8d3fe031b02a342379e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.4.11"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1631,18 +1623,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.1.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      sha256: a447acb083d3a5ef17f983dd36201aeea33fedadb3228fa831f2f0c92f0f3aca
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5"
+    version: "1.3.7"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1695,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.5.6"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1839,26 +1831,26 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      sha256: "0aedad096a85b49df2e4725fa32118f9fa580f3b14af7a2d2221896a02cd5656"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.16"
+    version: "6.3.17"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.3.4"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1871,10 +1863,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1919,18 +1911,18 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      sha256: c86987475f162fadff579e7320c7ddda04cd2fdeffbe1129227a85d9ac9e03da
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.13"
+    version: "1.1.11+1"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "557a315b7d2a6dbb0aaaff84d857967ce6bdc96a63dc6ee2a57ce5a6ee5d3331"
+      sha256: "12faff3f73b1741a36ca7e31b292ddeb629af819ca9efe9953b70bd63fc8cd81"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.17"
+    version: "1.1.11+1"
   vector_math:
     dependency: transitive
     description:
@@ -2039,26 +2031,26 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_android
-      sha256: f6e6afef6e234801da77170f7a1847ded8450778caf2fe13979d140484be3678
+      sha256: "0a42444056b24ed832bdf3442d65c5194f6416f7e782152384944053c2ecc9a3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.10.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: f0dc2dc3a2b1e3a6abdd6801b9355ebfeb3b8f6cde6b9dc7c9235909c4a1f147
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.14.0"
   webview_flutter_wkwebview:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: a3d461fe3467014e05f3ac4962e5fdde2a4bf44c561cb53e9ae5c586600fdbc3
+      sha256: fb46db8216131a3e55bcf44040ca808423539bc6732e7ed34fb6d8044e3d512f
       url: "https://pub.dev"
     source: hosted
-    version: "3.22.0"
+    version: "3.23.0"
   win32:
     dependency: transitive
     description:
@@ -2079,10 +2071,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:
@@ -2095,10 +2087,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   xxh3:
     dependency: transitive
     description:
@@ -2117,4 +2109,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     git: 
       url: https://github.com/shiosyakeyakini-info/misskey_dart.git
       ref: master
-  mfm: ^1.0.8
+  mfm: ^1.0.9
   tuple: ^2.0.1
   path_provider: ^2.0.14
   dio: ^5.1.1

--- a/test/test_util/mock.mocks.dart
+++ b/test/test_util/mock.mocks.dart
@@ -2396,9 +2396,9 @@ class MockMisskeyChannels extends _i1.Mock implements _i3.MisskeyChannels {
 /// See the documentation for Mockito's code generation for more information.
 class MockMisskeyClips extends _i1.Mock implements _i3.MisskeyClips {
   @override
-  _i17.Future<Iterable<_i3.Clip>> list() =>
+  _i17.Future<Iterable<_i3.Clip>> list(_i3.ClipsListRequest? request) =>
       (super.noSuchMethod(
-            Invocation.method(#list, []),
+            Invocation.method(#list, [request]),
             returnValue: _i17.Future<Iterable<_i3.Clip>>.value(<_i3.Clip>[]),
             returnValueForMissingStub: _i17.Future<Iterable<_i3.Clip>>.value(
               <_i3.Clip>[],

--- a/test/view/clip_list_page/clip_list_page_test.dart
+++ b/test/view/clip_list_page/clip_list_page_test.dart
@@ -14,7 +14,7 @@ void main() {
       final clip = MockMisskeyClips();
       final misskey = MockMisskey();
       when(misskey.clips).thenReturn(clip);
-      when(clip.list()).thenAnswer((_) async => [TestData.clip]);
+      when(clip.list(any)).thenAnswer((_) async => [TestData.clip]);
 
       await tester.pumpWidget(
         ProviderScope(


### PR DESCRIPTION
## Summary
- mfmパッケージを1.0.8から1.0.9にアップデート
- misskey_dart APIの変更に対応してClipListPageをPushableListViewに移行
- clips/list APIのページネーション対応（Misskey PR #16434）

## Changes
- `pubspec.yaml`: mfm ^1.0.8 → ^1.0.9
- `ClipsNotifier`: ページネーション対応のloadClips実装
- `ClipListPage`: ListView.builderからPushableListViewに変更
- テストモックの更新とCIフォーマット修正

## Test plan
- [ ] クリップ一覧の表示確認
- [ ] クリップの作成・削除動作確認
- [ ] ページネーション動作確認
- [ ] CIテスト通過確認

🤖 Generated with [Claude Code](https://claude.ai/code)