### PR TITLE
Misskey.ioの次元タイムラインに対応したタブテンプレートを追加

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -12,6 +12,13 @@
     ], 
     "particularTimelinePresets": [
         {
+            "host": "misskey.io",
+            "name": "ローカルタイムライン（1次元）",
+            "endpoint": "notes/local-timeline",
+            "websocketChannelName": "localTimeline",
+            "parameters": "{\"dimension\": 1}"
+        },
+        {
             "host": "mi.taichan.site",
             "name": "ホームタイムライン（ローカルのみ）",
             "endpoint": "notes/timeline",


### PR DESCRIPTION
Misskey.ioの次元タイムラインに対応したサーバー独自タイムラインタブテンプレートを追加する提案です。
ローカルタイムラインの1次元を基本としています。