### PR TITLE
fix: ミュートユーザーリストの続きを読み込めるようにする

### DIFF
--- a/lib/state_notifier/muted_users_page/muted_users_notifier.dart
+++ b/lib/state_notifier/muted_users_page/muted_users_notifier.dart
@@ -8,21 +8,27 @@ part "muted_users_notifier.g.dart";
 
 @Riverpod(dependencies: [misskeyPostContext])
 class MutedUsersNotifier extends _$MutedUsersNotifier {
+  /// 一覧そのものは `PushableListView` が持つので、ここでは状態を持たない。
   @override
-  Future<List<Muting>> build() async {
+  void build() {}
+
+  /// ミュート済みユーザーを1ページ分取得する。
+  ///
+  /// `mute/list` は `untilId` に [Muting] の id を渡してページングする。
+  /// ミュートされている側のユーザーIDではない。
+  Future<List<Muting>> fetch({String? untilId}) async {
     final response = await ref
         .read(misskeyPostContextProvider)
         .mute
-        .list(const MuteListRequest());
+        .list(MuteListRequest(untilId: untilId));
     return response.toList();
   }
 
-  Future<void> delete(String userId) async {
+  /// ミュートを解除する。解除したら `true`。
+  Future<bool> delete(Muting muting) async {
+    var deleted = false;
     await ref.read(dialogStateProvider.notifier).guard(() async {
-      // ユーザー名を取得
-      final user = state.value?.firstWhere((e) => e.muteeId == userId);
-      final userName = user?.mutee.name ?? user?.mutee.username ?? "";
-
+      final userName = muting.mutee.name ?? muting.mutee.username;
       final result = await ref
           .read(dialogStateProvider.notifier)
           .showDialog(
@@ -34,11 +40,10 @@ class MutedUsersNotifier extends _$MutedUsersNotifier {
         await ref
             .read(misskeyPostContextProvider)
             .mute
-            .delete(MuteDeleteRequest(userId: userId));
-        state = AsyncValue.data([
-          ...?state.value?.where((e) => e.muteeId != userId),
-        ]);
+            .delete(MuteDeleteRequest(userId: muting.muteeId));
+        deleted = true;
       }
     });
+    return deleted;
   }
 }

--- a/lib/state_notifier/muted_users_page/muted_users_notifier.g.dart
+++ b/lib/state_notifier/muted_users_page/muted_users_notifier.g.dart
@@ -13,7 +13,7 @@ part of 'muted_users_notifier.dart';
 final mutedUsersProvider = MutedUsersNotifierProvider._();
 
 final class MutedUsersNotifierProvider
-    extends $AsyncNotifierProvider<MutedUsersNotifier, List<Muting>> {
+    extends $NotifierProvider<MutedUsersNotifier, void> {
   MutedUsersNotifierProvider._()
     : super(
         from: null,
@@ -38,22 +38,30 @@ final class MutedUsersNotifierProvider
   @$internal
   @override
   MutedUsersNotifier create() => MutedUsersNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
 }
 
 String _$mutedUsersNotifierHash() =>
-    r'627cc21f13351f8fbde61aa1ae5d560d413952ad';
+    r'b35275ec22130fa0361b63e1384609cd981313af';
 
-abstract class _$MutedUsersNotifier extends $AsyncNotifier<List<Muting>> {
-  FutureOr<List<Muting>> build();
+abstract class _$MutedUsersNotifier extends $Notifier<void> {
+  void build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<AsyncValue<List<Muting>>, List<Muting>>;
+    final ref = this.ref as $Ref<void, void>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<AsyncValue<List<Muting>>, List<Muting>>,
-              AsyncValue<List<Muting>>,
+              AnyNotifier<void, void>,
+              void,
               Object?,
               Object?
             >;

--- a/lib/view/several_account_settings_page/muted_users_page/muted_users_page.dart
+++ b/lib/view/several_account_settings_page/muted_users_page/muted_users_page.dart
@@ -10,7 +10,8 @@ import "package:miria/router/app_router.dart";
 import "package:miria/state_notifier/muted_users_page/muted_users_notifier.dart";
 import "package:miria/view/common/account_scope.dart";
 import "package:miria/view/common/avatar_icon.dart";
-import "package:miria/view/common/error_detail.dart";
+import "package:miria/view/common/pushable_listview.dart";
+import "package:misskey_dart/misskey_dart.dart";
 
 @RoutePage()
 class MutedUsersPage extends HookConsumerWidget implements AutoRouteWrapper {
@@ -24,52 +25,56 @@ class MutedUsersPage extends HookConsumerWidget implements AutoRouteWrapper {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final muted = ref.watch(mutedUsersProvider);
+    // notifierを生かしておく。readだけだとautoDisposeで即座に破棄され、
+    // 解除の確認ダイアログをawaitして戻ってきたときにはRefが死んでいる。
+    // （#677と同じ壊れかた）
+    ref.watch(mutedUsersProvider);
+
+    // ミュートを解除したら一覧を取り直すためのキー。
+    // PushableListViewは自分が持っている項目を外から消せない。
+    final listKey = useState(0);
 
     return Scaffold(
       appBar: AppBar(title: Text(S.of(context).mutedUsers)),
-      body: switch (muted) {
-        AsyncLoading() => const Center(
-          child: CircularProgressIndicator.adaptive(),
-        ),
-        AsyncError(:final error, :final stackTrace) => Center(
-          child: ErrorDetail(error: error, stackTrace: stackTrace),
-        ),
-        AsyncData(:final value) => ListView.builder(
-          itemCount: value.length,
-          itemBuilder: (context, index) {
-            final muting = value[index];
-            return HookBuilder(
-              builder: (context) {
-                final unmute = useAsync(
-                  () async => ref
-                      .read(mutedUsersProvider.notifier)
-                      .delete(muting.muteeId),
-                );
-                return ListTile(
-                  leading: AvatarIcon(user: muting.mutee),
-                  title: Text(muting.mutee.name ?? muting.mutee.username),
-                  subtitle: Text(
-                    "@${muting.mutee.username}${muting.mutee.host != null ? "@${muting.mutee.host}" : ""}",
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                  trailing: IconButton(
-                    icon: const Icon(Icons.volume_up),
-                    tooltip: S.of(context).unmute,
-                    onPressed: unmute.executeOrNull,
-                  ),
-                  onTap: () async => context.pushRoute(
-                    UserRoute(
-                      userId: muting.mutee.id,
-                      accountContext: ref.read(accountContextProvider),
-                    ),
-                  ),
-                );
-              },
+      // 以前は1ページ目を取ってそのままListViewに流していたので、
+      // 「さらに読み込む」が出ず続きを見られなかった (#777)
+      body: PushableListView<Muting>(
+        listKey: listKey.value,
+        showAd: false,
+        initializeFuture: () async =>
+            ref.read(mutedUsersProvider.notifier).fetch(),
+        nextFuture: (lastItem, _) async =>
+            ref.read(mutedUsersProvider.notifier).fetch(untilId: lastItem.id),
+        itemBuilder: (context, muting) => HookBuilder(
+          builder: (context) {
+            final unmute = useAsync(() async {
+              final deleted = await ref
+                  .read(mutedUsersProvider.notifier)
+                  .delete(muting);
+              if (deleted) listKey.value++;
+            });
+            return ListTile(
+              leading: AvatarIcon(user: muting.mutee),
+              title: Text(muting.mutee.name ?? muting.mutee.username),
+              subtitle: Text(
+                "@${muting.mutee.username}${muting.mutee.host != null ? "@${muting.mutee.host}" : ""}",
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              trailing: IconButton(
+                icon: const Icon(Icons.volume_up),
+                tooltip: S.of(context).unmute,
+                onPressed: unmute.executeOrNull,
+              ),
+              onTap: () async => context.pushRoute(
+                UserRoute(
+                  userId: muting.mutee.id,
+                  accountContext: ref.read(accountContextProvider),
+                ),
+              ),
             );
           },
         ),
-      },
+      ),
     );
   }
 }

--- a/test/view/muted_users_page/muted_users_page_test.dart
+++ b/test/view/muted_users_page/muted_users_page_test.dart
@@ -1,3 +1,4 @@
+import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:miria/providers.dart";
@@ -8,6 +9,7 @@ import "package:mockito/mockito.dart";
 import "../../test_util/default_root_widget.dart";
 import "../../test_util/mock.mocks.dart";
 import "../../test_util/test_datas.dart";
+import "../../test_util/widget_tester_extension.dart";
 
 class MockMisskeyMute extends Mock implements MisskeyMute {
   @override
@@ -20,6 +22,15 @@ class MockMisskeyMute extends Mock implements MisskeyMute {
             ),
           )
           as Future<Iterable<Muting>>;
+
+  @override
+  Future<void> delete(MuteDeleteRequest? request) =>
+      super.noSuchMethod(
+            Invocation.method(#delete, [request]),
+            returnValue: Future<void>.value(),
+            returnValueForMissingStub: Future<void>.value(),
+          )
+          as Future<void>;
 }
 
 void main() {
@@ -54,6 +65,93 @@ void main() {
         find.textContaining(TestData.detailedUser1.name!, findRichText: true),
         findsOneWidget,
       );
+    });
+
+    // 1ページ目を取ってそのままListViewに流していたので、続きを読み込む
+    // 手段がなかった
+    // https://github.com/shiosyakeyakini-info/miria/issues/777
+    testWidgets("「さらに読み込む」で続きを読み込めること", (tester) async {
+      final mute = MockMisskeyMute();
+      final misskey = MockMisskey();
+      when(misskey.mute).thenReturn(mute);
+      final user = UserDetailedNotMe.fromJson(TestData.detailedUser1.toJson());
+
+      Muting muting(String id) => Muting(
+        id: id,
+        createdAt: DateTime.now(),
+        muteeId: user.id,
+        mutee: user,
+      );
+
+      // 具体的なstubが後勝ちになるよう、先に既定を置く
+      when(
+        mute.list(any),
+      ).thenAnswer((_) => Future<Iterable<Muting>>.value(<Muting>[]));
+      when(mute.list(const MuteListRequest())).thenAnswer(
+        (_) => Future<Iterable<Muting>>.value([muting("1"), muting("2")]),
+      );
+      when(
+        mute.list(const MuteListRequest(untilId: "2")),
+      ).thenAnswer((_) => Future<Iterable<Muting>>.value([muting("3")]));
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [misskeyProvider.overrideWith((_, _) => misskey)],
+          child: DefaultRootWidget(
+            initialRoute: MutedUsersRoute(account: TestData.account),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ListTile), findsNWidgets(2));
+
+      await tester.pageNation();
+
+      // 2ページ目のぶんが足されていること
+      expect(find.byType(ListTile), findsNWidgets(3));
+      verify(mute.list(const MuteListRequest(untilId: "2"))).called(1);
+    });
+
+    // 一覧の持ち主がPushableListViewに移ったあとも、notifierを生かしておかないと
+    // 確認ダイアログのawaitから戻ったときにRefが破棄されていて何も起きない
+    testWidgets("ミュートを解除できること", (tester) async {
+      final mute = MockMisskeyMute();
+      final misskey = MockMisskey();
+      when(misskey.mute).thenReturn(mute);
+      final user = UserDetailedNotMe.fromJson(TestData.detailedUser1.toJson());
+
+      when(
+        mute.list(any),
+      ).thenAnswer((_) => Future<Iterable<Muting>>.value(<Muting>[]));
+      when(mute.list(const MuteListRequest())).thenAnswer(
+        (_) => Future<Iterable<Muting>>.value([
+          Muting(
+            id: "1",
+            createdAt: DateTime.now(),
+            muteeId: user.id,
+            mutee: user,
+          ),
+        ]),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [misskeyProvider.overrideWith((_, _) => misskey)],
+          child: DefaultRootWidget(
+            initialRoute: MutedUsersRoute(account: TestData.account),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.volume_up));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("ミュート解除"));
+      await tester.pumpAndSettle();
+
+      verify(mute.delete(MuteDeleteRequest(userId: user.id))).called(1);
     });
   });
 }


### PR DESCRIPTION
`mute/list` を1ページ分だけ取って、そのまま `ListView.builder` に流していたので、「さらに読み込む」が出ず 30 件より先を見られませんでした。

他の一覧に合わせて `PushableListView` に置き換えます。`untilId` に渡すのはミュートされている側のユーザーIDではなく `Muting` の id です。

| さらに読み込む | タップ後（31件目以降） |
|---|---|
| <img width="380" src="https://github.com/user-attachments/assets/6a2ad656-f2ff-45cd-aa28-c9742e085be4"> | <img width="380" src="https://github.com/user-attachments/assets/ba617172-b1d6-4391-a1e2-ba437d643d0f"> |

## copilot の #780 から変えたところ

[#780](https://github.com/shiosyakeyakini-info/miria/pull/780) をもとにしていますが、3点変えています。

**1. 解除対象の探しかた**

`delete` が `state.value?.firstWhere(...)` で対象を探していました。一覧の持ち主が `PushableListView` に移ると notifier の state は1ページ目しか持たないので、2ページ目以降のユーザーを解除しようとすると `firstWhere` が `StateError` を投げます。ちょうどこの issue で見られるようになる範囲なので、対象の `Muting` を引数で受け取るようにしました。

**2. 解除しても一覧から消えない**

`PushableListView` は自分が持っている項目を外から消せないので、`room_info.dart` と同じく `listKey` を進めて取り直しています。

**3. notifier が破棄されて解除が効かない**

`read` だけで触ると autoDispose で即座に破棄され、確認ダイアログを await して戻ったときには Ref が死んでいて、「ミュート解除」を押しても何も起きませんでした。#677 とまったく同じ壊れかたです。

```
Cannot use the Ref of mutedUsersProvider after it has been disposed.
```

画面で `watch` して生かしておきます。**これは実機で踏んで気づいたもの**なので、回帰テストも足しました（修正前は上記の例外で落ちます）。

## そのほか

- notifier は一覧を持たなくなったので `build` は何もしません
- 設定画面なので広告は出しません (`showAd: false`)

## 動作確認

ローカルの Misskey 2026.7.0 に35件のミュート（1ページ目30件＋2ページ目5件）を用意して marionette で確認しました。

1. 一番下まで送ると「さらに読み込む」が出る
2. タップすると mutee05〜01 が足される
3. **2ページ目のユーザーを解除**できる（サーバー側が34件になることを確認）

| 解除の確認 | 解除後（先頭が消える） |
|---|---|
| <img width="380" src="https://github.com/user-attachments/assets/74e9a156-f33a-471e-9289-6b13e15fbe46"> | <img width="380" src="https://github.com/user-attachments/assets/e87ae594-7e7a-4eb5-a18a-cf12d0e5d16f"> |

`fvm flutter test` は 404 件パスしています。

Fix #777