### PR TITLE
fix: ファイル名編集後の投稿でファイルの説明が空文字になる問題を修正

### DIFF
--- a/lib/state_notifier/note_create_page/note_create_state_notifier.dart
+++ b/lib/state_notifier/note_create_page/note_create_state_notifier.dart
@@ -488,6 +488,32 @@ class NoteCreateNotifier extends _$NoteCreateNotifier {
     state = state.copyWith(selectedDraftId: draftId);
   }
 
+  /// ドライブのファイル情報を更新する
+  ///
+  /// misskey_dartの`drive.files.update`はFreezedのtoJsonを経由するため
+  /// undefinedとnullを区別できず、`comment: null`を渡すとキーごと削除される。
+  /// 一方で説明が空のときに`comment: ''`を送ると、Misskey Webが
+  /// ALTテキストとしてファイル名を表示しなくなってしまう。
+  /// そのためapiServiceを直接呼び、commentについてはnullをそのまま送る。
+  Future<DriveFile> _updateDriveFile({
+    required String fileId,
+    required String name,
+    required bool isSensitive,
+    required String? comment,
+  }) async {
+    final response = await _misskey.apiService.post<Map<String, dynamic>>(
+      "drive/files/update",
+      DriveFilesUpdateRequest(
+        fileId: fileId,
+        name: name,
+        isSensitive: isSensitive,
+        comment: comment,
+      ).toJson(),
+      excludeRemoveNullPredicate: (key, _) => key == "comment",
+    );
+    return DriveFile.fromJson(response);
+  }
+
   /// ノートを投稿する
   Future<void> note() async {
     if (state.text.isEmpty && state.files.isEmpty && !state.isVote) {
@@ -573,25 +599,21 @@ class NoteCreateNotifier extends _$NoteCreateNotifier {
 
             case UnknownAlreadyPostedFile():
               if (file.isEdited) {
-                await _misskey.drive.files.update(
-                  DriveFilesUpdateRequest(
-                    fileId: file.id,
-                    name: file.fileName,
-                    isSensitive: file.isNsfw,
-                    comment: file.caption,
-                  ),
+                await _updateDriveFile(
+                  fileId: file.id,
+                  name: file.fileName,
+                  isSensitive: file.isNsfw,
+                  comment: file.caption,
                 );
               }
               fileIds.add(file.id);
             case ImageFileAlreadyPostedFile():
               if (file.isEdited) {
-                response = await _misskey.drive.files.update(
-                  DriveFilesUpdateRequest(
-                    fileId: file.id,
-                    name: file.fileName,
-                    isSensitive: file.isNsfw,
-                    comment: file.caption,
-                  ),
+                response = await _updateDriveFile(
+                  fileId: file.id,
+                  name: file.fileName,
+                  isSensitive: file.isNsfw,
+                  comment: file.caption,
                 );
               }
 

--- a/lib/state_notifier/note_create_page/note_create_state_notifier.g.dart
+++ b/lib/state_notifier/note_create_page/note_create_state_notifier.g.dart
@@ -58,7 +58,7 @@ final class NoteCreateNotifierProvider
 }
 
 String _$noteCreateNotifierHash() =>
-    r'c579b767931a88e49f21f444730a5ede1bdf6c26';
+    r'8f02313d01678db05b62133639831006e442b38a';
 
 abstract class _$NoteCreateNotifier extends $Notifier<NoteCreate> {
   NoteCreate build();

--- a/lib/view/note_create_page/file_settings_dialog.dart
+++ b/lib/view/note_create_page/file_settings_dialog.dart
@@ -7,7 +7,10 @@ import "package:miria/model/image_file.dart";
 class FileSettingsDialogResult {
   final String fileName;
   final bool isNsfw;
-  final String caption;
+
+  /// ファイルの説明。未入力の場合は空文字ではなくnull。
+  /// 空文字を送るとMisskey Webがファイル名をALTとして表示しなくなってしまう。
+  final String? caption;
 
   const FileSettingsDialogResult({
     required this.fileName,
@@ -95,7 +98,9 @@ class FileSettingsDialog extends HookConsumerWidget {
               FileSettingsDialogResult(
                 fileName: fileNameController.text,
                 isNsfw: isNsfw.value,
-                caption: captionController.text,
+                caption: captionController.text.isEmpty
+                    ? null
+                    : captionController.text,
               ),
             );
           },

--- a/test/view/note_create_page/file_caption_test.dart
+++ b/test/view/note_create_page/file_caption_test.dart
@@ -1,0 +1,150 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:miria/model/account_settings.dart";
+import "package:miria/model/image_file.dart";
+import "package:miria/providers.dart";
+import "package:miria/state_notifier/note_create_page/note_create_state_notifier.dart";
+import "package:miria/view/note_create_page/file_settings_dialog.dart";
+import "package:miria/view/note_create_page/note_create_page.dart";
+import "package:misskey_dart/misskey_dart.dart";
+import "package:misskey_dart/src/services/api_service.dart";
+import "package:mockito/mockito.dart";
+
+import "../../test_util/mock.mocks.dart";
+import "../../test_util/test_datas.dart";
+
+/// `drive/files/update` に送られたリクエストを記録するApiService
+class RecordingApiService extends Fake implements ApiService {
+  final requests =
+      <(String, Map<String, dynamic>, bool Function(String, String?)?)>[];
+
+  @override
+  Future<T> post<T>(
+    String path,
+    Map<String, dynamic> request, {
+    bool Function(String, String?)? excludeRemoveNullPredicate,
+  }) async {
+    requests.add((path, request, excludeRemoveNullPredicate));
+    return TestData.drive1.toJson() as T;
+  }
+}
+
+void main() {
+  group("ファイル情報の編集", () {
+    late ProviderContainer container;
+    late RecordingApiService apiService;
+
+    // 画像以外のファイルにするとダウンロード処理を挟まずに
+    // UnknownAlreadyPostedFileとして復元される
+    final driveFile = TestData.drive1.copyWith(
+      name: "before.txt",
+      type: "text/plain",
+      comment: null,
+    );
+    final noteWithFile = TestData.note1.copyWith(
+      files: [driveFile],
+      fileIds: [driveFile.id],
+    );
+
+    setUp(() {
+      apiService = RecordingApiService();
+      final mockMisskey = MockMisskey();
+      final mockNotes = MockMisskeyNotes();
+      when(mockMisskey.notes).thenReturn(mockNotes);
+      when(mockMisskey.apiService).thenReturn(apiService);
+
+      final account = TestData.account;
+      container = ProviderContainer(
+        overrides: [
+          misskeyProvider.overrideWith((ref, account) => mockMisskey),
+          accountContextProvider.overrideWithValue(
+            AccountContext(getAccount: account, postAccount: account),
+          ),
+          accountSettingsRepositoryProvider.overrideWith((ref) {
+            final repository = MockAccountSettingsRepository();
+            when(repository.fromAccount(any)).thenReturn(
+              AccountSettings(
+                userId: account.userId,
+                host: account.host,
+                defaultNoteVisibility: NoteVisibility.public,
+                defaultIsLocalOnly: false,
+                defaultReactionAcceptance: ReactionAcceptance.nonSensitiveOnly,
+              ),
+            );
+            return repository;
+          }),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    // #849: 説明が空のまま`comment: ''`を送ると、Misskey Webが
+    // ALTテキストとしてファイル名を表示しなくなってしまう
+    test("説明を入力せずにファイル名だけ編集した場合、commentが空文字で送られないこと", () async {
+      final notifier = container.read(noteCreateProvider.notifier);
+      await notifier.initialize(
+        null,
+        null,
+        null,
+        noteWithFile,
+        null,
+        null,
+        NoteCreationMode.recreate,
+      );
+
+      notifier.setFileMetaData(
+        0,
+        const FileSettingsDialogResult(
+          fileName: "after.txt",
+          isNsfw: false,
+          caption: null,
+        ),
+      );
+      notifier.setContentText("ぬるぽ");
+
+      await notifier.note();
+
+      final update = apiService.requests.singleWhere(
+        (e) => e.$1 == "drive/files/update",
+      );
+      expect(update.$2["name"], "after.txt");
+      expect(update.$2["comment"], isNot(""));
+      expect(update.$2["comment"], isNull);
+      // commentのnullがリクエストから削除されないようにする必要がある
+      expect(update.$3?.call("comment", null), isTrue);
+    });
+
+    test("説明を入力した場合はその内容が送られること", () async {
+      final notifier = container.read(noteCreateProvider.notifier);
+      await notifier.initialize(
+        null,
+        null,
+        null,
+        noteWithFile,
+        null,
+        null,
+        NoteCreationMode.recreate,
+      );
+
+      notifier.setFileMetaData(
+        0,
+        const FileSettingsDialogResult(
+          fileName: "after.txt",
+          isNsfw: false,
+          caption: "ぬるぽのファイル",
+        ),
+      );
+      notifier.setContentText("ぬるぽ");
+
+      await notifier.note();
+
+      final update = apiService.requests.singleWhere(
+        (e) => e.$1 == "drive/files/update",
+      );
+      expect(update.$2["comment"], "ぬるぽのファイル");
+    });
+  });
+}


### PR DESCRIPTION
Fix #849

## 問題

ノート投稿画面から画像を添付し、ファイルのメニューを開いてファイル名を編集すると、説明が未入力のファイルでも `comment: ''` としてアップロードされる。

Misskey Web は `comment` が `null` ではなく `''` だと、ALT テキストとしてファイル名ではなくファイルの説明を表示しようとするため、何も表示されなくなってしまう。

## 修正

**1. 空文字を作らない**

`FileSettingsDialogResult.caption` を `String?` にし、未入力時は `''` ではなく `null` を返すようにしました。

**2. null をリクエストから消さない**

misskey_dart の `drive.files.update` は Freezed の `toJson` を経由するため undefined と null を区別できず、`comment: null` を渡すとフィールドごと削除されてしまいます（[api_service.dart](https://github.com/shiosyakeyakini-info/misskey_dart/blob/master/lib/src/services/api_service.dart#L34-L37)）。

そのため `Misskey.apiService.post` を直接呼び、`excludeRemoveNullPredicate` で `comment` だけは null をそのまま送るようにしました。misskey_dart 内の `notes/update` の `cw` や `i/update` と同じ手法で、issue でご案内いただいた Aria の対応方針と同じです。

呼び出し箇所が2つ（`UnknownAlreadyPostedFile` / `ImageFileAlreadyPostedFile`）あるため、`_updateDriveFile` に切り出しています。

## テスト

`test/view/note_create_page/file_caption_test.dart` を追加しました。`ApiService` の Fake でリクエストを記録し、以下を検証します。

- 説明未入力でファイル名だけ編集した場合、`comment` が空文字にならないこと・`excludeRemoveNullPredicate` が `comment` に対して true を返すこと
- 説明を入力した場合はその内容が送られること

`excludeRemoveNullPredicate` を外すとこのテストが落ちることを確認済みです。全384件のテストがパスしています。

## 補足（本PRの対象外）

`drive/files/create`（新規アップロード）と `chat_input_state_notifier.dart` にも同様に空文字が渡り得る箇所があります。create は新規作成のため undefined/null の差が小さく、影響範囲も変わるため本PRでは触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPFyykYBvh6hvnBckiFPQm