### PR TITLE
feat(marionette): ボタン配下のテキストをラベルとして要素一覧に載せる

### DIFF
--- a/.claude/skills/drive-miria/SKILL.md
+++ b/.claude/skills/drive-miria/SKILL.md
@@ -84,6 +84,11 @@ Note bodies are readable — they surface as `Mfm` / `SimpleMfm` elements with
 the text flattened the way it looks on screen, and are valid `--text`
 matchers. The `Text '￼'` sitting at the same spot is the same note; ignore it.
 
+Buttons carry their own label, so a confirm dialog reads `TextButton '削除する'`
+/ `TextButton 'やっぱやめる'` rather than two anonymous buttons — match those by
+`--text`, never by guessing which side is affirmative. Icon-only buttons stay
+empty; the icon glyph is deliberately kept out of the label.
+
 ## The screen
 
 Coordinates below are for the default 384×661 window. Tabs are user

--- a/.claude/skills/drive-miria/reference.md
+++ b/.claude/skills/drive-miria/reference.md
@@ -75,6 +75,26 @@ The accessibility question — whether mfm_renderer should carry
 currently has none, and ignores `MediaQuery.disableAnimations` for `shake` /
 `jelly` / `spin` / `twitch`.
 
+### Button labels
+
+Traversal stops at every interactive widget except `GestureDetector` and
+`InkWell` (`_isBuiltInStopWidget`), so a Material button's child `Text` is
+never emitted. Tabs built on `InkWell` kept their label, but every
+`TextButton` / `ElevatedButton` / `OutlinedButton` arrived as `''` — a confirm
+dialog was two anonymous buttons at two coordinates, and the affirmative is
+not reliably the right-hand one (`削除する` sits on the **left**). That
+mis-tap happened.
+
+`extractText` runs before traversal stops, so `_extractButtonLabel` in
+`lib/marionette_debug.dart` walks the button's own subtree and joins the
+`Text` it finds. Only widgets that stop traversal are eligible, so no new
+elements appear — these are already interactive and listed, and only their
+empty `text` gets filled.
+
+`Icon` subtrees are skipped: `Icon` builds a `RichText` whose plain text is a
+private-use codepoint, which would turn every icon button into `''`-grade
+noise. Icon-only buttons therefore stay empty, which is the honest answer.
+
 ## Element discovery
 
 `isElementHittable` hit-tests the element's **centre point** and checks the

--- a/lib/marionette_debug.dart
+++ b/lib/marionette_debug.dart
@@ -9,8 +9,8 @@
 library;
 
 import "package:flutter/foundation.dart";
+import "package:flutter/material.dart";
 import "package:flutter/services.dart";
-import "package:flutter/widgets.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:marionette_flutter/marionette_flutter.dart";
 import "package:marionette_riverpod_plugin/marionette_riverpod_plugin.dart";
@@ -43,7 +43,7 @@ void initializeMarionetteBinding() {
   MarionetteBinding.ensureInitialized(
     MarionetteConfiguration(
       logCollector: logCollector,
-      extractText: _extractMfmText,
+      extractText: extractMarionetteText,
     ),
   );
   logger.onLogged = (log, info) => logCollector.addLog(log);
@@ -172,6 +172,81 @@ String? _extractMfmText(Element element) {
     _ => null,
   };
 }
+
+/// marionette の `extractText` に渡す本体。
+///
+/// 組み込みの抽出（[Text] や [TextField] など）が null を返したときだけ呼ばれる。
+@visibleForTesting
+String? extractMarionetteText(Element element) =>
+    _extractMfmText(element) ?? _extractButtonLabel(element);
+
+/// ラベルを直接持たないボタン類に、配下の [Text] をラベルとして与える。
+///
+/// marionette は操作可能ウィジェットで走査を打ち切る（`shouldStopAtType`）。
+/// [InkWell] と [GestureDetector] だけは例外で子まで降りるため、それらで
+/// 組まれたタブなどはラベルが要素一覧に出る。一方 Material のボタン類は
+/// 走査が止まるので、子の [Text] が一覧にまったく現れない。結果、確認
+/// ダイアログの「削除する」「やっぱやめる」がどちらも `TextButton ''` になり、
+/// 座標でしか撃ち分けられなくなる（実際に取り違えが起きた）。
+///
+/// 走査が止まる前に呼ばれる `extractText` で配下を自前で辿ってラベルを
+/// 組み立てれば、`tap --text "削除する"` が通るようになる。
+///
+/// 走査が止まるウィジェットにしか適用しないので、要素の数は増えない。
+/// これらは元から操作可能で一覧に載っており、空だった `text` が埋まるだけ。
+String? _extractButtonLabel(Element element) {
+  if (!_isLabelledButton(element.widget)) return null;
+
+  final parts = <String>[];
+
+  void visit(Element element) {
+    if (parts.length >= _maxLabelParts) return;
+
+    // アイコンは [Icon] が内部で [RichText] を作り、その平文はフォントの
+    // 私用領域のコードポイント（`` など）になる。ラベルとしては
+    // ノイズにしかならないので、[Icon] より下は見ない。
+    if (element.widget is Icon) return;
+
+    final text = _extractMfmText(element) ?? _labelTextOf(element.widget);
+    if (text != null) {
+      final trimmed = text.trim();
+      if (trimmed.isNotEmpty) parts.add(trimmed);
+      // [Text] より下は同じ文字列の作り直しなので降りない。
+      return;
+    }
+
+    element.visitChildren(visit);
+  }
+
+  element.visitChildren(visit);
+
+  return parts.isEmpty ? null : parts.join(" ");
+}
+
+/// ラベルを合成する対象。いずれも marionette の走査が止まるウィジェット。
+bool _isLabelledButton(Widget widget) =>
+    widget is ButtonStyleButton ||
+    widget is FloatingActionButton ||
+    widget is IconButton ||
+    widget is DropdownButton ||
+    widget is PopupMenuButton ||
+    widget is CheckboxListTile ||
+    widget is RadioListTile ||
+    widget is SwitchListTile;
+
+/// ラベルとして読める平文を持つウィジェットならそれを返す。
+String? _labelTextOf(Widget widget) => switch (widget) {
+  Text(:final data?) => data,
+  Text(:final textSpan?) => textSpan.toPlainText(),
+  RichText(:final text) => text.toPlainText(),
+  _ => null,
+};
+
+/// 1 つのボタンから拾うラベルの上限。
+///
+/// アイコン + 短い語という構成を想定しており、これを超える要素を持つボタンの
+/// 全文が要るとは考えにくい。走査が止まらない構造を踏んだときの保険でもある。
+const _maxLabelParts = 4;
 
 /// パース済みの MFM を、書かれていた文字列に近い平文へ戻す。
 ///

--- a/test/marionette_debug_test.dart
+++ b/test/marionette_debug_test.dart
@@ -1,0 +1,105 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:miria/marionette_debug.dart";
+
+/// [extractMarionetteText] は marionette の走査から呼ばれるので、
+/// テストからも同じように [Element] を渡して確かめる。
+String? labelOf(WidgetTester tester, Finder finder) =>
+    extractMarionetteText(tester.element(finder));
+
+Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+  MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  ),
+);
+
+void main() {
+  group("ボタンのラベル抽出", () {
+    testWidgets("TextButton のラベルが読めること", (tester) async {
+      await pump(
+        tester,
+        TextButton(onPressed: () {}, child: const Text("削除する")),
+      );
+
+      expect(labelOf(tester, find.byType(TextButton)), "削除する");
+    });
+
+    testWidgets("ElevatedButton / OutlinedButton も読めること", (tester) async {
+      await pump(
+        tester,
+        Column(
+          children: [
+            ElevatedButton(onPressed: () {}, child: const Text("更新")),
+            OutlinedButton(onPressed: () {}, child: const Text("削除")),
+          ],
+        ),
+      );
+
+      expect(labelOf(tester, find.byType(ElevatedButton)), "更新");
+      expect(labelOf(tester, find.byType(OutlinedButton)), "削除");
+    });
+
+    testWidgets("アイコン付きボタンでアイコンがラベルに混ざらないこと", (tester) async {
+      await pump(
+        tester,
+        ElevatedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.add),
+          label: const Text("作成"),
+        ),
+      );
+
+      // Icon が内部で作る RichText の平文はフォントの私用領域の
+      // コードポイントなので、拾ってしまうと読めないラベルになる。
+      expect(labelOf(tester, find.byType(ElevatedButton)), "作成");
+    });
+
+    testWidgets("ラベルのないアイコンボタンは null のままであること", (tester) async {
+      await pump(
+        tester,
+        IconButton(onPressed: () {}, icon: const Icon(Icons.close)),
+      );
+
+      expect(labelOf(tester, find.byType(IconButton)), isNull);
+    });
+
+    testWidgets("入れ子になったラベルも読めること", (tester) async {
+      await pump(
+        tester,
+        TextButton(
+          onPressed: () {},
+          child: const Padding(
+            padding: EdgeInsets.all(4),
+            child: Text("やっぱやめる"),
+          ),
+        ),
+      );
+
+      expect(labelOf(tester, find.byType(TextButton)), "やっぱやめる");
+    });
+
+    testWidgets("SwitchListTile のラベルが読めること", (tester) async {
+      await pump(
+        tester,
+        SwitchListTile(
+          value: true,
+          onChanged: (_) {},
+          title: const Text("ミュートする"),
+        ),
+      );
+
+      expect(labelOf(tester, find.byType(SwitchListTile)), "ミュートする");
+    });
+
+    testWidgets("ボタン以外は対象にならないこと", (tester) async {
+      // ここでラベルを返すと、操作できないウィジェットまで要素一覧に
+      // 載ってしまい、一覧が膨らむ。
+      await pump(
+        tester,
+        const Padding(padding: EdgeInsets.all(4), child: Text("ただの文字")),
+      );
+
+      expect(labelOf(tester, find.byType(Padding).first), isNull);
+    });
+  });
+}


### PR DESCRIPTION
marionette の要素一覧で、Material のボタン類のラベルが読めるようにします。

## 何が問題だったか

marionette は操作可能ウィジェットで走査を打ち切ります（`_isBuiltInStopWidget`）。`InkWell` と `GestureDetector` だけは例外で子まで降りるため、それらで組まれたタブのラベルは要素一覧に出ます。一方 Material のボタン類は走査が止まるので、子の `Text` がまったく現れません。

結果、確認ダイアログが「座標の違う無名のボタン2つ」になります。

```
Text               'ほんまに消してええな？'      center=(192,306)
TextButton         ''                        center=(179,364)
TextButton         ''                        center=(274,364)
```

肯定側が右とは限らず（「削除する」は**左**）、座標で撃ち分けるしかありません。実際 #808 の動作確認中に取り違えて、ルーム削除のつもりでキャンセルを踏みました。スクリーンショットを撮って初めて気づけるという状態です。

## 変更内容

走査が止まる前に呼ばれる `extractText` で、ボタン自身の subtree を辿ってラベルを組み立てます。

```
Text               'ほんまに消してええな？'      center=(192,306)
TextButton         '削除する'                  center=(179,364)
TextButton         'やっぱやめる'               center=(274,364)
```

`tap --text "削除する"` が通るようになります。

設計上のポイントが2つあります。

**要素は増えません。** 対象は走査が止まるウィジェットだけに限っています。これらは元から操作可能で一覧に載っているので、空だった `text` が埋まるだけです。ボタン以外にラベルを返すと、操作できないウィジェットまで一覧に載って肥大化するため、そこは意図的に対象外にしています（テストで固定しました）。

**`Icon` 配下は見ません。** `Icon` は内部で `RichText` を作りますが、その平文はフォントの私用領域のコードポイント（`` など）です。拾うと読めないラベルになるため除外しています。アイコンだけのボタンは空のままです。

marionette 本体はフォークせず、`MarionetteConfiguration.extractText` の既存の口だけで完結しています。debug ビルド限定なのも従来通りです。

## 確認

- `flutter test` 391件パス（`test/marionette_debug_test.dart` に7件追加）
- `dart analyze` エラー0件
- 実機（Windows debug）で marionette 経由で確認:
  - `ElevatedButton '更新'` / `OutlinedButton '削除'` / `ElevatedButton '作成'` がラベル付きで出ること
  - `tap --text "やっぱやめる"` でキャンセルされ、ルームが消えないこと
  - `tap --text "削除する"` で削除され、サーバー側の `chat/rooms/owned` が0件になること
  - アイコンのみのボタンが空のままであること

スキル側のドキュメント（`SKILL.md` / `reference.md`）も併せて更新しています。