### PR TITLE
fix: Update server preset test endpoints to match servers.json

### DIFF
--- a/test/model/server_preset_test.dart
+++ b/test/model/server_preset_test.dart
@@ -138,7 +138,7 @@ void main() {
       final homePreset = taiChanPresets.firstWhere(
         (preset) => preset.name == "ホームタイムライン（ローカルのみ）",
       );
-      expect(homePreset.endpoint, "api/notes/timeline");
+      expect(homePreset.endpoint, "notes/timeline");
       expect(homePreset.websocketChannelName, "localTimeline");
       expect(homePreset.parameters, {"onlyLocal": true});
 
@@ -146,7 +146,7 @@ void main() {
       final socialPreset = taiChanPresets.firstWhere(
         (preset) => preset.name == "ソーシャルタイムライン（ローカルのみ）",
       );
-      expect(socialPreset.endpoint, "api/notes/hybrid-timeline");
+      expect(socialPreset.endpoint, "notes/hybrid-timeline");
       expect(socialPreset.websocketChannelName, "hybridTimeline");
       expect(socialPreset.parameters, {"onlyLocal": true});
     });


### PR DESCRIPTION
## 概要
origin/developブランチでテストが失敗していた問題を修正します。

## 問題
- `test/model/server_preset_test.dart`の`TimelinePreset should validate servers.json specific data`テストが失敗
- テストが期待していたエンドポイント: `api/notes/timeline`
- 実際の`servers.json`のエンドポイント: `notes/timeline`

## 修正内容
- `test/model/server_preset_test.dart`のテスト期待値を実際の`servers.json`データに合わせて修正
- ホームタイムラインのエンドポイント期待値を`api/notes/timeline` → `notes/timeline`に変更
- ソーシャルタイムラインのエンドポイント期待値を`api/notes/hybrid-timeline` → `notes/hybrid-timeline`に変更

## テスト結果
- 全382テストが正常にパス ✅
- origin/developブランチのテスト問題は完全に解決

## チェックリスト
- [x] テストが正常にパス
- [x] コードフォーマットが適用済み
- [x] 実際のデータ構造と一貫性を保持

🤖 Generated with [Claude Code](https://claude.ai/code)