### PR TITLE
feat: silent URL (?<url>) のリンクプレビューを抑制

### DIFF
--- a/lib/extensions/list_mfm_node_extension.dart
+++ b/lib/extensions/list_mfm_node_extension.dart
@@ -25,7 +25,9 @@ extension ListMfmNodeExtension on List<MfmNode> {
         links.addAll(children.extractLinks());
       }
       if (node is MfmURL) {
-        links.add(node.value);
+        if (!node.silent) {
+          links.add(node.value);
+        }
       } else if (node is MfmLink) {
         if (!node.silent) {
           links.add(node.url);

--- a/test/extensions/list_mfm_node_extension_test.dart
+++ b/test/extensions/list_mfm_node_extension_test.dart
@@ -1,0 +1,36 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:mfm_parser/mfm_parser.dart";
+import "package:miria/extensions/list_mfm_node_extension.dart";
+
+void main() {
+  group("ListMfmNodeExtension extractLinks", () {
+    test("extracts plain url", () {
+      final nodes = const MfmParser().parse("https://example.com");
+      expect(nodes.extractLinks(), ["https://example.com"]);
+    });
+
+    test("does not extract silent url (?<...>)", () {
+      final nodes = const MfmParser().parse("?<https://example.com>");
+      expect(nodes.extractLinks(), isEmpty);
+    });
+
+    test("does not extract silent link (?[...](...))", () {
+      final nodes = const MfmParser().parse("?[example](https://example.com)");
+      expect(nodes.extractLinks(), isEmpty);
+    });
+
+    test("extracts non-silent url while skipping silent one", () {
+      final nodes = const MfmParser().parse(
+        "https://a.example.com ?<https://b.example.com>",
+      );
+      expect(nodes.extractLinks(), ["https://a.example.com"]);
+    });
+
+    test("deduplicates urls that differ only by hash", () {
+      final nodes = const MfmParser().parse(
+        "https://example.com/page#a https://example.com/page#b",
+      );
+      expect(nodes.extractLinks(), ["https://example.com/page#a"]);
+    });
+  });
+}


### PR DESCRIPTION
## What

silent URL 記法 `?<https://example.com>` を貼ったとき、通常URLと同じ見た目のまま**リンクプレビューを表示しない**ようにします。

`extractLinks()` で silent な `MfmURL` をプレビュー対象から除外します(既存の `MfmLink` の silent 処理と対称)。

- ベースブランチ: `miria_v4`

## 背景

- 仕様: [misskey-dev/misskey#12902](https://github.com/misskey-dev/misskey/issues/12902) —「リンク構文でないURLのリンクプレビューを無効化する構文」。**通常のURLと同じ見た目**でプレビューだけ無効化する意図。
- パーサー側追従: [shiosyakeyakini-info/dart_mfm_parser#11](https://github.com/shiosyakeyakini-info/dart_mfm_parser/pull/11)(`MfmURL` に `silent` を追加、上流 [mfm.js#141](https://github.com/misskey-dev/mfm.js/pull/141) は Review Approved)

`mfm_renderer`(`mfm` パッケージ)自体は silent URL でも描画が通常URLと同一のためコード変更なし。プレビューの出し分けは本 extractLinks が担うため、対応はここに入れています。

## Changes

- `lib/extensions/list_mfm_node_extension.dart` — silent な `MfmURL` を extractLinks から除外
- `test/extensions/list_mfm_node_extension_test.dart` — extractLinks のテストを新規追加(plain / silent url / silent link / 混在 / ハッシュ重複排除)

## Draft の理由 / マージ前に必要なこと

`MfmURL.silent` は **mfm_parser の silent 対応版リリースが前提**です。以下が揃うまでマージ不可のため Draft:

1. dart_mfm_parser#11 のマージ & pub.dev リリース
2. 本リポジトリの `mfm_parser` 依存(現状 `^1.0.7`)がリリース版で解決されること(`^1.0.7` は 1.0.8 以降を許容するため通常は変更不要)
3. CI(`flutter test`)通過

### CI について

- `dart format` ステップは対応済み(Dart 3.8 の tall フォーマッタで整形、リポジトリ全体 0 changed を確認)。
- `flutter test` ステップは、`MfmURL.silent` が未リリースの mfm_parser には存在しないため、**リリース前は必ずコンパイル失敗します**。これは上記 Draft 条件そのもので、パーサーのリリース後に緑化します。

## テスト

- `extractLinks` のロジックは silent 実装済みの mfm_parser 上で純Dart検証済み(plain=抽出 / silent url=除外 / silent link=除外 / 混在=非silentのみ / ハッシュ重複排除)。
- 本環境では `flutter test` は未実行(SDK制約)。CI での確認をお願いします(パーサーリリース後)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)