### PR TITLE
feat: marionette 導入と、連合オフのサーバーでログインできない問題の修正 (#770)

### DIFF
--- a/.claude/skills/drive-miria/SKILL.md
+++ b/.claude/skills/drive-miria/SKILL.md
@@ -1,172 +1,189 @@
 ---
 name: drive-miria
-description: Launch miria and operate it as a real user through marionette — log in, navigate, post a note, inspect Riverpod state, take screenshots. Use when asked to run miria, reproduce a UI bug, or confirm a change works in the running app rather than only in tests.
+description: Launch miria and operate it as a real user through marionette — log in, navigate, post a note, react, search, inspect Riverpod state, take screenshots. Use when asked to run miria, reproduce a UI bug, or confirm a change works in the running app rather than only in tests.
 ---
 
 # Driving miria with marionette
 
-miria's debug builds embed a [marionette](https://github.com/leancodepl/marionette_mcp)
-binding (`lib/marionette_debug.dart`), so a running instance can be inspected and
-driven from outside. This skill is the operating manual: how to get an app up,
-how to find things on screen, and the sequences that are known to work.
+miria's debug builds embed a marionette binding (`lib/marionette_debug.dart`),
+so a running instance can be driven from outside. This file is the operating
+manual. When something behaves in a way it does not explain, read
+`reference.md` next to it — the mechanics, the limits, and the traps live
+there.
 
-Everything below was executed against a real build; the gotchas are ones that
-actually bit.
+## Connect
 
-## 1. Get an app running
-
-```bash
-fvm flutter run -d windows --debug
-```
-
-Copy the line it prints:
-
-```
-A Dart VM Service on Windows is available at: http://127.0.0.1:49570/_id8d8wYirU=/
-```
-
-That URI is the handle for everything else. It changes on every launch.
-
-> **Windows builds need a pinned toolset.** `permission_handler_windows` passes
-> `/await`, which MSVC 14.51+ rejects (`error C2338`, STL1011). Configure the
-> build directory against the v143 toolset once, and Flutter will reuse it:
->
-> ```powershell
-> Remove-Item -Recurse -Force build\windows
-> & "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" `
->   -S windows -B build\windows\x64 -G "Visual Studio 18 2026" -A x64 -T v143
-> fvm flutter run -d windows --debug
-> ```
->
-> This needs the "C++ ATL for v14.42 build tools" component
-> (`Microsoft.VisualStudio.Component.VC.14.42.17.12.ATL`) installed, otherwise
-> `flutter_secure_storage_windows` fails on `atlstr.h`. Redo the `cmake` step
-> after any `flutter clean`.
-
-## 2. Connect
-
-**Preferred — the MCP server.** `.mcp.json` already declares it; install once
-with `dart pub global activate marionette_mcp`, then hand the agent the VM
-Service URI and use the MCP tools directly: `get_interactive_elements`, `tap`,
-`enter_text`, `scroll_to`, `swipe`, `long_press`, `press_back_button`,
-`take_screenshots`, `get_logs`, `hot_reload`, plus miria's own
-`riverpod_snapshot` / `riverpod_read`.
-
-**Fallback — `scripts/marionette.py`.** Same capabilities over plain HTTP, for
-when the MCP server is not set up or you want a scripted sequence:
+The app may already be running. Check before rebuilding: a debug build takes
+minutes, and login survives restarts (secure storage), so an existing process
+is usually already signed in.
 
 ```bash
-python .claude/skills/drive-miria/scripts/marionette.py \
-  --uri http://127.0.0.1:49570/_id8d8wYirU=/ elements   # caches the URI
-python .claude/skills/drive-miria/scripts/marionette.py tap --text "APIキーでログイン"
-python .claude/skills/drive-miria/scripts/marionette.py text --input "hello"
-python .claude/skills/drive-miria/scripts/marionette.py shot out.png
-python .claude/skills/drive-miria/scripts/marionette.py snapshot --filter account
+fvm flutter run -d windows --debug    # prints: A Dart VM Service ... at: <URI>
 ```
 
-Every tool is also reachable raw as `ext.flutter.marionette.<name>` /
-`ext.flutter.riverpod.<name>` on the VM Service, with `isolateId` as a query
-parameter.
+That URI is the handle for everything, and changes on every launch. Windows
+builds need a pinned MSVC toolset — see `reference.md` if the build fails.
 
-## 3. Find things on screen
+Drive it with `scripts/marionette.py` (plain HTTP, no MCP server needed):
 
-`elements` (`get_interactive_elements`) is the map. It returns each interactive
-widget with its type, text, and bounds. Match in this order:
+```bash
+python .claude/skills/drive-miria/scripts/marionette.py --uri <URI> elements
+```
 
-1. **`text`** — works with Japanese labels: `tap --text "APIキーでログイン"`.
-2. **`key`** — if the widget has one.
-3. **coordinates** — `tap --x 200 --y 328`, using the element's *centre*.
-4. **`type`** — `tap --type ElevatedButton`. Only when the type is unique on
-   screen; it silently takes the first match.
+The URI is cached, so later calls can omit `--uri`. Below, `m` stands for that
+script path.
 
-Then take a screenshot to confirm you are where you think you are. The element
-list and the pixels occasionally disagree — dialogs in particular.
+## Verbs
 
-## 4. Sequences that work
+| | |
+|---|---|
+| `m elements` | the map — every interactive widget with type, text, bounds |
+| `m tap` | `--text` / `--key` / `--x --y` / `--type` |
+| `m text --input "..."` | replaces the whole value of the focused field |
+| `m submit` | fires `onSubmitted`. `--action done\|next\|previous` |
+| `m swipe --start X Y --end X Y` | drag. **This is how you scroll** |
+| `m back` | pop the current route |
+| `m shot out.png` | screenshot |
+| `m snapshot` / `m read <name>` | Riverpod state |
+| `m logs` | miria's logger output (nearly always empty — `reference.md`) |
+
+There are more built-ins (`longPress`, `secondaryTap`, `doubleTap`,
+`pinchZoom`, `scrollTo`, `pressKey`) reachable raw as
+`ext.flutter.marionette.<name>`. `scrollTo` and `pressKey` do not do what
+their names suggest here — `reference.md` explains why, and `swipe` /
+`submit` are the working substitutes.
+
+## The loop
+
+**`elements` → act → verify.** Never skip the third step.
+
+- **A tap that hits nothing still reports success.** `Tapped element matching:
+  {...}` only means a pointer event was dispatched.
+- **Seeing what you wanted on screen is not proof your action ran.** The
+  search page's ユーザー tab lists bob before you type anything, so "I typed
+  bob and bob is there" says nothing. For anything that changes state, ask the
+  server:
+
+```bash
+curl -s -X POST http://localhost:3000/api/users/notes \
+  -H "Content-Type: application/json" -d '{"userId":"<id>","limit":5}'
+```
+
+- **Re-read `elements` before every tap.** Coordinates shift constantly — one
+  new reaction chip moves a whole timeline.
+- **Give the UI seconds**, not milliseconds, after anything network-backed.
+  There is no settle primitive. A tap right after a route pop was swallowed
+  once; the retry worked.
+
+Match in this order: **`text`** (exact only, no substring; several matches →
+silently the first), **`key`** (`MisskeyNote` carries the note id, emoji
+buttons carry the emoji: `tap --key 👍`), **coordinates** (the element's
+*centre*), **`type`** (only when unique).
+
+Note bodies are readable — they surface as `Mfm` / `SimpleMfm` elements with
+the text flattened the way it looks on screen, and are valid `--text`
+matchers. The `Text '￼'` sitting at the same spot is the same note; ignore it.
+
+## The screen
+
+Coordinates below are for the default 384×661 window. Tabs are user
+configurable, so trust the title text under the bar rather than the icon.
+
+- **Top bar** `y≈28` — hamburger `x=28`, then the timeline tabs (`76` home,
+  `116` local, `156` …), notifications `x=364`
+- **Second row** `y≈76` — current timeline name, then per-tab actions and
+  reload `x=364`
+- **Bottom** `y≈641` — composer field `x≈152`, send `x=324`, full compose
+  page `x=364`
+- **Note action row** — reply `x=118`, renote `x=192`, react `x=264`, menu
+  `x=338`. The note body is not a tap target; open detail via menu → 詳細
+- **Drawer** (hamburger) — 通知 / お気に入り / リスト / アンテナ / クリップ /
+  チャンネル / チャット / 検索 / みつける / Misskey Games / 設定, account at top
+
+## Recipes
+
+### Post a note
+
+```bash
+m tap  --x 152 --y 641
+m text --input "marionette から投稿しました"
+m tap  --x 324 --y 641
+```
+
+### React
+
+The picker opens with a search field on top and category accordions below.
+Search by English shortcode, then tap the result by its key.
+
+```bash
+m tap  --x 264 --y <note action row>   # ＋
+m tap  --x 192 --y 53                  # picker's search field
+m text --input "thumbs"
+m tap  --key 👍
+```
+
+### Search
+
+Search runs on `onSubmitted`, which neither `text` nor `pressKey enter` can
+trigger — `submit` exists for exactly this.
+
+```bash
+m tap  --text "検索"        # drawer
+m tap  --text "ユーザー"     # tab: ノート x=64, ユーザー x=192, Play x=320, all y=80
+m tap  --x 172 --y 134     # query field
+m text --input "bob"
+m submit
+```
+
+Read-only actions leave nothing on the server to check, so prove the mechanism
+instead: run it once with input that **must** produce a different result. A
+query no user can match empties the list (「なんもないで」), which the
+pre-populated default never does — then repeat with the real query.
+
+### Scroll
+
+```bash
+m swipe --start 190 450 --end 190 150
+```
 
 ### Log in (API key)
 
-Fastest way to a logged-in app; MiAuth needs a browser round-trip.
-
-Get a token from the server (first admin on an empty instance):
+Only needed on a fresh profile. MiAuth opens an external browser and cannot be
+driven; API key is the only automatable sign-in.
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/accounts/create \
-  -H "Content-Type: application/json" \
-  -d '{"username":"miria","password":"..."}'
 curl -X POST http://localhost:3000/api/signin-flow \
   -H "Content-Type: application/json" \
   -d '{"username":"miria","password":"..."}'   # -> {"i": "<token>"}
 ```
 
-Then drive the login screen:
-
 ```bash
-marionette.py tap  --text "APIキーでログイン"
-marionette.py tap  --x 200 --y 328                     # focus サーバー
-marionette.py text --input "http://localhost:3000"
-marionette.py tap  --x 200 --y 378                     # focus APIキー
-marionette.py text --input "<token>"
-marionette.py tap  --type ElevatedButton
+m tap  --text "APIキーでログイン"
+m tap  --x 200 --y 328                 # サーバー field
+m text --input "http://localhost:3000"  # the scheme is required
+m tap  --x 200 --y 378                 # APIキー field
+m text --input "<token>"
+m tap  --type ElevatedButton
 ```
-
-The two fields are both bare `TextField`s, so `--type TextField` always hits the
-first one. Tap the field by coordinate, then write to `focused` (the default
-matcher for `text`).
-
-**The scheme is required for a local server.** `localhost:3000` alone is tried
-over https, fails the TLS handshake, and you get
-「サーバーとして認識できませんでした」. Use `http://localhost:3000`.
 
 Success looks like the ホームタイムライン screen.
-
-### Post a note
-
-From the timeline, the composer is the `TextField` pinned to the bottom:
-
-```bash
-marionette.py tap  --x 150 --y 640     # composer
-marionette.py text --input "marionette から投稿しました"
-marionette.py tap  --x 304 --y 640     # send
-```
-
-A `MisskeyNote` appears in the element list and the composer clears. Confirm on
-the server rather than trusting the UI:
-
-```bash
-curl -X POST http://localhost:3000/api/users/notes \
-  -H "Content-Type: application/json" -d '{"userId":"<id>","limit":5}'
-```
 
 ### Inspect state
 
 ```bash
-marionette.py snapshot                    # names and types only — start here
-marionette.py snapshot --filter account --values
-marionette.py read accountRepositoryProvider
+m snapshot                        # names and types only — start here
+m snapshot --filter account --values
+m read accountRepositoryProvider
 ```
 
-Providers that were never read do not appear: Riverpod builds state lazily, so
-there is genuinely nothing to report for them. This is the single most common
-source of "my provider is missing".
+Providers that were never read are absent — Riverpod builds state lazily.
+Repositories serialize to `{"runtimeType": ...}` only, so the timeline's notes
+are not reachable this way. Values can contain API tokens; never paste a raw
+snapshot anywhere public.
 
-Miria's hand-written providers (`ChangeNotifierProvider<...>`, `StateProvider<...>`)
-carry no `name`, so they show up as their type plus `:unnamed`. Codegen
-(`@riverpod`) providers get real names. If you need to address one of the
-unnamed ones repeatedly, giving it a `name:` is worth it.
+## When it looks like nothing happened
 
-## 5. Gotchas
-
-- **Read responses as UTF-8.** The VM Service answers in UTF-8; a Windows
-  console defaulting to CP932 turns every Japanese label into mojibake and makes
-  it look like the app is broken when it is not.
-- **Do not run `flutter test` and `flutter run` at once.** They share `build/`
-  and clobber each other's `native_assets.json`.
-- **Give the UI time.** Network-backed transitions need several seconds before
-  the element list settles; a screenshot taken too early shows the old screen.
-- **`take_screenshots` works** on Windows/Impeller — a real PNG, not a blank
-  frame.
-- **Values can contain secrets.** An account object holds its API token, and
-  provider values are dumped best-effort. This is debug-only for that reason;
-  do not paste raw snapshots into anywhere public.
-- **A fresh `flutter run` means a fresh URI.** Nothing caches across launches.
+In order: re-read `elements`; take a screenshot; check whether a **native
+dialog** is up (`Get-Process | ? { $_.MainWindowTitle }` — file pickers and
+browsers are invisible to marionette); ask the server. `reference.md` has the
+full list of what is out of reach and why.

--- a/.claude/skills/drive-miria/SKILL.md
+++ b/.claude/skills/drive-miria/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: drive-miria
+description: Launch miria and operate it as a real user through marionette — log in, navigate, post a note, inspect Riverpod state, take screenshots. Use when asked to run miria, reproduce a UI bug, or confirm a change works in the running app rather than only in tests.
+---
+
+# Driving miria with marionette
+
+miria's debug builds embed a [marionette](https://github.com/leancodepl/marionette_mcp)
+binding (`lib/marionette_debug.dart`), so a running instance can be inspected and
+driven from outside. This skill is the operating manual: how to get an app up,
+how to find things on screen, and the sequences that are known to work.
+
+Everything below was executed against a real build; the gotchas are ones that
+actually bit.
+
+## 1. Get an app running
+
+```bash
+fvm flutter run -d windows --debug
+```
+
+Copy the line it prints:
+
+```
+A Dart VM Service on Windows is available at: http://127.0.0.1:49570/_id8d8wYirU=/
+```
+
+That URI is the handle for everything else. It changes on every launch.
+
+> **Windows builds need a pinned toolset.** `permission_handler_windows` passes
+> `/await`, which MSVC 14.51+ rejects (`error C2338`, STL1011). Configure the
+> build directory against the v143 toolset once, and Flutter will reuse it:
+>
+> ```powershell
+> Remove-Item -Recurse -Force build\windows
+> & "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" `
+>   -S windows -B build\windows\x64 -G "Visual Studio 18 2026" -A x64 -T v143
+> fvm flutter run -d windows --debug
+> ```
+>
+> This needs the "C++ ATL for v14.42 build tools" component
+> (`Microsoft.VisualStudio.Component.VC.14.42.17.12.ATL`) installed, otherwise
+> `flutter_secure_storage_windows` fails on `atlstr.h`. Redo the `cmake` step
+> after any `flutter clean`.
+
+## 2. Connect
+
+**Preferred — the MCP server.** `.mcp.json` already declares it; install once
+with `dart pub global activate marionette_mcp`, then hand the agent the VM
+Service URI and use the MCP tools directly: `get_interactive_elements`, `tap`,
+`enter_text`, `scroll_to`, `swipe`, `long_press`, `press_back_button`,
+`take_screenshots`, `get_logs`, `hot_reload`, plus miria's own
+`riverpod_snapshot` / `riverpod_read`.
+
+**Fallback — `scripts/marionette.py`.** Same capabilities over plain HTTP, for
+when the MCP server is not set up or you want a scripted sequence:
+
+```bash
+python .claude/skills/drive-miria/scripts/marionette.py \
+  --uri http://127.0.0.1:49570/_id8d8wYirU=/ elements   # caches the URI
+python .claude/skills/drive-miria/scripts/marionette.py tap --text "APIキーでログイン"
+python .claude/skills/drive-miria/scripts/marionette.py text --input "hello"
+python .claude/skills/drive-miria/scripts/marionette.py shot out.png
+python .claude/skills/drive-miria/scripts/marionette.py snapshot --filter account
+```
+
+Every tool is also reachable raw as `ext.flutter.marionette.<name>` /
+`ext.flutter.riverpod.<name>` on the VM Service, with `isolateId` as a query
+parameter.
+
+## 3. Find things on screen
+
+`elements` (`get_interactive_elements`) is the map. It returns each interactive
+widget with its type, text, and bounds. Match in this order:
+
+1. **`text`** — works with Japanese labels: `tap --text "APIキーでログイン"`.
+2. **`key`** — if the widget has one.
+3. **coordinates** — `tap --x 200 --y 328`, using the element's *centre*.
+4. **`type`** — `tap --type ElevatedButton`. Only when the type is unique on
+   screen; it silently takes the first match.
+
+Then take a screenshot to confirm you are where you think you are. The element
+list and the pixels occasionally disagree — dialogs in particular.
+
+## 4. Sequences that work
+
+### Log in (API key)
+
+Fastest way to a logged-in app; MiAuth needs a browser round-trip.
+
+Get a token from the server (first admin on an empty instance):
+
+```bash
+curl -X POST http://localhost:3000/api/admin/accounts/create \
+  -H "Content-Type: application/json" \
+  -d '{"username":"miria","password":"..."}'
+curl -X POST http://localhost:3000/api/signin-flow \
+  -H "Content-Type: application/json" \
+  -d '{"username":"miria","password":"..."}'   # -> {"i": "<token>"}
+```
+
+Then drive the login screen:
+
+```bash
+marionette.py tap  --text "APIキーでログイン"
+marionette.py tap  --x 200 --y 328                     # focus サーバー
+marionette.py text --input "http://localhost:3000"
+marionette.py tap  --x 200 --y 378                     # focus APIキー
+marionette.py text --input "<token>"
+marionette.py tap  --type ElevatedButton
+```
+
+The two fields are both bare `TextField`s, so `--type TextField` always hits the
+first one. Tap the field by coordinate, then write to `focused` (the default
+matcher for `text`).
+
+**The scheme is required for a local server.** `localhost:3000` alone is tried
+over https, fails the TLS handshake, and you get
+「サーバーとして認識できませんでした」. Use `http://localhost:3000`.
+
+Success looks like the ホームタイムライン screen.
+
+### Post a note
+
+From the timeline, the composer is the `TextField` pinned to the bottom:
+
+```bash
+marionette.py tap  --x 150 --y 640     # composer
+marionette.py text --input "marionette から投稿しました"
+marionette.py tap  --x 304 --y 640     # send
+```
+
+A `MisskeyNote` appears in the element list and the composer clears. Confirm on
+the server rather than trusting the UI:
+
+```bash
+curl -X POST http://localhost:3000/api/users/notes \
+  -H "Content-Type: application/json" -d '{"userId":"<id>","limit":5}'
+```
+
+### Inspect state
+
+```bash
+marionette.py snapshot                    # names and types only — start here
+marionette.py snapshot --filter account --values
+marionette.py read accountRepositoryProvider
+```
+
+Providers that were never read do not appear: Riverpod builds state lazily, so
+there is genuinely nothing to report for them. This is the single most common
+source of "my provider is missing".
+
+Miria's hand-written providers (`ChangeNotifierProvider<...>`, `StateProvider<...>`)
+carry no `name`, so they show up as their type plus `:unnamed`. Codegen
+(`@riverpod`) providers get real names. If you need to address one of the
+unnamed ones repeatedly, giving it a `name:` is worth it.
+
+## 5. Gotchas
+
+- **Read responses as UTF-8.** The VM Service answers in UTF-8; a Windows
+  console defaulting to CP932 turns every Japanese label into mojibake and makes
+  it look like the app is broken when it is not.
+- **Do not run `flutter test` and `flutter run` at once.** They share `build/`
+  and clobber each other's `native_assets.json`.
+- **Give the UI time.** Network-backed transitions need several seconds before
+  the element list settles; a screenshot taken too early shows the old screen.
+- **`take_screenshots` works** on Windows/Impeller — a real PNG, not a blank
+  frame.
+- **Values can contain secrets.** An account object holds its API token, and
+  provider values are dumped best-effort. This is debug-only for that reason;
+  do not paste raw snapshots into anywhere public.
+- **A fresh `flutter run` means a fresh URI.** Nothing caches across launches.

--- a/.claude/skills/drive-miria/reference.md
+++ b/.claude/skills/drive-miria/reference.md
@@ -1,0 +1,191 @@
+# marionette against miria — mechanics and limits
+
+Read `SKILL.md` first; this is the "why" behind it. Everything here was
+observed against a real build (marionette_flutter 0.6.0, Flutter 3.44.6,
+Windows).
+
+## Building on Windows
+
+`permission_handler_windows` passes `/await`, which MSVC 14.51+ rejects
+(`error C2338`, STL1011). Configure the build directory against the v143
+toolset once and Flutter reuses it:
+
+```powershell
+Remove-Item -Recurse -Force build\windows
+& "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" `
+  -S windows -B build\windows\x64 -G "Visual Studio 18 2026" -A x64 -T v143
+fvm flutter run -d windows --debug
+```
+
+Needs the "C++ ATL for v14.42 build tools" component
+(`Microsoft.VisualStudio.Component.VC.14.42.17.12.ATL`), otherwise
+`flutter_secure_storage_windows` fails on `atlstr.h`. Redo the `cmake` step
+after any `flutter clean`.
+
+Do not run `flutter test` while `flutter run` is up — they share `build/` and
+clobber each other's `native_assets.json`.
+
+## Transports
+
+**MCP server.** `.mcp.json` declares it; `dart pub global activate
+marionette_mcp` once, then hand the agent the VM Service URI.
+
+**`scripts/marionette.py`.** Plain HTTP over the VM Service. Every tool is
+also reachable raw as `ext.flutter.marionette.<name>` /
+`ext.flutter.riverpod.<name>` / `ext.flutter.text.submit`, with `isolateId` as
+a query parameter.
+
+`marionette.listExtensions` reports only app-registered extensions, not the
+built-ins. The 17 built-ins are `tap`, `secondaryTap`, `doubleTap`,
+`longPress`, `swipe`, `pinchZoom`, `scrollTo`, `enterText`, `pressKey`,
+`pressBackButton`, `interactiveElements`, `getLogs`, `getVersion`,
+`listExtensions`, `takeScreenshots`, `startScreencast`, `stopScreencast`. Read
+the package for their parameters.
+
+`startScreencast` returns a TCP port carrying a raw frame protocol — for a
+viewer client, not for reading frames as an agent.
+
+## Why note bodies need help
+
+mfm_renderer ends in `Text.rich(TextSpan(children: [WidgetSpan(...)]))`, and
+marionette stops traversing at the first `Text` (built in, not configurable).
+That `Text`'s `toPlainText()` is the WidgetSpan placeholder `￼`, and the inner
+`Text.rich` that holds the real spans is never reached.
+
+`lib/marionette_debug.dart` passes an `extractText` to
+`MarionetteConfiguration` that returns the original text from the `Mfm` /
+`SimpleMfm` widget above it. Those are `InheritedWidget` / `StatefulWidget`,
+visited before the stop, and `Element.renderObject` resolves down to the
+paragraph so bounds and hit testing still work.
+
+Decorations are dropped, `:shortcode:` / `@acct` / `#tag` / URLs kept:
+
+```
+Mfm    '太字 ぷるぷる :neko: @miria #marionette https://example.com code 通常テキスト'
+Text   '￼'
+```
+
+Because `extractText` feeds `TextMatcher` (unlike the `Semantics` fallback,
+which is discovery-only), body text also works for `tap --text`. Verified: on
+a hashtag-only note it reaches the inner `TapGestureRecognizer` and opens the
+hashtag page.
+
+The accessibility question — whether mfm_renderer should carry
+`Semantics`/`semanticsLabel` itself — is separate and unresolved. The package
+currently has none, and ignores `MediaQuery.disableAnimations` for `shake` /
+`jelly` / `spin` / `twitch`.
+
+## Element discovery
+
+`isElementHittable` hit-tests the element's **centre point** and checks the
+render object is in the path. An element whose centre is offscreen or covered
+is dropped from `elements` entirely — a half-scrolled note is absent, not
+merely `visible: false`. Five notes on screen routinely yield three
+`MisskeyNote` entries.
+
+`findElement` stops descending once a node matches, so nested same-type
+widgets are unreachable. `key` matching is `ValueKey<String>` only —
+`ValueKey<int>` and `GlobalKey` do not match. Text matching is exact equality;
+multiple matches silently take the first.
+
+## Input
+
+`enterText` calls `EditableTextState.updateEditingValue`. That means:
+
+- controller listeners and `onChanged` **do** fire (verified: typing `:sm` in
+  the composer flips `inputCompletionTypeProvider` to `Emoji`)
+- the whole value is replaced and the caret collapses to the end — no
+  incremental typing, no IME composition, no selection control
+- `performAction` is **not** called, so `onSubmitted` never runs
+
+`pressKey` dispatches `KeyEvent`s through `HardwareKeyboard` and
+`FocusManager`, which drives `Shortcuts`/`Actions` and focus traversal but
+never reaches `TextInputClient`. So `pressKey enter` cannot submit a field
+either.
+
+`text.submit` (`lib/marionette_debug.dart`) closes the gap by calling
+`EditableTextState.performAction` on the focused field — public API, no
+private imports. It belongs upstream in marionette_flutter, as its own verb or
+an `enterText(submit: true)` option; it lives here until then. A standalone
+plugin is also viable (`registerMarionetteExtension` and
+`ExtensionInputSchema` are exported, as is `WidgetMatcher`), but `WidgetFinder`
+and the hit-test helpers are not, so a matcher-targeted version would have to
+reimplement the tree walk. Focused-only needs nothing private.
+
+Fields driven by `onSubmitted` in miria: `note_search.dart`,
+`play_search.dart`, `user_select_dialog.dart`.
+
+## Scrolling
+
+`scrollTo` derives its attempt budget from the current `maxScrollExtent`
+(`_calculateMaxScrollAttempts`), which a lazily-loaded timeline understates
+badly. It fails with `Widget not found after 44 scroll attempts` even when the
+target is a screen away — observed becoming visible right after the failure.
+
+`swipe` does not accept the `x`/`y` matcher; that is a `tap`-only fast path.
+Passing it yields the misleading `Element matching {x: 190.0, y: 400.0} not
+found`. Use `startX/startY/endX/endY`. The drag has no fling momentum.
+
+## Riverpod
+
+Providers never read are absent — Riverpod builds state lazily. This is the
+usual cause of "my provider is missing".
+
+Values serialize via `toJson()` if present, else `toString()`. miria's
+`ChangeNotifier` repositories have neither, so `TimelineRepository`,
+`NoteRepository` and friends read as `{"runtimeType": "..."}`. **The
+timeline's notes are not reachable through Riverpod** — the element tree or
+the server API are the only routes.
+
+Hand-written providers carry no `name` and appear as their type plus
+`:unnamed`. Three `ChangeNotifierProvider<TimelineRepository>` are live at
+once (home/local/global), so `read` by name fails as ambiguous and the exact
+id is a ~400-character `TabSetting` string. Giving them a `name:` would fix
+this. Codegen (`@riverpod`) providers get real names.
+
+`accountProvider` includes the API token. Never paste a raw snapshot anywhere
+public — this is why the whole binding is debug-only.
+
+## Logs
+
+`get_logs` is effectively empty. miria calls `logger` in seven places, none on
+the common error paths, and `PrintLogCollector` is a pass-through that
+captures neither `print` nor framework errors. An API failure surfaces as a
+dialog whose full text — exception, code, stack — **is** in the element list;
+read that instead.
+
+Wiring `FlutterError.onError` and a `runZoned` print handler into the
+collector would make this tool useful.
+
+## Out of reach
+
+- **Native dialogs.** 「アップロード」 opens a `File Picker` window owned by the
+  miria process. `elements` does not change, `take_screenshots` does not show
+  it (it renders the Flutter scene only), and the VM Service keeps answering —
+  indistinguishable from a tap that did nothing. Detect with `Get-Process | ?
+  { $_.MainWindowTitle }`; dismiss with
+  `(New-Object -ComObject WScript.Shell).AppActivate("File Picker")` then
+  `SendKeys("{ESC}")`. The in-app drive picker (「ドライブから」) is fully
+  driveable.
+- **External browser.** MiAuth (`account_repository.dart`) and note links use
+  `launchUrl(externalApplication)`. Same invisibility. API-key login is the
+  only automatable sign-in for this reason.
+- **Clipboard.** 「内容をコピー」 works but marionette has no clipboard tool —
+  verify with `Get-Clipboard`.
+- **Window control.** No resize or multi-window API, so width-dependent
+  desktop layouts (deck mode) cannot be exercised.
+- **Hot reload.** `flutter run` owns the compiler; calling the VM Service's own
+  `reloadSources` fails with `Error while starting Kernel isolate task`.
+
+## Encoding
+
+The VM Service answers in UTF-8. A Windows console defaulting to CP932 turns
+every Japanese label into mojibake and makes a healthy app look broken. This
+also bites *between* processes: piping UTF-8 JSON into a second `python -c`
+that reads `sys.stdin` with the locale codec produces lone surrogates that
+look exactly like server-side corruption.
+
+`curl -d` with a multibyte JSON body fails with
+`FST_ERR_CTP_INVALID_CONTENT_LENGTH` — the byte length and the character count
+disagree. Write the body to a file and use `--data-binary @file`, or post from
+Python.

--- a/.claude/skills/drive-miria/scripts/.gitignore
+++ b/.claude/skills/drive-miria/scripts/.gitignore
@@ -1,0 +1,1 @@
+.marionette_uri

--- a/.claude/skills/drive-miria/scripts/marionette.py
+++ b/.claude/skills/drive-miria/scripts/marionette.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Talk to a running miria (or any marionette-enabled Flutter app) over the
+Dart VM Service, without needing the marionette_mcp server.
+
+The MCP server is the normal route. This exists for when it is not set up, or
+when you want a scripted, repeatable sequence.
+
+    python marionette.py --uri http://127.0.0.1:49570/_id8d8wYirU=/ elements
+    python marionette.py tap --text "APIキーでログイン"
+    python marionette.py tap --x 200 --y 328
+    python marionette.py text --input "hello"          # focused field
+    python marionette.py shot out.png
+    python marionette.py snapshot --filter account
+
+The URI is printed by `flutter run` as
+"A Dart VM Service on Windows is available at: ...". Pass it with --uri or set
+MARIONETTE_VM_URI; it is cached in .marionette_uri next to this script so
+subsequent calls can omit it.
+"""
+
+import argparse
+import base64
+import io
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# The VM Service answers in UTF-8. Windows consoles often default to CP932,
+# which turns every Japanese label into mojibake.
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+
+CACHE = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".marionette_uri")
+
+
+def resolve_uri(explicit):
+    uri = explicit or os.environ.get("MARIONETTE_VM_URI")
+    if uri:
+        with open(CACHE, "w", encoding="utf-8") as f:
+            f.write(uri)
+        return uri
+    if os.path.exists(CACHE):
+        with open(CACHE, encoding="utf-8") as f:
+            return f.read().strip()
+    sys.exit("No VM Service URI. Pass --uri or set MARIONETTE_VM_URI.")
+
+
+class App:
+    def __init__(self, base):
+        self.base = base if base.endswith("/") else base + "/"
+        self.isolate = self._first_isolate()
+
+    def _get(self, method, params):
+        url = self.base + method + "?" + urllib.parse.urlencode(params)
+        try:
+            with urllib.request.urlopen(url) as r:
+                return json.loads(r.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            return json.loads(e.read().decode("utf-8"))
+
+    def _first_isolate(self):
+        vm = self._get("getVM", {})
+        return vm["result"]["isolates"][0]["id"]
+
+    def call(self, method, **params):
+        params["isolateId"] = self.isolate
+        result = self._get(method, params)
+        if "error" in result:
+            raise SystemExit(json.dumps(result["error"], ensure_ascii=False, indent=1))
+        return result["result"]
+
+    def marionette(self, name, **params):
+        return self.call("ext.flutter.marionette." + name, **params)
+
+
+def cmd_elements(app, args):
+    """Print the interactive widget tree, one line per element.
+
+    This is the map you navigate by: match on `text` when a widget has a
+    label, fall back to coordinates when several widgets share a type.
+    """
+    for e in app.marionette("interactiveElements")["elements"]:
+        b = e.get("bounds", {})
+        cx = b.get("x", 0) + b.get("width", 0) / 2
+        cy = b.get("y", 0) + b.get("height", 0) / 2
+        print(
+            f"{e.get('type',''):18} {e.get('text','')!r:44} "
+            f"center=({cx:.0f},{cy:.0f})"
+        )
+
+
+def _matcher(args):
+    if args.text:
+        return {"text": args.text}
+    if args.key:
+        return {"key": args.key}
+    if args.x is not None and args.y is not None:
+        return {"x": str(args.x), "y": str(args.y)}
+    if args.type:
+        return {"type": args.type}
+    return {"focused": "true"}
+
+
+def cmd_tap(app, args):
+    print(app.marionette("tap", **_matcher(args))["message"])
+
+
+def cmd_text(app, args):
+    print(app.marionette("enterText", input=args.input, **_matcher(args))["message"])
+
+
+def cmd_shot(app, args):
+    shots = app.marionette("takeScreenshots")["screenshots"]
+    first = shots[0]
+    raw = base64.b64decode(first["data"] if isinstance(first, dict) else first)
+    with open(args.path, "wb") as f:
+        f.write(raw)
+    print(f"{args.path}: {len(raw)} bytes")
+
+
+def cmd_logs(app, args):
+    print(json.dumps(app.marionette("getLogs"), ensure_ascii=False, indent=1))
+
+
+def cmd_snapshot(app, args):
+    params = {"includeValues": "true" if args.values else "false"}
+    if args.filter:
+        params["filter"] = args.filter
+    print(
+        json.dumps(
+            app.call("ext.flutter.riverpod.snapshot", **params),
+            ensure_ascii=False,
+            indent=1,
+        )
+    )
+
+
+def cmd_read(app, args):
+    print(
+        json.dumps(
+            app.call("ext.flutter.riverpod.read", name=args.name),
+            ensure_ascii=False,
+            indent=1,
+        )
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--uri", help="Dart VM Service base URI")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def with_matcher(sp):
+        sp.add_argument("--text", help="match by visible text")
+        sp.add_argument("--type", help="match by widget type, e.g. TextField")
+        sp.add_argument("--key", help="match by widget key")
+        sp.add_argument("--x", type=float)
+        sp.add_argument("--y", type=float)
+        return sp
+
+    sub.add_parser("elements").set_defaults(fn=cmd_elements)
+    with_matcher(sub.add_parser("tap")).set_defaults(fn=cmd_tap)
+    t = with_matcher(sub.add_parser("text"))
+    t.add_argument("--input", required=True)
+    t.set_defaults(fn=cmd_text)
+    s = sub.add_parser("shot")
+    s.add_argument("path")
+    s.set_defaults(fn=cmd_shot)
+    sub.add_parser("logs").set_defaults(fn=cmd_logs)
+    sn = sub.add_parser("snapshot")
+    sn.add_argument("--filter")
+    sn.add_argument("--values", action="store_true", help="include provider values")
+    sn.set_defaults(fn=cmd_snapshot)
+    rd = sub.add_parser("read")
+    rd.add_argument("name")
+    rd.set_defaults(fn=cmd_read)
+
+    args = p.parse_args()
+    args.fn(App(resolve_uri(args.uri)), args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/drive-miria/scripts/marionette.py
+++ b/.claude/skills/drive-miria/scripts/marionette.py
@@ -111,6 +111,39 @@ def cmd_text(app, args):
     print(app.marionette("enterText", input=args.input, **_matcher(args))["message"])
 
 
+def cmd_submit(app, args):
+    """Confirm the focused field, the way a keyboard's done/search key does.
+
+    `enterText` only rewrites the value and `pressKey enter` never reaches
+    `TextInputClient`, so anything wired to `onSubmitted` — note search, for
+    one — needs this. Registered by lib/marionette_debug.dart.
+    """
+    print(app.call("ext.flutter.text.submit", action=args.action)["message"])
+
+
+def cmd_swipe(app, args):
+    """Drag between two points.
+
+    Use this rather than `scroll_to` on the timeline: `scroll_to` sizes its
+    attempt budget from the current `maxScrollExtent`, which a lazily loaded
+    list understates, so it gives up early. Note the coordinate matcher used
+    by `tap` is not accepted here — swipe wants an explicit start and end.
+    """
+    print(
+        app.marionette(
+            "swipe",
+            startX=str(args.start[0]),
+            startY=str(args.start[1]),
+            endX=str(args.end[0]),
+            endY=str(args.end[1]),
+        )["message"]
+    )
+
+
+def cmd_back(app, args):
+    print(app.marionette("pressBackButton")["message"])
+
+
 def cmd_shot(app, args):
     shots = app.marionette("takeScreenshots")["screenshots"]
     first = shots[0]
@@ -165,6 +198,18 @@ def main():
     t = with_matcher(sub.add_parser("text"))
     t.add_argument("--input", required=True)
     t.set_defaults(fn=cmd_text)
+    sb = sub.add_parser("submit")
+    sb.add_argument(
+        "--action",
+        default="done",
+        choices=["done", "go", "search", "send", "next", "previous", "newline"],
+    )
+    sb.set_defaults(fn=cmd_submit)
+    sw = sub.add_parser("swipe")
+    sw.add_argument("--start", type=float, nargs=2, required=True, metavar=("X", "Y"))
+    sw.add_argument("--end", type=float, nargs=2, required=True, metavar=("X", "Y"))
+    sw.set_defaults(fn=cmd_swipe)
+    sub.add_parser("back").set_defaults(fn=cmd_back)
     s = sub.add_parser("shot")
     s.add_argument("path")
     s.set_defaults(fn=cmd_shot)

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,6 +8,12 @@
         "@upstash/context7-mcp"
       ],
       "env": {}
+    },
+    "marionette": {
+      "type": "stdio",
+      "command": "marionette_mcp",
+      "args": [],
+      "env": {}
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,42 @@ fvm flutter pub run cider bump build --bump-build
 fvm flutter pub run cider version
 ```
 
+### 実行中アプリの観測・操作（marionette MCP）
+
+debug ビルドには [marionette_mcp](https://github.com/leancodepl/marionette_mcp)
+の binding が組み込まれており、AI エージェントから実行中のアプリを直接
+操作・観測できる。実装は `lib/marionette_debug.dart`（release では
+`kDebugMode` ガードで丸ごと無効化される）。
+
+```bash
+dart pub global activate marionette_mcp   # 初回のみ
+fvm flutter run                           # コンソールの VM Service URI を控える
+```
+
+`.mcp.json` に `marionette` サーバーを定義済み。エージェントに上記 URI を
+渡して接続させると、以下が使えるようになる。
+
+| ツール | 用途 |
+|---|---|
+| `get_interactive_elements` | ウィジェットツリー（トークン節約版） |
+| `tap` / `enter_text` / `scroll_to` | 画面操作 |
+| `take_screenshots` | スクリーンショット |
+| `get_logs` | `lib/log.dart` の `logger` 出力 |
+| `riverpod_snapshot` | 生きている Provider と値の一覧 |
+| `riverpod_read` | Provider 1 個の値を深く見る |
+
+`riverpod_snapshot` / `riverpod_read` は
+[marionette_riverpod_plugin](https://github.com/shiosyakeyakini-info/marionette_riverpod_plugin)
+が提供する。まだ一度も read されていない
+Provider は Riverpod の遅延生成の仕様上スナップショットに現れない。
+まず `includeValues=false` で一覧を取り、目的の Provider を `riverpod_read`
+で掘るのが効率的。詳細はプラグインの README を参照。
+
+実際に操作する手順（ログイン、ノート投稿、要素の探し方、Windows ビルドの
+ツールセット固定など）は `.claude/skills/drive-miria/` にスキルとしてまとめて
+ある。MCP サーバーを立てずに済ませたい場合の
+`scripts/marionette.py` も同梱している。
+
 ## アーキテクチャ
 
 ### 状態管理

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:media_kit/media_kit.dart";
 import "package:miria/const.dart";
 import "package:miria/l10n/app_localizations.dart";
+import "package:miria/marionette_debug.dart";
 import "package:miria/providers.dart";
 import "package:miria/view/common/dialog/dialog_scope.dart";
 import "package:miria/view/common/error_dialog_listener.dart";
@@ -19,7 +20,9 @@ import "package:stack_trace/stack_trace.dart" as stack_trace;
 import "package:window_manager/window_manager.dart";
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
+  // debug ビルドでは marionette の binding が立ち上がる。
+  // release では通常の WidgetsFlutterBinding と同じ。
+  initializeMarionetteBinding();
   MediaKit.ensureInitialized();
   if (!kIsWeb && (Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
     await windowManager.ensureInitialized();
@@ -30,7 +33,7 @@ Future<void> main() async {
     return stack;
   };
 
-  runApp(const ProviderScope(child: Miria()));
+  runApp(ProviderScope(observers: marionetteObservers, child: const Miria()));
 }
 
 class Miria extends HookConsumerWidget with WidgetsBindingObserver {

--- a/lib/marionette_debug.dart
+++ b/lib/marionette_debug.dart
@@ -9,10 +9,13 @@
 library;
 
 import "package:flutter/foundation.dart";
+import "package:flutter/services.dart";
 import "package:flutter/widgets.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:marionette_flutter/marionette_flutter.dart";
 import "package:marionette_riverpod_plugin/marionette_riverpod_plugin.dart";
+import "package:mfm/mfm.dart";
+import "package:mfm_parser/mfm_parser.dart";
 import "package:miria/log.dart";
 
 /// root [ProviderContainer] を捕捉する observer。
@@ -38,11 +41,183 @@ void initializeMarionetteBinding() {
   // これがないと `get_logs` は「ロガーが未設定」というエラーを返すだけになる。
   final logCollector = PrintLogCollector();
   MarionetteBinding.ensureInitialized(
-    MarionetteConfiguration(logCollector: logCollector),
+    MarionetteConfiguration(
+      logCollector: logCollector,
+      extractText: _extractMfmText,
+    ),
   );
   logger.onLogged = (log, info) => logCollector.addLog(log);
 
   registerRiverpodMarionetteExtensions(containerLocator: _observer!.locate);
+  _registerSubmitTextExtension();
+}
+
+/// `TextInputAction` の名前と値の対応。拡張の `action` パラメータで使う。
+const _textInputActions = <String, TextInputAction>{
+  "done": TextInputAction.done,
+  "go": TextInputAction.go,
+  "search": TextInputAction.search,
+  "send": TextInputAction.send,
+  "next": TextInputAction.next,
+  "previous": TextInputAction.previous,
+  "newline": TextInputAction.newline,
+  "unspecified": TextInputAction.unspecified,
+};
+
+/// フォーカスされているテキストフィールドに「確定」を送る拡張を登録する。
+///
+/// marionette 0.6.0 には submit にあたる操作がない。`enterText` は
+/// [EditableTextState.updateEditingValue] を呼ぶだけで `performAction` を
+/// 呼ばず、`pressKey enter` は [HardwareKeyboard] 経由なので
+/// [TextInputClient] には届かない。結果として `onSubmitted` でしか起動しない
+/// UI（miria ではノート検索）をエージェントから動かせない。
+///
+/// [EditableTextState.performAction] は [TextInputClient] の公開メソッドなので、
+/// 拡張として登録すれば穴は埋まる。本来は marionette_flutter 本体
+/// （あるいは `enterText` の `submit` オプション）に置かれるべきもので、
+/// ここにあるのは上流に入るまでの暫定措置。
+void _registerSubmitTextExtension() {
+  registerMarionetteExtension(
+    name: "text.submit",
+    description:
+        "Sends a TextInputAction to the focused text field, the way a "
+        "software keyboard's confirm key does. enterText only rewrites the "
+        "value and pressKey does not reach TextInputClient, so this is the "
+        "only way to fire onSubmitted / onFieldSubmitted.",
+    inputSchema: const ExtensionInputSchema(
+      description: "Which confirm action to send. The field must be focused.",
+      properties: {
+        "action": ExtensionParam.string(
+          description:
+              "TextInputAction to perform. 'done' finalizes editing and "
+              "unfocuses; 'next'/'previous' move focus; 'newline' is a no-op "
+              "on a multiline field.",
+          defaultValue: "done",
+          enumValues: [
+            "done",
+            "go",
+            "search",
+            "send",
+            "next",
+            "previous",
+            "newline",
+            "unspecified",
+          ],
+        ),
+      },
+    ),
+    callback: (params) async {
+      final name = params["action"] ?? "done";
+      final action = _textInputActions[name];
+      if (action == null) {
+        return MarionetteExtensionResult.invalidParams(
+          'Unknown action "$name". Supported: '
+          "${_textInputActions.keys.join(", ")}.",
+        );
+      }
+
+      final state = _focusedEditableTextState();
+      if (state == null) {
+        return MarionetteExtensionResult.invalidParams(
+          "No text field is focused. Tap the field first, then submit.",
+        );
+      }
+
+      state.performAction(action);
+      WidgetsBinding.instance.scheduleFrame();
+
+      return MarionetteExtensionResult.success({
+        "message": "Performed $name on the focused text field",
+      });
+    },
+  );
+}
+
+/// フォーカス中の [EditableTextState] を返す。無ければ null。
+///
+/// marionette 内部の `TextInputSimulator` と同じ辿り方だが、あちらは
+/// エクスポートされていないので複製している。
+EditableTextState? _focusedEditableTextState() {
+  final context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) {
+    return null;
+  }
+
+  EditableTextState? found;
+  context.visitAncestorElements((element) {
+    if (element case StatefulElement(state: final EditableTextState state)) {
+      found = state;
+      return false;
+    }
+    return true;
+  });
+  return found;
+}
+
+/// ノート本文を marionette の要素ツリーに載せる。
+///
+/// mfm_renderer は最終的に `Text.rich(TextSpan(children: [WidgetSpan(...)]))`
+/// を返す。marionette の走査は [Text] に達した時点で打ち切られ（この挙動は
+/// 設定で外せない）、その [Text] の `toPlainText()` は WidgetSpan の
+/// プレースホルダ `￼` だけなので、本文がまったく読めなくなる。
+///
+/// [Mfm] / [SimpleMfm] は [Text] より上にあるので、ここで元テキストを返せば
+/// 走査が止まる前に拾われる。marionette 側の都合を mfm_renderer に持ち込まず、
+/// debug ビルドだけで完結させるためにこの位置に置いている。
+String? _extractMfmText(Element element) {
+  return switch (element.widget) {
+    Mfm(:final mfmText?) => mfmText,
+    Mfm(:final mfmNode?) => _plainTextOf(mfmNode),
+    SimpleMfm(:final mfmText) => mfmText,
+    _ => null,
+  };
+}
+
+/// パース済みの MFM を、書かれていた文字列に近い平文へ戻す。
+///
+/// 読むための文字列なので厳密な MFM の復元ではない。装飾（`**`、`$[...]`）は
+/// 落として中身だけを繋ぎ、絵文字・メンション・ハッシュタグ・URL は
+/// 表示上そう見える形に整える。
+String? _plainTextOf(List<MfmNode> nodes) {
+  final buffer = StringBuffer();
+
+  void visit(List<MfmNode> nodes) {
+    for (final node in nodes) {
+      switch (node) {
+        case MfmText(:final text):
+          buffer.write(text);
+        case MfmPlain(:final text):
+          buffer.write(text);
+        case MfmUnicodeEmoji(:final emoji):
+          buffer.write(emoji);
+        case MfmEmojiCode(:final name):
+          buffer.write(":$name:");
+        case MfmHashTag(:final hashTag):
+          buffer.write("#$hashTag");
+        case MfmMention(:final acct):
+          buffer.write(acct);
+        case MfmURL(:final value):
+          buffer.write(value);
+        case MfmInlineCode(:final code):
+          buffer.write(code);
+        case MfmCodeBlock(:final code):
+          buffer.write(code);
+        case MfmMathInline(:final formula):
+          buffer.write(formula);
+        case MfmMathBlock(:final formula):
+          buffer.write(formula);
+        case MfmSearch(:final content):
+          buffer.write(content);
+        default:
+          if (node.children case final children?) {
+            visit(children);
+          }
+      }
+    }
+  }
+
+  visit(nodes);
+  return buffer.isEmpty ? null : buffer.toString();
 }
 
 /// [ProviderScope] に渡す observer。release ビルドでは空になる。

--- a/lib/marionette_debug.dart
+++ b/lib/marionette_debug.dart
@@ -1,0 +1,49 @@
+/// marionette_mcp（AI エージェントから実行中アプリを操作・観測する MCP サーバー）
+/// との接続を debug ビルド限定で有効にする。
+///
+/// リリースビルドでは [kDebugMode] ガードによりすべて無効化され、marionette 由来の
+/// コードはツリーシェイクで落ちる。アプリの状態を無制限に読めるため、
+/// リリースに混入させてはならない。
+///
+/// 使い方は `marionette_riverpod_plugin/README.md` を参照。
+library;
+
+import "package:flutter/foundation.dart";
+import "package:flutter/widgets.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:marionette_flutter/marionette_flutter.dart";
+import "package:marionette_riverpod_plugin/marionette_riverpod_plugin.dart";
+import "package:miria/log.dart";
+
+/// root [ProviderContainer] を捕捉する observer。
+///
+/// Riverpod にはグローバルな container レジストリがないため、`riverpod_snapshot`
+/// にどの container を見せるかはアプリ側から渡す必要がある。observer なら
+/// 既存の [ProviderScope] に引数を 1 つ足すだけで済み、
+/// `UncontrolledProviderScope` への組み替えが要らない。
+final _observer = kDebugMode ? MarionetteRiverpodObserver() : null;
+
+/// Flutter の binding を初期化する。
+///
+/// [WidgetsFlutterBinding.ensureInitialized] の代わりに `main()` の先頭で呼ぶこと。
+/// debug 時は marionette の binding（[WidgetsFlutterBinding] の派生）を立て、
+/// release 時は通常の binding を立てる。
+void initializeMarionetteBinding() {
+  if (!kDebugMode) {
+    WidgetsFlutterBinding.ensureInitialized();
+    return;
+  }
+
+  // miria のログ (lib/log.dart) を marionette の `get_logs` に流す。
+  // これがないと `get_logs` は「ロガーが未設定」というエラーを返すだけになる。
+  final logCollector = PrintLogCollector();
+  MarionetteBinding.ensureInitialized(
+    MarionetteConfiguration(logCollector: logCollector),
+  );
+  logger.onLogged = (log, info) => logCollector.addLog(log);
+
+  registerRiverpodMarionetteExtensions(containerLocator: _observer!.locate);
+}
+
+/// [ProviderScope] に渡す observer。release ビルドでは空になる。
+List<ProviderObserver> get marionetteObservers => [?_observer];

--- a/lib/repository/account_repository.dart
+++ b/lib/repository/account_repository.dart
@@ -2,7 +2,6 @@
 
 import "dart:convert";
 
-import "package:dio/dio.dart";
 import "package:flutter/foundation.dart";
 import "package:miria/log.dart";
 import "package:miria/model/account.dart";
@@ -274,10 +273,13 @@ class AccountRepository extends _$AccountRepository {
     await _save();
   }
 
+  /// サーバーが Miria と互換性のある Misskey かどうかを検証する。
+  ///
+  /// まず Misskey の API を素直に叩き、読めなければそのときだけ nodeinfo で
+  /// サーバー種別を調べる。nodeinfo を入口にすると、連合をオフにしたサーバーが
+  /// `.well-known/nodeinfo` を含む連合系エンドポイントを一律 403 で返すため
+  /// ログインできない (#770)。
   Future<void> _validateMisskey(String server) async {
-    //先にnodeInfoを取得する
-    final Response nodeInfo;
-
     final Uri serverUri;
     try {
       serverUri = serverToUri(server);
@@ -285,15 +287,16 @@ class AccountRepository extends _$AccountRepository {
       throw InvalidServerException(server);
     }
 
-    final uri = Uri(
-      scheme: serverUri.scheme,
-      host: serverUri.host,
-      port: serverUri.hasPort ? serverUri.port : null,
-      pathSegments: [".well-known", "nodeinfo"],
+    final hostWithPort = serverUri.hasPort
+        ? "${serverUri.host}:${serverUri.port}"
+        : serverUri.host;
+    final misskey = ref.read(
+      misskeyWithoutAccountProvider("${serverUri.scheme}://$hostWithPort"),
     );
 
+    final List<String> endpoints;
     try {
-      nodeInfo = await ref.read(dioProvider).getUri(uri);
+      endpoints = await misskey.endpoints();
     } catch (e) {
       // HandshakeExceptionの場合、HTTPを使用するよう促す
       if (e.toString().contains("HandshakeException") &&
@@ -301,53 +304,51 @@ class AccountRepository extends _$AccountRepository {
           !server.startsWith("https://")) {
         throw InvalidServerException(server);
       }
+
+      // Misskey として読めなかったので、ここで初めてサーバー種別を調べる。
+      final software = await _fetchSoftware(serverUri);
+      // these software already known as unavailable this app
+      if (software?.name == "mastodon" || software?.name == "fedibird") {
+        throw SoftwareNotSupportedException(software!.name);
+      }
       throw ServerIsNotMisskeyException(server);
     }
-    final nodeInfoHref = nodeInfo.data["links"][0]["href"];
-    final nodeInfoHrefResponse = await ref.read(dioProvider).get(nodeInfoHref);
-    final nodeInfoResult = nodeInfoHrefResponse.data;
 
-    final software = nodeInfoResult["software"]["name"];
-    // these software already known as unavailable this app
-    if (software == "mastodon" || software == "fedibird") {
-      throw SoftwareNotSupportedException(software.toString());
-    }
-
-    final version = nodeInfoResult["software"]["version"];
-
-    try {
-      final serverUrl =
-          "${serverUri.scheme}://${serverUri.host}${serverUri.hasPort ? ':${serverUri.port}' : ''}";
-      final hostWithPort = serverUri.hasPort
-          ? "${serverUri.host}:${serverUri.port}"
-          : serverUri.host;
-      final meta = await ref
-          .read(misskeyWithoutAccountProvider(serverUrl))
-          .meta();
-
-      final endpoints = await ref
-          .read(
-            misskeyProvider(
-              Account.demoAccount(
-                serverUri.host,
-                meta,
-                scheme: serverUri.scheme == "http" ? "http" : null,
-                port: serverUri.hasPort ? serverUri.port : null,
-              ),
-            ),
-          )
-          .endpoints();
-      if (!endpoints.contains("emojis")) {
-        throw SoftwareNotCompatibleException(
-          software.toString(),
-          version.toString(),
-        );
-      }
-    } catch (e) {
+    // Misskey ではあるが、Miria が前提とするエンドポイントを持たない場合。
+    if (!endpoints.contains("emojis")) {
+      final software = await _fetchSoftware(serverUri);
       throw SoftwareNotCompatibleException(
-        software.toString(),
-        version.toString(),
+        software?.name ?? hostWithPort,
+        software?.version ?? "",
       );
+    }
+  }
+
+  /// nodeinfo からソフトウェア名とバージョンを取得する。
+  ///
+  /// 取得できなければ `null`。連合をオフにしたサーバーは nodeinfo を 403 で
+  /// 返すため、取れないこと自体は異常ではない。エラーメッセージを具体的に
+  /// するためだけの情報なので、失敗しても呼び出し側の判定は変えない。
+  Future<({String name, String version})?> _fetchSoftware(Uri serverUri) async {
+    try {
+      final dio = ref.read(dioProvider);
+      final nodeInfo = await dio.getUri(
+        Uri(
+          scheme: serverUri.scheme,
+          host: serverUri.host,
+          port: serverUri.hasPort ? serverUri.port : null,
+          pathSegments: [".well-known", "nodeinfo"],
+        ),
+      );
+      final href = nodeInfo.data["links"][0]["href"];
+      final software = (await dio.get(href.toString())).data["software"];
+      return (
+        name: software["name"].toString(),
+        version: software["version"].toString(),
+      );
+    } catch (e) {
+      logger.warning(e);
+      return null;
     }
   }
 

--- a/lib/view/common/misskey_notes/link_navigator.dart
+++ b/lib/view/common/misskey_notes/link_navigator.dart
@@ -25,15 +25,9 @@ class LinkNavigator {
     // 他サーバーや外部サイトは別アプリで起動する
     if (uri.host != accountContext.getAccount.host) {
       try {
-        await ref
-            .read(dioProvider)
-            .getUri(
-              Uri(
-                scheme: "https",
-                host: uri.host,
-                pathSegments: [".well-known", "nodeinfo"],
-              ),
-            );
+        // nodeinfo は見ない。連合をオフにしたサーバーは 403 を返すため、
+        // ここで弾くと Misskey なのに外部ブラウザに飛んでしまう (#770)。
+        // Misskey かどうかは下の endpoints() で判定できる。
         final meta = await ref
             .read(misskeyWithoutAccountProvider(uri.host))
             .meta();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -937,6 +937,23 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  marionette_flutter:
+    dependency: "direct main"
+    description:
+      name: marionette_flutter
+      sha256: "9bf6aa531157edeb3d94f7c4972367240a1d704bbe9f4ac558ef1a125c4d1a6d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
+  marionette_riverpod_plugin:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: main
+      resolved-ref: "29ab3075aa152f52eac9922b057fbc9829c446b2"
+      url: "https://github.com/shiosyakeyakini-info/marionette_riverpod_plugin.git"
+    source: git
+    version: "0.1.0"
   markdown:
     dependency: transitive
     description:
@@ -1818,7 +1835,7 @@ packages:
     source: hosted
     version: "3.2.5"
   url_launcher_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,16 @@ dependencies:
   flutter_twemoji: ^1.0.1
   mime: ^2.0.0
 
+  # AI エージェントから実行中アプリを操作・観測するための開発用依存
+  # (marionette_mcp)。Dart には debug 限定の依存指定がないため通常の
+  # dependencies に置くが、lib/marionette_debug.dart の kDebugMode ガードにより
+  # release ビルドではツリーシェイクで落ちる。
+  marionette_flutter: ^0.6.0
+  marionette_riverpod_plugin:
+    git:
+      url: https://github.com/shiosyakeyakini-info/marionette_riverpod_plugin.git
+      ref: main
+
 dependency_overrides:
   image_editor:
     git:
@@ -121,6 +131,8 @@ dev_dependencies:
   cider: ^0.2.3
   riverpod_generator: ^4.0.3
   riverpod_lint: ^3.0.0-dev.16
+  # テストで UrlLauncherPlatform.instance を差し替えるために直接参照する
+  url_launcher_platform_interface: ^2.3.2
 
 flutter:
   uses-material-design: true

--- a/test/repository/account_repository/auth_test_data.dart
+++ b/test/repository/account_repository/auth_test_data.dart
@@ -58,6 +58,26 @@ class AuthTestData {
     },
   };
 
+  static Map<String, dynamic> mastodonNodeInfo = {
+    "links": [
+      {
+        "rel": "http://nodeinfo.diaspora.software/ns/schema/2.0",
+        "href": "https://mastodon.social/nodeinfo/2.0",
+      },
+    ],
+  };
+
+  static Map<String, dynamic> mastodonNodeInfo2 = {
+    "version": "2.0",
+    "software": {"name": "mastodon", "version": "4.3.0"},
+    "protocols": ["activitypub"],
+    "openRegistrations": true,
+    "usage": {
+      "users": {"total": 1000},
+    },
+    "metadata": <String, dynamic>{},
+  };
+
   static Map<String, dynamic> oldVerMisskeyNodeInfo = {
     "links": [
       {

--- a/test/repository/account_repository/open_mi_auth_test.dart
+++ b/test/repository/account_repository/open_mi_auth_test.dart
@@ -7,6 +7,7 @@ import "package:miria/providers.dart";
 import "package:miria/repository/account_repository.dart";
 import "package:misskey_dart/misskey_dart.dart";
 import "package:mockito/mockito.dart";
+import "package:url_launcher_platform_interface/url_launcher_platform_interface.dart";
 
 import "../../test_util/mock.mocks.dart";
 import "../../test_util/test_datas.dart";
@@ -25,33 +26,83 @@ void main() {
     );
   });
 
-  test("Activity Pub非対応サーバーの場合、エラーを返すこと", () {
+  test("Misskeyとして読めないサーバーの場合、エラーを返すこと", () async {
     final dio = MockDio();
+    // nodeinfoも引けないので、サーバー種別は特定できない。
     // ignore: discarded_futures
     when(dio.getUri(any)).thenAnswer((_) async => throw TestData.response404);
+    final mockMisskey = MockMisskey();
+    // ignore: discarded_futures
+    when(mockMisskey.endpoints()).thenAnswer((_) async => throw Exception());
     final provider = ProviderContainer(
-      overrides: [dioProvider.overrideWithValue(dio)],
+      overrides: [
+        dioProvider.overrideWithValue(dio),
+        misskeyWithoutAccountProvider.overrideWith((ref, host) => mockMisskey),
+      ],
     );
     final accountRepository = provider.read(accountRepositoryProvider.notifier);
 
-    expect(
+    await expectLater(
       () async => await accountRepository.openMiAuth("sawakai.space"),
       throwsA(isA<ServerIsNotMisskeyException>()),
     );
-    verify(
-      // ignore: discarded_futures
-      dio.getUri(
-        argThat(
-          equals(
-            Uri(
-              scheme: "https",
-              host: "sawakai.space",
-              pathSegments: [".well-known", "nodeinfo"],
-            ),
-          ),
-        ),
+  });
+
+  test("Misskeyとして読めない場合、nodeinfoでソフトウェアを特定すること", () async {
+    final dio = MockDio();
+    when(dio.getUri(any)).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(),
+        data: AuthTestData.mastodonNodeInfo,
       ),
     );
+    when(dio.get(any)).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(),
+        data: AuthTestData.mastodonNodeInfo2,
+      ),
+    );
+    final mockMisskey = MockMisskey();
+    // ignore: discarded_futures
+    when(mockMisskey.endpoints()).thenAnswer((_) async => throw Exception());
+    final provider = ProviderContainer(
+      overrides: [
+        dioProvider.overrideWithValue(dio),
+        misskeyWithoutAccountProvider.overrideWith((ref, host) => mockMisskey),
+      ],
+    );
+    final accountRepository = provider.read(accountRepositoryProvider.notifier);
+
+    await expectLater(
+      () async => await accountRepository.openMiAuth("mastodon.social"),
+      throwsA(isA<SoftwareNotSupportedException>()),
+    );
+  });
+
+  test("連合オフでnodeinfoが403でも、ログインできること", () async {
+    // 連合をオフにしたサーバーは .well-known/nodeinfo を403で返す。
+    // それを入口にすると本来使えるサーバーが弾かれてしまう。
+    // https://github.com/shiosyakeyakini-info/miria/issues/770
+    final dio = MockDio();
+    // ignore: discarded_futures
+    when(dio.getUri(any)).thenAnswer((_) async => throw TestData.response404);
+    final mockMisskey = MockMisskey();
+    when(mockMisskey.endpoints()).thenAnswer((_) async => ["emojis", "meta"]);
+    final mockUrlLauncher = MockUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = mockUrlLauncher;
+    final provider = ProviderContainer(
+      overrides: [
+        dioProvider.overrideWithValue(dio),
+        misskeyWithoutAccountProvider.overrideWith((ref, host) => mockMisskey),
+      ],
+    );
+    final accountRepository = provider.read(accountRepositoryProvider.notifier);
+
+    await accountRepository.openMiAuth("http://localhost:3000");
+
+    // nodeinfoを見に行かずにMisskeyと判定できていること。
+    verifyNever(dio.getUri(any));
+    verify(mockUrlLauncher.launchUrl(any, any));
   });
 
   // test("非対応のソフトウェアの場合、エラーを返すこと", () async {


### PR DESCRIPTION
動作中の miria を AI エージェントから操作・観測できるようにし、その過程で見つかった #770 を修正します。

## 1. marionette の導入

debug ビルドに [marionette](https://github.com/leancodepl/marionette_mcp) の binding を組み込みます。エージェントがウィジェットツリー・ログ・スクリーンショット・タップ/入力を扱えるようになります。

初期化は `lib/marionette_debug.dart` にまとめ、`main.dart` の変更は2行に留めました。`lib/log.dart` の `logger` を marionette の `LogCollector` に繋いだので、`get_logs` が miria のログを返します。

`kDebugMode` ガードにより release ビルドではツリーシェイクで落ちます。アプリの状態を無制限に読めるため、リリースに混入させてはいけません。

## 2. Riverpod の状態を読めるようにする

marionette はウィジェットツリーまでは見えますが、状態レイヤーは見えません。Riverpod アプリではそこにこそ大半の挙動が宿るため、別リポジトリに [marionette_riverpod_plugin](https://github.com/shiosyakeyakini-info/marionette_riverpod_plugin) を作り、git 依存で参照しています。

| MCP ツール | 内容 |
|---|---|
| `riverpod_snapshot` | 現在生きている Provider と値の一覧 |
| `riverpod_read` | Provider 1個をより深く |

root `ProviderContainer` の受け渡しは `ProviderObserver` で行っています。公開 API だけで済み、`ProviderScope` に引数を1つ足すだけで `UncontrolledProviderScope` への組み替えが要りません。

## 3. 連合オフのサーバーでログインできない問題を修正 (#770)

`federation = none` のサーバーは `.well-known/nodeinfo` を含む連合系エンドポイントを一律 403 で返します。これを入口にしていたため、本来使えるサーバーが弾かれていました。

issue の方針どおり、まず `api/endpoints` を素直に叩き、**読めなかった場合に限って** nodeinfo でサーバー種別を調べる形に変えています。Mastodon のように Misskey ではないと分かっているソフトウェアは従来どおり名指しで伝えられます。

`link_navigator` の nodeinfo 呼び出しも削除しました。結果を捨てて到達性チェックにしか使っておらず、後続の `endpoints()` で十分だったためです。

**補足:** `meta()` は判定経路から外しました。現行の misskey_dart は古い Misskey の `meta` をパースできず `MetaResponse.fromJson` が投げるため、これを必須にすると古いサーバーが「Misskeyではない」と誤判定されます。旧実装は全例外を握り潰していたため露見していませんでした。

## 4. 操作手順をスキル化

`.claude/skills/drive-miria/` に、起動 → 接続 → 要素の探し方 → 検証済みレシピ（APIキーログイン / ノート投稿 / 状態確認）→ ハマりどころ をまとめました。MCP サーバーを立てずに VM Service を直接叩く `scripts/marionette.py` も同梱しています。

書いてあるのは実際に通した手順のみです。

## 検証

ローカルの Misskey 2026.7.0（`federation = none`）に対して、**marionette 経由で起動 → APIキーでログイン → ノート投稿** まで通し、サーバー API でもノートを確認しました。

| | 結果 |
|---|---|
| `flutter test` | **384件パス** |
| `dart analyze lib` | 追加分の指摘なし |
| プラグイン側 | 40件パス / analyze クリーン |
| `take_screenshots` | Windows/Impeller で正常な PNG |

## レビュー時の注意

- **コミットは2つに分かれています。** marionette 導入と #770 修正は独立しているので、分割したい場合は言ってください
- `pubspec.yaml` の `url_launcher_platform_interface`（dev_dependencies）は #770 のテスト用ですが、pubspec を分割できないため1つ目のコミットに入っています
- **Windows ビルドには別途 v143 ツールセットの固定が必要です**（`permission_handler_windows` が `/await` を付けており MSVC 14.51+ が拒否するため）。手順はスキルに書いてあります。これはフォーク側の問題なので本 PR では触っていません
- ローカルサーバーへの接続はスキーマの明示が必要です（`localhost:3000` ではなく `http://localhost:3000`）。#731 の範囲なので手を付けていません

Closes #770
