### PR TITLE
feat: 予約投稿に関する通知に対応

### DIFF
--- a/lib/l10n/app_ja-oj.arb
+++ b/lib/l10n/app_ja-oj.arb
@@ -67,6 +67,8 @@
     "renotedUsersInNotification": "リノートされた方",
     "reactionUsersInNotification": "リアクションされた人",
     "finishedVotedNotification": "投票結果が出たそうですわよ",
+    "scheduledNotePostedNotification": "予約投稿がノートされましてよ",
+    "scheduledNotePostFailedNotification": "予約投稿が失敗したそうですわ",
     "renoteAndReactionsNotification": "{reactionUser}らがリアクションを、{renotedUser}らがリノートをされましたのよ",
     "renoteNotification": "{renoteUser}らがリノートされましてよ",
     "reactionNotification": "{reactionUser}らがリアクションされましてよ",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -335,6 +335,8 @@
     "renotedUsersInNotification": "リノートしてくれはった人",
     "reactionUsersInNotification": "リアクションしてくれはった人",
     "finishedVotedNotification": "投票が終わったみたいや",
+    "scheduledNotePostedNotification": "予約投稿がノートされたで",
+    "scheduledNotePostFailedNotification": "予約投稿がしくじったみたいや",
     "renoteAndReactionsNotification": "{reactionUser}さんたちがリアクションしはって、{renotedUser}さんたちがリノートしはったで",
     "@renoteAndReactionsNotification": {
         "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1215,6 +1215,18 @@ abstract class S {
   /// **'投票が終わったみたいや'**
   String get finishedVotedNotification;
 
+  /// No description provided for @scheduledNotePostedNotification.
+  ///
+  /// In ja, this message translates to:
+  /// **'予約投稿がノートされたで'**
+  String get scheduledNotePostedNotification;
+
+  /// No description provided for @scheduledNotePostFailedNotification.
+  ///
+  /// In ja, this message translates to:
+  /// **'予約投稿がしくじったみたいや'**
+  String get scheduledNotePostFailedNotification;
+
   /// No description provided for @renoteAndReactionsNotification.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -634,6 +634,12 @@ class SJa extends S {
   String get finishedVotedNotification => '投票が終わったみたいや';
 
   @override
+  String get scheduledNotePostedNotification => '予約投稿がノートされたで';
+
+  @override
+  String get scheduledNotePostFailedNotification => '予約投稿がしくじったみたいや';
+
+  @override
   String renoteAndReactionsNotification(
     String? reactionUser,
     String? renotedUser,
@@ -2310,6 +2316,12 @@ class SJaOj extends SJa {
 
   @override
   String get finishedVotedNotification => '投票結果が出たそうですわよ';
+
+  @override
+  String get scheduledNotePostedNotification => '予約投稿がノートされましてよ';
+
+  @override
+  String get scheduledNotePostFailedNotification => '予約投稿が失敗したそうですわ';
 
   @override
   String renoteAndReactionsNotification(

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -632,6 +632,12 @@ class SZh extends S {
   String get finishedVotedNotification => '投票已经结束了';
 
   @override
+  String get scheduledNotePostedNotification => '预约发布的帖子已发布';
+
+  @override
+  String get scheduledNotePostFailedNotification => '预约发布失败了';
+
+  @override
   String renoteAndReactionsNotification(
     String? reactionUser,
     String? renotedUser,
@@ -2730,6 +2736,12 @@ class SZhCn extends SZh {
 
   @override
   String get finishedVotedNotification => '投票已经结束了';
+
+  @override
+  String get scheduledNotePostedNotification => '预约发布的帖子已发布';
+
+  @override
+  String get scheduledNotePostFailedNotification => '预约发布失败了';
 
   @override
   String renoteAndReactionsNotification(

--- a/lib/l10n/app_zh-cn.arb
+++ b/lib/l10n/app_zh-cn.arb
@@ -321,6 +321,8 @@
     "renotedUsersInNotification": "转发的人",
     "reactionUsersInNotification": "回应的人",
     "finishedVotedNotification": "投票已经结束了",
+    "scheduledNotePostedNotification": "预约发布的帖子已发布",
+    "scheduledNotePostFailedNotification": "预约发布失败了",
     "renoteAndReactionsNotification": "{reactionUser}回应了，{renotedUser}转发了",
     "@renoteAndReactionsNotification": {
         "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -321,6 +321,8 @@
     "renotedUsersInNotification": "转发的人",
     "reactionUsersInNotification": "回应的人",
     "finishedVotedNotification": "投票已经结束了",
+    "scheduledNotePostedNotification": "预约发布的帖子已发布",
+    "scheduledNotePostFailedNotification": "预约发布失败了",
     "renoteAndReactionsNotification": "{reactionUser}回应了，{renotedUser}转发了",
     "@renoteAndReactionsNotification": {
         "placeholders": {

--- a/lib/view/notification_page/notification_page.dart
+++ b/lib/view/notification_page/notification_page.dart
@@ -468,6 +468,29 @@ class NotificationItem extends ConsumerWidget {
             ],
           ),
         );
+      case ScheduledNoteNotification(:final note):
+        return Padding(
+          padding: const EdgeInsets.only(top: 10, bottom: 10, right: 10),
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(left: 10.0),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        S.of(context).scheduledNotePostedNotification,
+                      ),
+                    ),
+                    Text(notification.createdAt.differenceNow(context)),
+                  ],
+                ),
+              ),
+              if (note != null)
+                misskey_note.MisskeyNote(note: note, isDisplayBorder: false),
+            ],
+          ),
+        );
       case NoteNotification(:final note):
         final user = note?.user;
         return Padding(

--- a/lib/view/notification_page/notification_page_data.dart
+++ b/lib/view/notification_page/notification_page_data.dart
@@ -135,6 +135,16 @@ class NoteNotification extends NotificationData {
   });
 }
 
+/// 予約投稿がノートされたときの通知
+class ScheduledNoteNotification extends NotificationData {
+  final Note? note;
+  ScheduledNoteNotification({
+    required this.note,
+    required super.createdAt,
+    required super.id,
+  });
+}
+
 class RoleNotification extends NotificationData {
   final RolesListResponse? role;
   RoleNotification({
@@ -292,6 +302,22 @@ extension INotificationsResponseExtension on Iterable<INotificationsResponse> {
           resultList.add(
             PollNotification(
               note: element.note,
+              createdAt: element.createdAt,
+              id: element.id,
+            ),
+          );
+        case NotificationType.scheduledNotePosted:
+          resultList.add(
+            ScheduledNoteNotification(
+              note: element.note,
+              createdAt: element.createdAt,
+              id: element.id,
+            ),
+          );
+        case NotificationType.scheduledNotePostFailed:
+          resultList.add(
+            SimpleNotificationData(
+              text: localize.scheduledNotePostFailedNotification,
               createdAt: element.createdAt,
               id: element.id,
             ),

--- a/test/view/notification_page/notification_page_data_test.dart
+++ b/test/view/notification_page/notification_page_data_test.dart
@@ -1,0 +1,55 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:miria/l10n/app_localizations.dart";
+import "package:miria/view/notification_page/notification_page_data.dart";
+import "package:misskey_dart/misskey_dart.dart";
+
+import "../../test_util/test_datas.dart";
+
+void main() {
+  group("予約投稿の通知", () {
+    late S localize;
+
+    setUp(() async {
+      localize = await S.delegate.load(const Locale("ja"));
+    });
+
+    INotificationsResponse notification(NotificationType type, {Note? note}) =>
+        INotificationsResponse(
+          id: "notification1",
+          createdAt: DateTime(2026, 7, 19),
+          type: type,
+          note: note,
+        );
+
+    // #851: 予約投稿に関する通知がunknownNotificationとして扱われていた
+    test("予約投稿がノートされた通知がノートつきで表示されること", () {
+      final result = [
+        notification(
+          NotificationType.scheduledNotePosted,
+          note: TestData.note1,
+        ),
+      ].toNotificationData(localize);
+
+      expect(result, hasLength(1));
+      final data = result.first;
+      expect(data, isA<ScheduledNoteNotification>());
+      expect((data as ScheduledNoteNotification).note?.id, TestData.note1.id);
+    });
+
+    test("予約投稿に失敗した通知が専用のメッセージで表示されること", () {
+      final result = [
+        notification(NotificationType.scheduledNotePostFailed),
+      ].toNotificationData(localize);
+
+      expect(result, hasLength(1));
+      final data = result.first;
+      expect(data, isA<SimpleNotificationData>());
+      expect(
+        (data as SimpleNotificationData).text,
+        localize.scheduledNotePostFailedNotification,
+      );
+      expect(data.text, isNot(localize.unknownNotification));
+    });
+  });
+}


### PR DESCRIPTION
Fix #851

## 問題

予約投稿がノートされた、といった通知を受け取ったとき、Miria では `unknownNotification`（「知らんタイプの通知やわ」）として表示されてしまう。

## 修正

misskey_dart 側は `NotificationType.scheduledNotePosted` / `scheduledNotePostFailed` に既に対応済みなので、Miria 側で対応する case を追加しました。

- **`scheduledNotePosted`** — 投票終了通知（`PollNotification`）と同様に、見出しつきでノート本体を表示する `ScheduledNoteNotification` を追加
- **`scheduledNotePostFailed`** — 専用のメッセージを表示（`SimpleNotificationData`）

l10n は ja / ja-OJ / zh / zh-cn の4ロケールすべてに追加しています。

## テスト

`test/view/notification_page/notification_page_data_test.dart` を追加しました（このディレクトリのテストは初）。それぞれの通知種別が期待通りの `NotificationData` に変換され、`unknownNotification` に落ちないことを検証します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPFyykYBvh6hvnBckiFPQm