### PR TITLE
絵文字パレットを開く条件を追加

### DIFF
--- a/lib/view/several_account_settings_page/reaction_deck_page/reaction_deck_page.dart
+++ b/lib/view/several_account_settings_page/reaction_deck_page/reaction_deck_page.dart
@@ -169,7 +169,9 @@ class ReactionDeckPageState extends ConsumerState<ReactionDeckPage> {
     final domain = endpoints.contains("i/registry/scopes-with-domain")
         ? "@"
         : "system";
-    final useEmojiPalette = endpoints.contains("chat/history");
+    final useEmojiPalette =
+        endpoints.contains("chat/history") ||
+        !endpoints.contains("i/read-all-unread-notes");
     if (!context.mounted) return;
     final emojiNames = await showDialog<List<String>>(
       context: context,


### PR DESCRIPTION
next.misskey.ioはMisskey 2025.4.1をベースにしているため #728 のレジストリの変更が起こります
#729 では `chat/history` が存在するかどうかで2025.4.0以降かどうか判定していましたが、next.misskey.ioではチャット系のエンドポイントをコメントアウトする形でチャット機能が無効化されています
そのため、リアクションの一括追加時にレジストリを開く挙動になっています

このPRでは `i/read-all-unread-notes` が存在しないことを2025.4.0以降と判定する条件に加えました
このエンドポイントはかなり昔から存在していましたが2025.4.0で削除されました

エンドポイントの増減でバージョンを推定する方法で今回使えるものはチャット関連のものと `i/read-all-unread-notes` しかありませんでした
https://github.com/misskey-dev/misskey/compare/2025.3.1...2025.4.0#diff-6f3c4d0fd38f7935afad575df2b07a1bc86d276adc9c92b3a0ca42410c03cb4e