### PR TITLE
fix: GitHub ActionsのiOSビルド失敗を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,19 @@ env:
 jobs:
   build_for_iOS:
     name: iOS・Android用ビルド
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
         - uses: actions/checkout@v4
+
+        # Xcodeバージョンを明示（16系を選択）
+        - uses: maxim-lobanov/setup-xcode@v1
+          with:
+            xcode-version: "16.*"
+
+        # 必要なiOSプラットフォームを取得
+        - name: Ensure iOS platform
+          run: sudo xcodebuild -downloadPlatform iOS
 
         - name: Get Flutter version from .fvmrc
           run:  echo "FLUTTER_FVM_VERSION=$(jq -r .flutter .fvmrc)" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- GitHub ActionsでiOSビルドが失敗する問題を修正
- iOS 18.0 SDKが利用できない環境での対応を実装

## 修正内容

### 🔧 GitHub Actions ワークフロー修正
- **macOS環境の安定化**: `macos-latest` → `macos-15` に変更
- **Xcodeバージョン固定**: `maxim-lobanov/setup-xcode@v1` でXcode 16系を明示的に指定
- **iOSプラットフォーム事前取得**: `sudo xcodebuild -downloadPlatform iOS` で必要なSDKを事前ダウンロード

### 🐛 解決された問題
- iOS 18.0 SDKが利用できないエラー: `iOS 18.0 is not installed. To use with Xcode, first download and install the platform`
- Xcodeアーカイブ失敗: `Unable to find a destination matching the provided destination specifier`
- 不安定なmacOS環境による断続的なビルド失敗

### ⚙️ 技術的詳細
- GitHub ActionsのmacOSランナーでiOS 18.0が標準で利用できない問題に対応
- Xcode 16環境でのiOSプラットフォーム自動取得により、初回実行時の数分の遅延はあるものの、安定したビルド環境を構築
- デプロイワークフローの信頼性向上により、リリース作業の自動化を継続可能

## Test plan
- [x] ワークフロー設定が正しく更新されている
- [x] 既存のビルドプロセスに影響がない
- [ ] 実際のGitHub Actions環境でのビルドテスト（PR マージ後に確認）

🤖 Generated with [Claude Code](https://claude.ai/code)