### PR TITLE
refactor: Analyze除外対象パスの修正

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -51,8 +51,8 @@ linter:
 
 analyzer:
   exclude:
-    - /**/*.freezed.dart
-    - /**/*.g.dart
+    - "**/*.freezed.dart"
+    - "**/*.g.dart"
   plugins:
     - custom_lint
   language:


### PR DESCRIPTION
「なぜWindows環境で`*.freezed.dart`と`*.g.dart`が分析対象になっているんだ？」と思っていたら、システムのルートまで対象に含まれていそうなexcludeが設定されていました。
開発環境のパフォーマンスに大きく影響するため修正する提案です。

#850 にこの修正が含まれています。