### PR TITLE
fix: チャットで添付ファイルの情報を変更できるようにする

### DIFF
--- a/lib/state_notifier/chat_input_state_notifier.dart
+++ b/lib/state_notifier/chat_input_state_notifier.dart
@@ -8,6 +8,7 @@ import "package:miria/model/image_file.dart";
 import "package:miria/providers.dart";
 import "package:miria/router/app_router.dart";
 import "package:miria/view/note_create_page/drive_modal_sheet.dart";
+import "package:miria/view/note_create_page/file_settings_dialog.dart";
 import "package:misskey_dart/misskey_dart.dart";
 import "package:path/path.dart" as p;
 import "package:path_provider/path_provider.dart";
@@ -49,6 +50,77 @@ class ChatInputStateNotifier extends _$ChatInputStateNotifier {
 
   void clearFiles() {
     state = state.copyWith(files: []);
+  }
+
+  /// ファイルのメタデータを変更する
+  ///
+  /// ドライブから添付したファイルは `isEdited` を立てておき、送信時に
+  /// `drive/files/update` を投げる。
+  void setFileMetaData(int index, FileSettingsDialogResult result) {
+    if (index < 0 || index >= state.files.length) return;
+    final files = state.files.toList();
+    final file = files[index];
+
+    files[index] = switch (file) {
+      ImageFile() => ImageFile(
+        data: file.data,
+        fileName: result.fileName,
+        isNsfw: result.isNsfw,
+        caption: result.caption,
+      ),
+      ImageFileAlreadyPostedFile() => ImageFileAlreadyPostedFile(
+        data: file.data,
+        id: file.id,
+        fileName: result.fileName,
+        isNsfw: result.isNsfw,
+        caption: result.caption,
+        isEdited: true,
+      ),
+      UnknownFile() => UnknownFile(
+        data: file.data,
+        fileName: result.fileName,
+        isNsfw: result.isNsfw,
+        caption: result.caption,
+      ),
+      UnknownAlreadyPostedFile() => UnknownAlreadyPostedFile(
+        url: file.url,
+        id: file.id,
+        fileName: result.fileName,
+        isNsfw: result.isNsfw,
+        caption: result.caption,
+        isEdited: true,
+      ),
+    };
+
+    state = state.copyWith(files: files);
+  }
+
+  /// ドライブのファイル情報を更新する
+  ///
+  /// misskey_dartの`drive.files.update`はFreezedのtoJsonを経由するため
+  /// undefinedとnullを区別できず、`comment: null`を渡すとキーごと削除される。
+  /// 一方で説明が空のときに`comment: ''`を送ると、Misskey Webが
+  /// ALTテキストとしてファイル名を表示しなくなってしまう。
+  /// そのためapiServiceを直接呼び、commentについてはnullをそのまま送る。
+  Future<void> _updateDriveFile({
+    required String fileId,
+    required String name,
+    required bool isSensitive,
+    required String? comment,
+  }) async {
+    await ref
+        .read(misskeyPostContextProvider)
+        .apiService
+        .post<Map<String, dynamic>>(
+          "drive/files/update",
+          DriveFilesUpdateRequest(
+            fileId: fileId,
+            name: name,
+            isSensitive: isSensitive,
+            comment: comment,
+          ).toJson(),
+          excludeRemoveNullPredicate: (key, _) => key == "comment",
+        );
   }
 
   Future<void> chooseFile() async {
@@ -166,6 +238,14 @@ class ChatInputStateNotifier extends _$ChatInputStateNotifier {
           file.data,
         );
       case ImageFileAlreadyPostedFile():
+        if (file.isEdited) {
+          await _updateDriveFile(
+            fileId: file.id,
+            name: file.fileName,
+            isSensitive: file.isNsfw,
+            comment: file.caption,
+          );
+        }
         clearFiles();
         return file.id;
       case UnknownFile():
@@ -178,13 +258,19 @@ class ChatInputStateNotifier extends _$ChatInputStateNotifier {
           file.data,
         );
       case UnknownAlreadyPostedFile():
+        if (file.isEdited) {
+          await _updateDriveFile(
+            fileId: file.id,
+            name: file.fileName,
+            isSensitive: file.isNsfw,
+            comment: file.caption,
+          );
+        }
         clearFiles();
         return file.id;
     }
 
     clearFiles();
     return uploadedFile.id;
-
-    return null;
   }
 }

--- a/lib/view/chat_page/chat_file_preview.dart
+++ b/lib/view/chat_page/chat_file_preview.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:miria/l10n/app_localizations.dart";
 import "package:miria/model/image_file.dart";
@@ -16,226 +18,125 @@ class ChatFilePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    switch (file) {
-      case ImageFile():
-        return Stack(
-          children: [
-            Container(
+    return Stack(
+      children: [
+        // 以前は onFileSettingChanged を受け取っていながら、どこからも
+        // 呼んでいなかったため、ファイルの情報を変更する手段がなかった (#854)。
+        GestureDetector(
+          key: ValueKey("chatFile:${file.fileName}"),
+          // サムネイルは中身が透けている箇所があるので、枠全体で受ける
+          behavior: HitTestBehavior.opaque,
+          onTap: () => unawaited(onFileSettingChanged(file)),
+          child: _Thumbnail(file: file),
+        ),
+        Positioned(
+          top: 0,
+          right: 0,
+          child: Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface.withAlpha(200),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: IconButton(
+              icon: const Icon(Icons.close, size: 16),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
+              // 既定のタップ領域は48x48あり、80x80のサムネイルの中心まで
+              // 覆ってしまう。見た目どおりの24x24に狭める。
+              style: IconButton.styleFrom(
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              onPressed: onFileDeleted,
+            ),
+          ),
+        ),
+        if (file.isNsfw)
+          Positioned(
+            bottom: 4,
+            left: 4,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Theme.of(context).dividerColor),
+                color: Colors.red,
+                borderRadius: BorderRadius.circular(4),
               ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Image.memory(
-                  (file as ImageFile).data,
-                  width: 80,
-                  height: 80,
-                  fit: BoxFit.cover,
+              child: Text(
+                S.of(context).chatNsfw,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
             ),
-            Positioned(
-              top: 0,
-              right: 0,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface.withAlpha(200),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: IconButton(
-                  icon: const Icon(Icons.close, size: 16),
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(
-                    minWidth: 24,
-                    minHeight: 24,
-                  ),
-                  onPressed: onFileDeleted,
-                ),
-              ),
-            ),
-            if (file.isNsfw)
-              Positioned(
-                bottom: 4,
-                left: 4,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 2,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.red,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  child: Text(
-                    S.of(context).chatNsfw,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 10,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ),
-          ],
-        );
-      case UnknownFile():
-        return Stack(
-          children: [
-            Container(
-              width: 80,
-              height: 80,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Theme.of(context).dividerColor),
-                color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              ),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Icon(Icons.insert_drive_file, size: 32),
-                  const SizedBox(height: 4),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
-                    child: Text(
-                      file.fileName,
-                      style: const TextStyle(fontSize: 10),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Positioned(
-              top: 0,
-              right: 0,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface.withAlpha(200),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: IconButton(
-                  icon: const Icon(Icons.close, size: 16),
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(
-                    minWidth: 24,
-                    minHeight: 24,
-                  ),
-                  onPressed: onFileDeleted,
-                ),
-              ),
-            ),
-          ],
-        );
-      case ImageFileAlreadyPostedFile():
-        return Stack(
-          children: [
-            Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Theme.of(context).dividerColor),
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
+          ),
+      ],
+    );
+  }
+}
 
-                child: Image.memory(
-                  (file as ImageFileAlreadyPostedFile).data,
-                  width: 80,
-                  height: 80,
-                  fit: BoxFit.cover,
-                ),
-              ),
-            ),
-            Positioned(
-              top: 0,
-              right: 0,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface.withAlpha(200),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: IconButton(
-                  icon: const Icon(Icons.close, size: 16),
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(
-                    minWidth: 24,
-                    minHeight: 24,
-                  ),
-                  onPressed: onFileDeleted,
-                ),
-              ),
-            ),
-            if (file.isNsfw)
-              Positioned(
-                bottom: 4,
-                left: 4,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 2,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.red,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  child: Text(
-                    S.of(context).chatNsfw,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 10,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ),
-          ],
-        );
-      case UnknownAlreadyPostedFile():
-        return Stack(
+class _Thumbnail extends StatelessWidget {
+  final MisskeyPostFile file;
+
+  const _Thumbnail({required this.file});
+
+  @override
+  Widget build(BuildContext context) {
+    final border = BoxDecoration(
+      borderRadius: BorderRadius.circular(8),
+      border: Border.all(color: Theme.of(context).dividerColor),
+    );
+
+    return switch (file) {
+      ImageFile(:final data) ||
+      ImageFileAlreadyPostedFile(:final data) => Container(
+        decoration: border,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: Image.memory(data, width: 80, height: 80, fit: BoxFit.cover),
+        ),
+      ),
+      UnknownFile() => Container(
+        width: 80,
+        height: 80,
+        decoration: border.copyWith(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Theme.of(context).dividerColor),
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: SizedBox(
-                  width: 80,
-                  height: 80,
-                  child: Center(
-                    child: Icon(
-                      Icons.insert_drive_file,
-                      size: 40,
-                      color: Colors.grey,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            Positioned(
-              top: 0,
-              right: 0,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface.withAlpha(200),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: IconButton(
-                  icon: const Icon(Icons.close, size: 16),
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(
-                    minWidth: 24,
-                    minHeight: 24,
-                  ),
-                  onPressed: onFileDeleted,
-                ),
+            const Icon(Icons.insert_drive_file, size: 32),
+            const SizedBox(height: 4),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                file.fileName,
+                style: const TextStyle(fontSize: 10),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
               ),
             ),
           ],
-        );
-    }
+        ),
+      ),
+      UnknownAlreadyPostedFile() => Container(
+        decoration: border,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: const SizedBox(
+            width: 80,
+            height: 80,
+            child: Center(
+              child: Icon(
+                Icons.insert_drive_file,
+                size: 40,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+        ),
+      ),
+    };
   }
 }

--- a/lib/view/chat_page/room_chat.dart
+++ b/lib/view/chat_page/room_chat.dart
@@ -505,36 +505,16 @@ class RoomChatTextField extends HookConsumerWidget {
                         .read(chatInputStateProvider.notifier)
                         .removeFile(index),
                     onFileSettingChanged: (file) async {
-                      final editedFile =
+                      final result =
                           await showDialog<FileSettingsDialogResult?>(
                             context: context,
                             builder: (context) =>
                                 FileSettingsDialog(file: file),
                           );
-                      if (editedFile != null) {
-                        // NSFWやキャプションの変更を反映
-                        final updatedFile = switch (file) {
-                          ImageFile() => ImageFile(
-                            data: file.data,
-                            fileName: file.fileName,
-                            isNsfw: editedFile.isNsfw,
-                            caption: editedFile.caption,
-                          ),
-                          UnknownFile() => UnknownFile(
-                            data: file.data,
-                            fileName: file.fileName,
-                            isNsfw: editedFile.isNsfw,
-                            caption: editedFile.caption,
-                          ),
-                          _ => file,
-                        };
-                        ref
-                            .read(chatInputStateProvider.notifier)
-                            .removeFile(index);
-                        await ref
-                            .read(chatInputStateProvider.notifier)
-                            .addFile(updatedFile);
-                      }
+                      if (result == null) return;
+                      ref
+                          .read(chatInputStateProvider.notifier)
+                          .setFileMetaData(index, result);
                     },
                   ),
                 );

--- a/lib/view/chat_page/user_chat.dart
+++ b/lib/view/chat_page/user_chat.dart
@@ -489,36 +489,16 @@ class UserChatTextField extends HookConsumerWidget {
                         .read(chatInputStateProvider.notifier)
                         .removeFile(index),
                     onFileSettingChanged: (file) async {
-                      final editedFile =
+                      final result =
                           await showDialog<FileSettingsDialogResult?>(
                             context: context,
                             builder: (context) =>
                                 FileSettingsDialog(file: file),
                           );
-                      if (editedFile != null) {
-                        // NSFWやキャプションの変更を反映
-                        final updatedFile = switch (file) {
-                          ImageFile() => ImageFile(
-                            data: file.data,
-                            fileName: file.fileName,
-                            isNsfw: editedFile.isNsfw,
-                            caption: editedFile.caption,
-                          ),
-                          UnknownFile() => UnknownFile(
-                            data: file.data,
-                            fileName: file.fileName,
-                            isNsfw: editedFile.isNsfw,
-                            caption: editedFile.caption,
-                          ),
-                          _ => file,
-                        };
-                        ref
-                            .read(chatInputStateProvider.notifier)
-                            .removeFile(index);
-                        await ref
-                            .read(chatInputStateProvider.notifier)
-                            .addFile(updatedFile);
-                      }
+                      if (result == null) return;
+                      ref
+                          .read(chatInputStateProvider.notifier)
+                          .setFileMetaData(index, result);
                     },
                   ),
                 );

--- a/test/state_notifier/chat_input_state_notifier_test.dart
+++ b/test/state_notifier/chat_input_state_notifier_test.dart
@@ -11,7 +11,9 @@ import "package:miria/providers.dart";
 import "package:miria/router/app_router.dart";
 import "package:miria/state_notifier/chat_input_state_notifier.dart";
 import "package:miria/view/note_create_page/drive_modal_sheet.dart";
+import "package:miria/view/note_create_page/file_settings_dialog.dart";
 import "package:misskey_dart/misskey_dart.dart" show DriveFile;
+import "package:misskey_dart/src/services/api_service.dart";
 import "package:mockito/mockito.dart";
 import "package:path/path.dart" as p;
 
@@ -34,6 +36,22 @@ class TestAppRouter extends AppRouter {
       return driveFileSelectReturnValue as T?;
     }
     return null;
+  }
+}
+
+/// `drive/files/update` に送られたリクエストを記録するApiService
+class RecordingApiService extends Fake implements ApiService {
+  final requests =
+      <(String, Map<String, dynamic>, bool Function(String, String?)?)>[];
+
+  @override
+  Future<T> post<T>(
+    String path,
+    Map<String, dynamic> request, {
+    bool Function(String, String?)? excludeRemoveNullPredicate,
+  }) async {
+    requests.add((path, request, excludeRemoveNullPredicate));
+    return TestData.drive1.toJson() as T;
   }
 }
 
@@ -470,6 +488,107 @@ void main() {
         // クリア後の確認
         state = container.read(chatInputStateProvider);
         expect(state.files, isEmpty);
+      });
+    });
+
+    // ChatFilePreview から onFileSettingChanged が呼ばれても、反映する先が
+    // なかった。
+    // https://github.com/shiosyakeyakini-info/miria/issues/854
+    group("ファイル情報の変更", () {
+      test("アップロード予定のファイルの名前・説明・NSFWを変更できること", () async {
+        final notifier = container.read(chatInputStateProvider.notifier);
+        await notifier.addFile(
+          ImageFile(data: await TestData.binaryImage, fileName: "before.jpg"),
+        );
+
+        notifier.setFileMetaData(
+          0,
+          const FileSettingsDialogResult(
+            fileName: "after.jpg",
+            isNsfw: true,
+            caption: "ねこ",
+          ),
+        );
+
+        final file = container.read(chatInputStateProvider).files.single;
+        expect(file.fileName, "after.jpg");
+        expect(file.isNsfw, isTrue);
+        expect(file.caption, "ねこ");
+      });
+
+      test("変更しても添付の順番が変わらないこと", () async {
+        final notifier = container.read(chatInputStateProvider.notifier);
+        await notifier.addFile(
+          UnknownFile(data: Uint8List.fromList([1]), fileName: "1.pdf"),
+        );
+        await notifier.addFile(
+          UnknownFile(data: Uint8List.fromList([2]), fileName: "2.pdf"),
+        );
+
+        notifier.setFileMetaData(
+          0,
+          const FileSettingsDialogResult(
+            fileName: "1-edited.pdf",
+            isNsfw: false,
+            caption: null,
+          ),
+        );
+
+        final files = container.read(chatInputStateProvider).files;
+        expect(files.map((e) => e.fileName), ["1-edited.pdf", "2.pdf"]);
+      });
+
+      test("ドライブのファイルを変更すると、送信時にdrive/files/updateが飛ぶこと", () async {
+        final apiService = RecordingApiService();
+        when(mockMisskey.apiService).thenReturn(apiService);
+
+        final notifier = container.read(chatInputStateProvider.notifier);
+        await notifier.addFile(
+          ImageFileAlreadyPostedFile(
+            data: await TestData.binaryImage,
+            id: "drive-file-id",
+            fileName: "before.jpg",
+          ),
+        );
+
+        notifier.setFileMetaData(
+          0,
+          const FileSettingsDialogResult(
+            fileName: "after.jpg",
+            isNsfw: true,
+            caption: null,
+          ),
+        );
+
+        final fileId = await notifier.uploadAndGetFileId();
+
+        expect(fileId, "drive-file-id");
+        expect(apiService.requests.length, 1);
+        final (path, request, predicate) = apiService.requests.single;
+        expect(path, "drive/files/update");
+        expect(request["fileId"], "drive-file-id");
+        expect(request["name"], "after.jpg");
+        expect(request["isSensitive"], isTrue);
+        // 説明が未入力のとき、空文字ではなくnullをそのまま送る
+        expect(predicate?.call("comment", null), isTrue);
+      });
+
+      test("ドライブのファイルを変更していなければ、drive/files/updateは飛ばないこと", () async {
+        final apiService = RecordingApiService();
+        when(mockMisskey.apiService).thenReturn(apiService);
+
+        final notifier = container.read(chatInputStateProvider.notifier);
+        await notifier.addFile(
+          ImageFileAlreadyPostedFile(
+            data: await TestData.binaryImage,
+            id: "drive-file-id",
+            fileName: "before.jpg",
+          ),
+        );
+
+        await notifier.uploadAndGetFileId();
+
+        expect(apiService.requests, isEmpty);
       });
     });
   });

--- a/test/view/chat_page/chat_file_preview_test.dart
+++ b/test/view/chat_page/chat_file_preview_test.dart
@@ -166,6 +166,61 @@ void main() {
       expect(fileSettingChanged, isFalse);
     });
 
+    // onFileSettingChanged を受け取っていながら、どこからも呼んでいなかった
+    // https://github.com/shiosyakeyakini-info/miria/issues/854
+    for (final (name, file) in [
+      (
+        "画像",
+        () async =>
+            ImageFile(data: await TestData.binaryImage, fileName: "a.jpg"),
+      ),
+      (
+        "ドライブの画像",
+        () async => ImageFileAlreadyPostedFile(
+          data: await TestData.binaryImage,
+          id: "id",
+          fileName: "a.jpg",
+        ),
+      ),
+      (
+        "その他ファイル",
+        () async =>
+            UnknownFile(data: Uint8List.fromList([1, 2]), fileName: "a.pdf"),
+      ),
+      (
+        "ドライブのその他ファイル",
+        () async => UnknownAlreadyPostedFile(
+          url: "https://example.com/a.pdf",
+          id: "id",
+          fileName: "a.pdf",
+        ),
+      ),
+    ]) {
+      testWidgets("$name のプレビューをタップすると、ファイル設定のコールバックが呼ばれること", (tester) async {
+        var fileDeleted = false;
+        MisskeyPostFile? changed;
+        final target = await file();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ChatFilePreview(
+                file: target,
+                onFileDeleted: () => fileDeleted = true,
+                onFileSettingChanged: (file) async => changed = file,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byKey(ValueKey("chatFile:${target.fileName}")));
+        await tester.pumpAndSettle();
+
+        expect(changed, same(target));
+        expect(fileDeleted, isFalse);
+      });
+    }
+
     testWidgets("画像プレビューのサイズが正しいこと", (tester) async {
       var fileDeleted = false;
       var fileSettingChanged = false;


### PR DESCRIPTION
`ChatFilePreview` は `onFileSettingChanged` を受け取っていながら、ウィジェットの中からどこにも繋がっておらず、チャットでは添付ファイルのファイル名・説明・NSFW を変更する手段がありませんでした。

## サムネイルをタップで開くようにした

タップ判定は `ValueKey("chatFile:<ファイル名>")` で引けます。

このとき削除ボタンが邪魔をしていました。`IconButton` の既定のタップ領域は 48x48 あり、80x80 のサムネイルの中心まで覆っているので、真ん中を押してもサムネイルには届きません。見た目どおりの 24x24 に狭めています。

| 添付した状態 | タップで開くダイアログ |
|---|---|
| <img width="380" src="https://github.com/user-attachments/assets/42673894-06fc-4c55-b37b-9d7c2f19867f"> | <img width="380" src="https://github.com/user-attachments/assets/14f6150a-7867-4efc-be7b-9ea7ab7aac67"> |

## 反映先を作った

`ChatInputStateNotifier.setFileMetaData` を足しました。ユーザーチャットとルームチャットに同じ処理がベタ書きで重複していて、どちらも

- `ImageFile` / `UnknownFile` しか扱っておらず、ドライブ由来のファイルは素通り
- `removeFile` してから `addFile` していたので添付の順番が変わる

という状態でした。`note_create_state_notifier` の同名メソッドに揃えて4種類すべてをその場で差し替えるようにし、呼び出し側は notifier を叩くだけにしています。

## ドライブのファイルも反映されるようにした

ドライブから添付したファイルは、情報を変えても送信時に何も起きませんでした。`isEdited` のときに `drive/files/update` を投げます。説明が未入力のときに空文字を送らない扱いは #849 と同じく `excludeRemoveNullPredicate` です。

| 変更後（NSFWが反映される） | 送信後 |
|---|---|
| <img width="380" src="https://github.com/user-attachments/assets/5ed1cf80-b955-4d64-8eac-235a51be1952"> | <img width="380" src="https://github.com/user-attachments/assets/a0065790-c7d4-41d7-a0ed-be15bca21abe"> |

## 動作確認

ローカルの Misskey 2026.7.0 で、ドライブから添付 → サムネイルをタップ → ファイル名・説明・NSFW を変更 → 送信、まで marionette で通しました。サーバー側のファイルが変わっていることも確認しています。

```
name: ねこの写真.png        (before: nyanko.png)
comment: '青いねこ'         (before: null)
isSensitive: True          (before: False)
```

編集ダイアログの入力：

| |
|---|
| <img width="380" src="https://github.com/user-attachments/assets/9161a23c-7049-448a-a9fb-7fe07dc72627"> |

テストは `chat_file_preview_test.dart` に4種類のファイルでコールバックが呼ばれること、`chat_input_state_notifier_test.dart` に反映・並び順・`drive/files/update` の送信を足しました。`fvm flutter test` は 410 件パスしています。

Fix #854