### PR TITLE
クリップがソートされているか確認する

### DIFF
--- a/lib/view/clip_list_page/clip_list_page.dart
+++ b/lib/view/clip_list_page/clip_list_page.dart
@@ -1,4 +1,5 @@
 import "package:auto_route/auto_route.dart";
+import "package:collection/collection.dart";
 import "package:flutter/material.dart" hide Clip;
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:miria/hooks/use_async.dart";
@@ -49,6 +50,13 @@ class ClipListPage extends ConsumerWidget implements AutoRouteWrapper {
           return await ref.read(clipsNotifierProvider.future);
         },
         nextFuture: (lastItem, _) async {
+          final clips = await ref.read(clipsNotifierProvider.future);
+          // Misskey 2025.8.0以前では `clips/list` のページネーションが実装されておらず、
+          // クリップがソートされずに返ってくる。そのような場合は次のページを読み込まない。
+          final isSorted = clips.isSorted((a, b) => b.id.compareTo(a.id));
+          if (!isSorted) {
+            return [];
+          }
           return await ref
               .read(clipsNotifierProvider.notifier)
               .loadClips(untilId: lastItem.id);

--- a/lib/view/clip_modal_sheet/clip_modal_sheet.dart
+++ b/lib/view/clip_modal_sheet/clip_modal_sheet.dart
@@ -1,4 +1,5 @@
 import "package:auto_route/auto_route.dart";
+import "package:collection/collection.dart";
 import "package:flutter/material.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 import "package:hooks_riverpod/experimental/mutation.dart";
@@ -129,7 +130,18 @@ class ClipModalSheet extends HookConsumerWidget implements AutoRouteWrapper {
     final state = ref.watch(_clipModalSheetNotifierProvider(noteId));
     final notifier = _clipModalSheetNotifierProvider(noteId).notifier;
     final loadClips = ref.watch(loadClipsMutation);
-    final isFinalPage = useState(false);
+    final isFinalPage = useState<bool?>(null);
+
+    // ソートされていない場合、ページネーションに対応していないとみなす。
+    ref.listen(_clipModalSheetNotifierProvider(noteId), (_, next) {
+      if (isFinalPage.value == null) {
+        if (next case AsyncData(:final value)) {
+          isFinalPage.value =
+              value.isEmpty ||
+              !value.isSorted((a, b) => b.$1.id.compareTo(a.$1.id));
+        }
+      }
+    });
 
     final create = useAsync(() async {
       final settings = await context.pushRoute<ClipSettings>(
@@ -161,7 +173,7 @@ class ClipModalSheet extends HookConsumerWidget implements AutoRouteWrapper {
               subtitle: Text(clip.description ?? ""),
             );
           } else if (index == value.length) {
-            if (isFinalPage.value) {
+            if (isFinalPage.value ?? false) {
               return SizedBox.shrink();
             }
 


### PR DESCRIPTION
#824 では `loadClips` で実際のレスポンスから `untilId` よりも新しいものを取り除いたものを返すようにすることで、ページネーションが実装されていないサーバーも同じように扱えるようにしました
しかし、過去のバージョンでは `clips/list` のレスポンスの順序が保証されていないため、最後のクリップが最も古いクリップではないことが起こります
この場合、読み込みを続けると一部のクリップが繰り返し追加されてしまいます

この問題を修正するため、ページネーションを実行する前にそれまでに取得したクリップがソートされているか確認するようにしました
ソートされていない場合は2回目の呼び出しを行いません