### PR TITLE
fix: ユーザーメニューからミュート・ブロックができない問題を修正

### DIFF
--- a/lib/view/user_page/update_memo_dialog.dart
+++ b/lib/view/user_page/update_memo_dialog.dart
@@ -29,10 +29,9 @@ class UpdateMemoDialog extends HookConsumerWidget implements AutoRouteWrapper {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final controller = useTextEditingController(text: initialMemo);
+    final notifier = ref.watch(userInfoNotifierProxyProvider(userId));
     final updateMemo = useAsync(() async {
-      await ref
-          .read(userInfoNotifierProxyProvider(userId))
-          .updateMemo(controller.text);
+      await notifier.updateMemo(controller.text);
       await ref.read(appRouterProvider).maybePop();
     });
 

--- a/lib/view/user_page/user_control_dialog.dart
+++ b/lib/view/user_page/user_control_dialog.dart
@@ -46,14 +46,17 @@ class UserControlDialog extends HookConsumerWidget implements AutoRouteWrapper {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final provider = userInfoNotifierProxyProvider(response.id);
+    // readではなくwatchすること。readだとこのダイアログがnotifierを購読せず、
+    // 呼び出し元がuserInfoProviderを購読していない場合(タイムラインのノートメニュー
+    // から開いた場合など)にnotifierが破棄され、ミュート・ブロックが動作しなくなる。
+    final notifier = ref.watch(userInfoNotifierProxyProvider(response.id));
 
-    final createBlocking = useAsync(ref.read(provider).createBlocking);
-    final deleteBlocking = useAsync(ref.read(provider).deleteBlocking);
-    final createRenoteMute = useAsync(ref.read(provider).createRenoteMute);
-    final deleteRenoteMute = useAsync(ref.read(provider).deleteRenoteMute);
-    final createMute = useAsync(ref.read(provider).createMute);
-    final deleteMute = useAsync(ref.read(provider).deleteMute);
+    final createBlocking = useAsync(notifier.createBlocking);
+    final deleteBlocking = useAsync(notifier.deleteBlocking);
+    final createRenoteMute = useAsync(notifier.createRenoteMute);
+    final deleteRenoteMute = useAsync(notifier.deleteRenoteMute);
+    final createMute = useAsync(notifier.createMute);
+    final deleteMute = useAsync(notifier.deleteMute);
     final copyName = useAsync(() async {
       await Clipboard.setData(
         ClipboardData(text: response.name ?? response.username),

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -28,7 +28,7 @@ class UserDetail extends ConsumerWidget {
     //   userInfoProvider(response.id)
     //       .select((value) => value.value?.follow is AsyncLoading),
     // );
-    final notifier = ref.read(userInfoNotifierProxyProvider(response.id));
+    final notifier = ref.watch(userInfoNotifierProxyProvider(response.id));
     final memo = response.memo ?? "";
 
     final isSameAccount = ref.read(accountContextProvider).isSame;

--- a/lib/view/user_page/user_info_notifier.dart
+++ b/lib/view/user_page/user_info_notifier.dart
@@ -29,9 +29,13 @@ abstract class UserInfo with _$UserInfo {
 // でもまだ https://github.com/rrousselGit/riverpod/issues/767 の機能がないことに加え、
 // https://github.com/rrousselGit/riverpod/issues/2383 のようなこともあるので、
 // UserInfoNotifierが直接accountContextにdependenciesを設定したり、引数のデフォルトにしたりすることが現状できない。
+// userInfoProviderはautoDisposeなので、readではなくwatchで参照する。
+// readにすると購読が張られず、このプロキシを利用しているだけの画面
+// (タイムラインのノートメニューから開いたユーザーメニューなど)では
+// UserInfoNotifierが即座に破棄され、以降の操作が一切効かなくなる。
 @Riverpod(dependencies: [accountContext])
 Raw<UserInfoNotifier> userInfoNotifierProxy(Ref ref, String userId) {
-  return ref.read(
+  return ref.watch(
     userInfoProvider(
       userId: userId,
       context: ref.read(accountContextProvider),

--- a/test/view/user_page/user_control_dialog_test.dart
+++ b/test/view/user_page/user_control_dialog_test.dart
@@ -1,0 +1,64 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:miria/providers.dart";
+import "package:miria/router/app_router.dart";
+import "package:misskey_dart/misskey_dart.dart";
+import "package:mockito/mockito.dart";
+
+import "../../test_util/default_root_widget.dart";
+import "../../test_util/mock.mocks.dart";
+import "../../test_util/test_datas.dart";
+import "../../test_util/widget_tester_extension.dart";
+
+void main() {
+  group("ユーザーメニュー", () {
+    // #677: userInfoProviderをwatchしていない画面(タイムラインのノートメニューなど)から
+    // ユーザーメニューを開くと、UserInfoNotifierが即座にautoDisposeされてしまい
+    // ミュート・ブロックの操作が一切効かなくなっていた。
+    // ユーザー情報画面を経由せずに直接ユーザーメニューを開いて操作が届くことを確認する。
+    testWidgets("ユーザー情報画面を経由せずに開いた場合でもリノートミュートができること", (tester) async {
+      final mockMisskey = MockMisskey();
+      final mockUser = MockMisskeyUsers();
+      final mockRenoteMute = MockMisskeyRenoteMute();
+      when(mockMisskey.users).thenReturn(mockUser);
+      when(mockMisskey.renoteMute).thenReturn(mockRenoteMute);
+      when(
+        mockUser.show(any),
+      ).thenAnswer((_) async => TestData.usersShowResponse1);
+      when(mockRenoteMute.create(any)).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            misskeyProvider.overrideWith((ref, account) => mockMisskey),
+          ],
+          child: DefaultRootWidget(
+            initialRoute: UserControlRoute(
+              account: TestData.account,
+              response: TestData.usersShowResponse1,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final target = find.text("リノートをミュートする");
+      await tester.scrollUntilVisible(
+        target,
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(target);
+      // 完了後はローディング表示のまま(実機ではmaybePopで閉じる)なのでpumpAndSettleは使えない
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      verify(
+        mockRenoteMute.create(
+          RenoteMuteCreateRequest(userId: TestData.usersShowResponse1.id),
+        ),
+      ).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Fix #677

## 問題

タイムラインのノートのメニューから開いたユーザーメニューで、ミュート・ブロックをタップしても何も起きない。ユーザー情報（プロフィール）画面から開いた場合は正常に動作する。

## 原因

`userInfoNotifierProxy` が `userInfoProvider` を `ref.read` で参照していたため購読が張られず、autoDispose によって `UserInfoNotifier` が即座に破棄されていました。

- **ユーザー情報画面から**: 背後の `UserPage` が `userInfoProxyProvider` を `watch` しているため、`userInfoProvider` が偶然生存しており動作していた
- **タイムラインのノートメニューから**: 誰も購読していないため破棄済みの `Ref` へアクセスすることになり `StateError` が発生

`useAsync` が例外を握り潰してログに落とすだけなので、UI 上は「タップしても無反応」に見えていました。

## 修正

プロキシ側と各利用箇所の双方を `ref.watch` に変更し、ダイアログの表示中は notifier が生存するようにしました。

- `user_info_notifier.dart` — プロキシが `userInfoProvider` を watch するよう変更
- `user_control_dialog.dart` — notifier を watch で取得
- `user_detail.dart` / `update_memo_dialog.dart` — 同種の `ref.read` を watch に変更

## テスト

`test/view/user_page/user_control_dialog_test.dart` を追加しました。ユーザー情報画面を経由せずに `UserControlRoute` を直接開き、リノートミュートの API 呼び出しが届くことを検証します。

修正前はこのテストが `Cannot use the Ref of userInfoProvider(...) after it has been disposed` で失敗することを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPFyykYBvh6hvnBckiFPQm