### PR TITLE
chore(deps): 各パッケージのバージョンアップ

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,34 +117,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -301,18 +301,18 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -341,18 +341,18 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.14"
+    version: "0.7.13"
   device_info_plus:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65"
+      sha256: "0891702f96b2e465fe567b7ec448380e6b1c14f60af552a8536d9f583b6b8442"
       url: "https://pub.dev"
     source: hosted
-    version: "13.1.0"
+    version: "13.2.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -365,18 +365,18 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      sha256: ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.2"
+    version: "5.10.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      sha256: dd58dc3861eb36edb13b217efc006a1c21e5bbc341de8c229b85634fa5e362e4
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   dotted_border:
     dependency: "direct main"
     description:
@@ -389,10 +389,10 @@ packages:
     dependency: transitive
     description:
       name: equatable
-      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -429,10 +429,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: fc83774ce5bd7ce08168333b5e53dbe9090ec04eb21e7aa7cd7bac921032c934
+      sha256: fdc6a37f715d19f35b131decf1ce39242eeed5ddae18c0818c3eccb731ab76be
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0-beta.5"
+    version: "12.0.0-beta.7"
   fixnum:
     dependency: transitive
     description:
@@ -499,50 +499,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_image_compress
-      sha256: "51d23be39efc2185e72e290042a0da41aed70b14ef97db362a6b5368d0523b27"
+      sha256: e7c48e0832f52ae65e775bf0d2324447a1781ed6d7e55a6c4136046ad44f2f22
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   flutter_image_compress_common:
     dependency: transitive
     description:
       name: flutter_image_compress_common
-      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
+      sha256: "10520a2d4bade23d31ba5a4b9f56fa7d11b6a62f11fe3576106c1867cc10dcf6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.1.0"
   flutter_image_compress_macos:
     dependency: transitive
     description:
       name: flutter_image_compress_macos
-      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
+      sha256: "0d2a842d2e544828fb32bda16dcfccb3149107df568898a4936d78232e486847"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   flutter_image_compress_ohos:
     dependency: transitive
     description:
       name: flutter_image_compress_ohos
-      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      sha256: "1491bb7bcfdf59e3b127c263c116cfbf8ed3afade6e7fa691d9622e838ed7e48"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.3"
+    version: "0.0.3+1"
   flutter_image_compress_platform_interface:
     dependency: transitive
     description:
       name: flutter_image_compress_platform_interface
-      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      sha256: bbefb7967bda565004fdabdb3300dcbfb40c7ef8402675d23206e5bddc358178
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   flutter_image_compress_web:
     dependency: transitive
     description:
       name: flutter_image_compress_web
-      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
+      sha256: "91cc58e091a1e09c7683d216d579e2b964119a8527fc43b64dfdb00f1acc94ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.5+1"
   flutter_image_gallery_saver:
     dependency: "direct main"
     description:
@@ -698,10 +698,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
+      sha256: d3f251381df389f7418d4dff416bd27c0a23138df22969aafd28c4a4b1bb3cd6
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.0"
   graphs:
     dependency: transitive
     description:
@@ -778,10 +778,10 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.1"
   image_editor:
     dependency: "direct main"
     description:
@@ -1126,10 +1126,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1158,10 +1158,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -1182,18 +1182,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -1230,10 +1230,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
+      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.9"
+    version: "9.4.10"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1408,50 +1408,50 @@ packages:
     dependency: transitive
     description:
       name: safe_local_storage
-      sha256: "287ea1f667c0b93cdc127dccc707158e2d81ee59fba0459c31a0c7da4d09c755"
+      sha256: "7483b3d5e8976f0bd263647c03b96131ee8e43f48b56fa8a8ec459e8515d74b0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   screen_retriever:
     dependency: transitive
     description:
       name: screen_retriever
-      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      sha256: ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_linux:
     dependency: transitive
     description:
       name: screen_retriever_linux
-      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      sha256: "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_macos:
     dependency: transitive
     description:
       name: screen_retriever_macos
-      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      sha256: a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_platform_interface:
     dependency: transitive
     description:
       name: screen_retriever_platform_interface
-      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      sha256: "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_windows:
     dependency: transitive
     description:
       name: screen_retriever_windows
-      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      sha256: dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   scrollable_positioned_list:
     dependency: "direct main"
     description:
@@ -1464,10 +1464,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0
+      sha256: "02180b01c1237b9706b663d9402b2cf2402b3407f48cce99cc19e3200f095b8a"
       url: "https://pub.dev"
     source: hosted
-    version: "13.1.0"
+    version: "13.2.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1496,10 +1496,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.25"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1645,18 +1645,18 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: cce558075afe2a83f3fd7fc123acd6b090683e4f23910d44fbb31ecd7800b014
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.9"
+    version: "2.5.11"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "164a5d73ab87a134566057219988bafde837029a64264e61f1f04376ef3cfcd2"
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.3+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
@@ -1845,10 +1845,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_graphics:
     dependency: transitive
     description:
@@ -1869,10 +1869,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:
@@ -1965,10 +1965,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
+      sha256: d53e1ccf5516f25017e3c9d44c39034db352d20fa34fe200674270242c2c5111
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.1"
+    version: "4.14.1"
   webview_flutter_android:
     dependency: "direct main"
     description:
@@ -2013,10 +2013,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      sha256: "05c231fd7b23d2380f14c5cc10b7b93d60d4fa4a2fb4e0f032de27e44b5560e9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -2029,10 +2029,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   xxh3:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ dependencies:
       ref: master
   mfm: ^1.0.9
   tuple: ^2.0.1
-  path_provider: ^2.0.14
-  dio: ^5.1.1
+  path_provider: ^2.1.6
+  dio: ^5.10.0
   path: ^1.8.2
   auto_route: ^11.1.0
   freezed_annotation: ^3.0.0
@@ -35,10 +35,10 @@ dependencies:
   badges: ^3.1.1
   bubble: ^1.2.1
   flutter_secure_storage: ^10.0.0
-  google_fonts: ^8.0.1
-  uuid: ^4.4.0
-  file_picker: ^12.0.0-beta.5
-  package_info_plus: ^10.1.0
+  google_fonts: ^8.2.0
+  uuid: ^4.6.0
+  file_picker: ^12.0.0-beta.7
+  package_info_plus: ^10.2.1
   reorderables: ^0.6.0
   confetti: ^0.8.0
   flutter_highlighting: ^0.9.0+11.8.0
@@ -51,7 +51,7 @@ dependencies:
     git:
       url: https://github.com/KasemJaffer/receive_sharing_intent
       ref: 2cea396843cd3ab1b5ec4334be4233864637874e
-  share_plus: ^13.1.0
+  share_plus: ^13.2.1
   mfm_parser: ^1.0.7
   flutter_svg: ^2.0.6
   image_editor: ^1.3.0
@@ -59,18 +59,18 @@ dependencies:
   file: ^7.0.0
   flutter_image_gallery_saver: ^2.0.0
   permission_handler: ^12.0.0+1
-  device_info_plus: ^13.1.0
+  device_info_plus: ^13.2.0
   colorfilter_generator: ^0.0.8
   matrix2d: ^1.0.4
-  flutter_image_compress: ^2.0.4
-  webview_flutter: ^4.3.0
+  flutter_image_compress: ^2.5.0
+  webview_flutter: ^4.14.1
   webview_flutter_android: ^4.7.0
   webview_flutter_wkwebview: ^3.9.0
   media_kit: ^1.1.11
   media_kit_video: ^2.0.1
   media_kit_libs_video: ^1.0.5
   flutter_colorpicker: ^1.1.0
-  window_manager: ^0.5.0
+  window_manager: ^0.5.2
   shared_preference_app_group: ^2.1.0
   stack_trace: ^1.11.1
   flutter_cache_manager: ^3.4.1
@@ -79,7 +79,7 @@ dependencies:
   hooks_riverpod: ^3.0.0-dev.16
   flutter_hooks: ^0.21.2
   punycode: ^1.0.0
-  image: ^4.3.0
+  image: ^4.9.1
   flutter_twemoji: ^1.0.1
   mime: ^2.0.0
 


### PR DESCRIPTION
## 概要

`miria_v4` 起点で各パッケージのバージョンアップを実施しました。差分は `pubspec.yaml` / `pubspec.lock` のみです。

## 更新したパッケージ

| パッケージ | before | after |
| --- | --- | --- |
| device_info_plus | 13.1.0 | 13.2.0 |
| dio | 5.9.2 | 5.10.0 |
| file_picker | 12.0.0-beta.5 | 12.0.0-beta.7 |
| flutter_image_compress | 2.4.0 | 2.5.0 |
| google_fonts | 8.1.0 | 8.2.0 |
| image | 4.8.0 | 4.9.1 |
| package_info_plus | 10.1.0 | 10.2.1 |
| path_provider | 2.1.5 | 2.1.6 |
| share_plus | 13.1.0 | 13.2.1 |
| uuid | 4.5.3 | 4.6.0 |
| webview_flutter | 4.13.1 | 4.14.1 |
| window_manager | 0.5.1 | 0.5.2 |

このほか推移的依存も `pub upgrade` により多数更新（xml 6.6.1 → 7.0.1 など）。
直接依存は制約の下限を解決済みバージョンへ引き上げています。

## analyzer 競合の分析と各パッケージの上限

codegen 系が軒並み上げられないのは個別の事情ではなく、**analyzer のバージョン帯が単一の解に絞られている**ためです。制約を整理した結果、**現在の解決結果が既に到達可能な最大値**であることを確認しました。

### 前提1: 上限は analyzer 13.0.0

Flutter 3.44.6 の `packages/flutter/pubspec.yaml` が `meta: 1.18.0` を**完全固定**しています。
analyzer 13.1.0 以降は `meta ^1.18.3` を要求するため、**analyzer ≤ 13.0.0** が SDK 由来のハード上限です。

### 前提2: analyzer 帯ごとの成立可否

各パッケージが要求する analyzer 帯:

| パッケージ | 要求する analyzer |
| --- | --- |
| riverpod_generator 4.0.3 / 4.0.4 | `^9` / `^12` （**10・11・13 に対応版が無い**） |
| auto_route_generator 10.4.0 | `>=8 <10` |
| auto_route_generator 10.5.0 | dart_style `^3.1.5` 経由で `>=10 <12` ∪ `>=13 <15` |
| auto_route_generator 10.6.0 | lean_builder `^1.2.0` 経由で `^13` |
| mockito 5.6.5+ | `^13` |
| json_serializable 6.13.1+ | `>=10 <13` |
| freezed 3.2.6-dev.1+ | `>=12 <13` |
| build_runner 2.15.2 | `>=13.3.0` |

これを帯ごとに評価すると:

| analyzer | riverpod_generator | auto_route_generator | 判定 |
| --- | --- | --- | --- |
| **9.0.0** | 4.0.3 ✅ | 10.4.0 ✅ | ✅ **全て成立（現在地）** |
| 10 / 11 | ❌ 対応版なし | 10.5.0 ✅ | ❌ |
| 12 | 4.0.4 ✅ | ❌ どの版も不適合 | ❌ |
| 13.0.0 | ❌ 対応版なし | 10.6.0 ✅ | ❌ |

つまり **riverpod_generator の `^9` / `^12` という飛び地** と **auto_route_generator（auto_route ^11 系）の帯** が交わるのは analyzer 9 のみです。

### 導出された各パッケージの最大値

analyzer 9.0.0 帯における上限は以下の通りで、**いずれも現在の解決結果と一致**します（`dart pub add --dry-run` で個別に実測確認済み）。

| パッケージ | 現在 = 最大値 | 最新 | 上限の理由 |
| --- | --- | --- | --- |
| analyzer | **9.0.0** | 14.1.0 | 9.x は 9.0.0 のみ |
| riverpod_generator | **4.0.3** | 4.0.4 | 4.0.4 は analyzer `^12` |
| riverpod_lint | **3.1.3** | 3.1.4 | 3.1.4 は analyzer `^12` |
| riverpod_annotation | **4.0.2** | 4.0.3 | riverpod_generator 4.0.3 が 4.0.2 を完全固定 |
| hooks_riverpod | **3.3.1** | 3.3.2 | riverpod_annotation 4.0.2 が riverpod 3.2.1 を完全固定 |
| auto_route_generator | **10.4.0** | 10.6.0 | 10.5.0 は dart_style 経由で analyzer `>=10` |
| mockito | **5.6.4** | 5.7.0 | 5.6.5+ は analyzer `^13` |
| json_serializable | **6.13.0** | 6.14.0 | 6.13.1+ は analyzer `>=10` |
| json_annotation | **4.11.0** | 4.12.0 | json_serializable 6.13.0 が `>=4.11.0 <4.12.0` を要求 |
| freezed | **3.2.5** | 3.2.6-dev.1 | 3.2.6-dev.1 は analyzer `>=12` |
| build_runner | **2.15.1** | 2.15.2 | 2.15.2 は analyzer `>=13.3.0` → **meta 固定により Flutter 側の更新が必要** |
| intl | **0.20.2** | 0.20.3 | `flutter_localizations` が 0.20.2 を完全固定 |

### 解消の条件

- 上表の build_runner / intl 以外は、**riverpod_generator が analyzer 13 対応版を出せば一斉に解消**します（auto_route_generator 10.6.0・mockito 5.7.0・json_serializable 6.14.0・json_annotation 4.12.0・freezed 4.0.0-dev が同時に開く）。
- build_runner 2.15.2 と intl 0.20.3 は Flutter SDK 側の `meta` / `intl` 固定が緩むまで不可で、パッケージ側の更新では解決しません。

## 動作確認

- `fvm flutter pub run build_runner build` … 生成物に差分なし
- `fvm dart analyze` … error 0 件
- `fvm dart format .` … 差分なし
- `fvm flutter test` … **382 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUFQEPsP4Qj9hqbyyQPddN