### PR TITLE
fix: 下書き保存の確認ダイアログが重ねて表示される問題を修正

### DIFF
--- a/lib/view/note_create_page/note_create_page.dart
+++ b/lib/view/note_create_page/note_create_page.dart
@@ -96,6 +96,8 @@ class NoteCreatePage extends HookConsumerWidget implements AutoRouteWrapper {
     final focusNode = ref.watch(noteFocusProvider);
     final notifier = ref.read(noteCreateProvider.notifier);
     final controller = ref.watch(noteInputTextProvider);
+    // 下書き保存の確認ダイアログの多重表示を防ぐためのフラグ
+    final isDraftDialogShowing = useRef(false);
 
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((timestamp) async {
@@ -171,6 +173,11 @@ class NoteCreatePage extends HookConsumerWidget implements AutoRouteWrapper {
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
 
+        // 下書き保存の確認ダイアログはNavigatorのルートを積まないオーバーレイ方式のため、
+        // 表示中でもAndroidの戻るキーはこのページに届いてしまう。
+        // ガードがないと戻るキーを連打した数だけダイアログが積み重なる。
+        if (isDraftDialogShowing.value) return;
+
         final state = ref.read(noteCreateProvider);
         final hasContent = _hasDraftContent(state);
         final draftLimitPolicy =
@@ -185,14 +192,20 @@ class NoteCreatePage extends HookConsumerWidget implements AutoRouteWrapper {
         if (hasContent && draftLimitPolicy > 0) {
           // Show save to draft dialog only if drafts are supported
           final dialogNotifier = ref.read(dialogStateProvider.notifier);
-          final choice = await dialogNotifier.showDialog(
-            message: (context) => S.of(context).saveToDrafts,
-            actions: (context) => [
-              S.of(context).discardAndReturn,
-              S.of(context).continueEditing,
-              S.of(context).saveAndClose,
-            ],
-          );
+          isDraftDialogShowing.value = true;
+          final int choice;
+          try {
+            choice = await dialogNotifier.showDialog(
+              message: (context) => S.of(context).saveToDrafts,
+              actions: (context) => [
+                S.of(context).discardAndReturn,
+                S.of(context).continueEditing,
+                S.of(context).saveAndClose,
+              ],
+            );
+          } finally {
+            isDraftDialogShowing.value = false;
+          }
 
           switch (choice) {
             case 0: // Discard

--- a/test/view/note_create_page/draft_dialog_duplication_test.dart
+++ b/test/view/note_create_page/draft_dialog_duplication_test.dart
@@ -1,0 +1,57 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:miria/providers.dart";
+import "package:miria/router/app_router.dart";
+import "package:miria/view/common/note_create/input_completation.dart";
+import "package:mockito/mockito.dart";
+
+import "../../test_util/default_root_widget.dart";
+import "../../test_util/mock.mocks.dart";
+import "../../test_util/test_datas.dart";
+import "../../test_util/widget_tester_extension.dart";
+
+void main() {
+  group("下書き保存の確認ダイアログ", () {
+    // #834: 確認ダイアログはNavigatorのルートを積まないオーバーレイ方式のため、
+    // 表示中でもAndroidの戻るキーはノート作成ページに届いてしまう。
+    // 再入ガードがないと戻るキーを連打した数だけダイアログが積み重なっていた。
+    testWidgets("戻るキーを連打してもダイアログが重ねて表示されないこと", (tester) async {
+      final mockMisskey = MockMisskey();
+      final mockNote = MockMisskeyNotes();
+      when(mockMisskey.notes).thenReturn(mockNote);
+
+      // 下書き機能が有効なアカウントでないと確認ダイアログが出ない
+      final account = TestData.account.copyWith(
+        i: TestData.account.i.copyWith(
+          policies: TestData.account.i.policies.copyWith(noteDraftLimit: 10),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            misskeyProvider.overrideWith((ref, account) => mockMisskey),
+            inputComplementDelayedProvider.overrideWithValue(1),
+          ],
+          child: DefaultRootWidget(
+            initialRoute: NoteCreateRoute(initialAccount: account),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 下書きに保存する内容がないとダイアログが出ない
+      await tester.enterText(find.byType(TextField).hitTestable(), "ぬるぽ");
+      await tester.pumpAndSettle();
+
+      // 戻るキーを連打する
+      await tester.binding.handlePopRoute();
+      await tester.binding.handlePopRoute();
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.text("下書きに保存しとく？"), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Fix #834

## 問題

Android で戻るキーを連打すると、押した回数だけ下書き保存の確認ダイアログが重ねて表示される。

## 原因

この確認ダイアログは Navigator のルートを積まないオーバーレイ方式（`DialogScope` が `dialogStateProvider` の `dialogs` を `Stack` に並べる）です。そのため表示中でも Android の戻るキーはノート作成ページの `PopScope` に届き続けます。

`onPopInvokedWithResult` に再入ガードがなかったため、戻るキーを押すたびに `showDialog` が `dialogs` へ append され、ダイアログが積み重なっていました。

## 修正

`useRef` でダイアログ表示中を示すフラグを持ち、表示中は `onPopInvokedWithResult` を即 return するようにしました。フラグの解除は `try`/`finally` で行っているため、ダイアログが例外で終わった場合も戻るキーが効かなくなることはありません。

## テスト

`test/view/note_create_page/draft_dialog_duplication_test.dart` を追加しました。戻るキーを3回連続で送り、ダイアログが1つだけであることを検証します。

修正前は同テストが `Found 3 widgets with text "下書きに保存しとく？"` で失敗することを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPFyykYBvh6hvnBckiFPQm