### PR TITLE
feat: ノートの検索で投稿日時を指定できるようにする

### DIFF
--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -38,6 +38,8 @@
     "home": "ホーム",
     "local": "ローカル",
     "direct": "ダイレクト",
+    "searchPostFrom": "投稿日時（から）",
+    "searchPostTo": "投稿日時（まで）",
     "onlyLocal": "ローカルのみ",
     "remote": "リモート",
     "@done": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -333,6 +333,18 @@ abstract class S {
   /// **'ダイレクト'**
   String get direct;
 
+  /// No description provided for @searchPostFrom.
+  ///
+  /// In ja, this message translates to:
+  /// **'投稿日時（から）'**
+  String get searchPostFrom;
+
+  /// No description provided for @searchPostTo.
+  ///
+  /// In ja, this message translates to:
+  /// **'投稿日時（まで）'**
+  String get searchPostTo;
+
   /// No description provided for @onlyLocal.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -126,6 +126,12 @@ class SJa extends S {
   String get direct => 'ダイレクト';
 
   @override
+  String get searchPostFrom => '投稿日時（から）';
+
+  @override
+  String get searchPostTo => '投稿日時（まで）';
+
+  @override
   String get onlyLocal => 'ローカルのみ';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -126,6 +126,12 @@ class SZh extends S {
   String get direct => '直接';
 
   @override
+  String get searchPostFrom => '起始日期';
+
+  @override
+  String get searchPostTo => '终止日期';
+
+  @override
   String get onlyLocal => '仅本地';
 
   @override
@@ -2251,6 +2257,12 @@ class SZhCn extends SZh {
 
   @override
   String get direct => '直接';
+
+  @override
+  String get searchPostFrom => '起始日期';
+
+  @override
+  String get searchPostTo => '终止日期';
 
   @override
   String get onlyLocal => '仅本地';

--- a/lib/l10n/app_zh-cn.arb
+++ b/lib/l10n/app_zh-cn.arb
@@ -38,6 +38,8 @@
     "home": "首页",
     "local": "本地",
     "direct": "直接",
+    "searchPostFrom": "起始日期",
+    "searchPostTo": "终止日期",
     "onlyLocal": "仅本地",
     "remote": "远程",
     "@done": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -38,6 +38,8 @@
     "home": "首页",
     "local": "本地",
     "direct": "直接",
+    "searchPostFrom": "起始日期",
+    "searchPostTo": "终止日期",
     "onlyLocal": "仅本地",
     "remote": "远程",
     "@done": {

--- a/lib/model/note_search_condition.dart
+++ b/lib/model/note_search_condition.dart
@@ -10,6 +10,8 @@ abstract class NoteSearchCondition with _$NoteSearchCondition {
     User? user,
     CommunityChannel? channel,
     @Default(false) bool localOnly,
+    DateTime? rangeStartAt,
+    DateTime? rangeEndAt,
   }) = _NoteSearchCondition;
   const NoteSearchCondition._();
 

--- a/lib/model/note_search_condition.freezed.dart
+++ b/lib/model/note_search_condition.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NoteSearchCondition {
 
- String? get query; User? get user; CommunityChannel? get channel; bool get localOnly;
+ String? get query; User? get user; CommunityChannel? get channel; bool get localOnly; DateTime? get rangeStartAt; DateTime? get rangeEndAt;
 /// Create a copy of NoteSearchCondition
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $NoteSearchConditionCopyWith<NoteSearchCondition> get copyWith => _$NoteSearchCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NoteSearchCondition&&(identical(other.query, query) || other.query == query)&&(identical(other.user, user) || other.user == user)&&(identical(other.channel, channel) || other.channel == channel)&&(identical(other.localOnly, localOnly) || other.localOnly == localOnly));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NoteSearchCondition&&(identical(other.query, query) || other.query == query)&&(identical(other.user, user) || other.user == user)&&(identical(other.channel, channel) || other.channel == channel)&&(identical(other.localOnly, localOnly) || other.localOnly == localOnly)&&(identical(other.rangeStartAt, rangeStartAt) || other.rangeStartAt == rangeStartAt)&&(identical(other.rangeEndAt, rangeEndAt) || other.rangeEndAt == rangeEndAt));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,query,user,channel,localOnly);
+int get hashCode => Object.hash(runtimeType,query,user,channel,localOnly,rangeStartAt,rangeEndAt);
 
 @override
 String toString() {
-  return 'NoteSearchCondition(query: $query, user: $user, channel: $channel, localOnly: $localOnly)';
+  return 'NoteSearchCondition(query: $query, user: $user, channel: $channel, localOnly: $localOnly, rangeStartAt: $rangeStartAt, rangeEndAt: $rangeEndAt)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $NoteSearchConditionCopyWith<$Res>  {
   factory $NoteSearchConditionCopyWith(NoteSearchCondition value, $Res Function(NoteSearchCondition) _then) = _$NoteSearchConditionCopyWithImpl;
 @useResult
 $Res call({
- String? query, User? user, CommunityChannel? channel, bool localOnly
+ String? query, User? user, CommunityChannel? channel, bool localOnly, DateTime? rangeStartAt, DateTime? rangeEndAt
 });
 
 
@@ -62,13 +62,15 @@ class _$NoteSearchConditionCopyWithImpl<$Res>
 
 /// Create a copy of NoteSearchCondition
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? query = freezed,Object? user = freezed,Object? channel = freezed,Object? localOnly = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? query = freezed,Object? user = freezed,Object? channel = freezed,Object? localOnly = null,Object? rangeStartAt = freezed,Object? rangeEndAt = freezed,}) {
   return _then(_self.copyWith(
 query: freezed == query ? _self.query : query // ignore: cast_nullable_to_non_nullable
 as String?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
 as User?,channel: freezed == channel ? _self.channel : channel // ignore: cast_nullable_to_non_nullable
 as CommunityChannel?,localOnly: null == localOnly ? _self.localOnly : localOnly // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,rangeStartAt: freezed == rangeStartAt ? _self.rangeStartAt : rangeStartAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,rangeEndAt: freezed == rangeEndAt ? _self.rangeEndAt : rangeEndAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
   ));
 }
 /// Create a copy of NoteSearchCondition
@@ -165,10 +167,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly,  DateTime? rangeStartAt,  DateTime? rangeEndAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NoteSearchCondition() when $default != null:
-return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
+return $default(_that.query,_that.user,_that.channel,_that.localOnly,_that.rangeStartAt,_that.rangeEndAt);case _:
   return orElse();
 
 }
@@ -186,10 +188,10 @@ return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly,  DateTime? rangeStartAt,  DateTime? rangeEndAt)  $default,) {final _that = this;
 switch (_that) {
 case _NoteSearchCondition():
-return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
+return $default(_that.query,_that.user,_that.channel,_that.localOnly,_that.rangeStartAt,_that.rangeEndAt);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -206,10 +208,10 @@ return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? query,  User? user,  CommunityChannel? channel,  bool localOnly,  DateTime? rangeStartAt,  DateTime? rangeEndAt)?  $default,) {final _that = this;
 switch (_that) {
 case _NoteSearchCondition() when $default != null:
-return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
+return $default(_that.query,_that.user,_that.channel,_that.localOnly,_that.rangeStartAt,_that.rangeEndAt);case _:
   return null;
 
 }
@@ -221,13 +223,15 @@ return $default(_that.query,_that.user,_that.channel,_that.localOnly);case _:
 
 
 class _NoteSearchCondition extends NoteSearchCondition {
-  const _NoteSearchCondition({this.query, this.user, this.channel, this.localOnly = false}): super._();
+  const _NoteSearchCondition({this.query, this.user, this.channel, this.localOnly = false, this.rangeStartAt, this.rangeEndAt}): super._();
   
 
 @override final  String? query;
 @override final  User? user;
 @override final  CommunityChannel? channel;
 @override@JsonKey() final  bool localOnly;
+@override final  DateTime? rangeStartAt;
+@override final  DateTime? rangeEndAt;
 
 /// Create a copy of NoteSearchCondition
 /// with the given fields replaced by the non-null parameter values.
@@ -239,16 +243,16 @@ _$NoteSearchConditionCopyWith<_NoteSearchCondition> get copyWith => __$NoteSearc
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NoteSearchCondition&&(identical(other.query, query) || other.query == query)&&(identical(other.user, user) || other.user == user)&&(identical(other.channel, channel) || other.channel == channel)&&(identical(other.localOnly, localOnly) || other.localOnly == localOnly));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NoteSearchCondition&&(identical(other.query, query) || other.query == query)&&(identical(other.user, user) || other.user == user)&&(identical(other.channel, channel) || other.channel == channel)&&(identical(other.localOnly, localOnly) || other.localOnly == localOnly)&&(identical(other.rangeStartAt, rangeStartAt) || other.rangeStartAt == rangeStartAt)&&(identical(other.rangeEndAt, rangeEndAt) || other.rangeEndAt == rangeEndAt));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,query,user,channel,localOnly);
+int get hashCode => Object.hash(runtimeType,query,user,channel,localOnly,rangeStartAt,rangeEndAt);
 
 @override
 String toString() {
-  return 'NoteSearchCondition(query: $query, user: $user, channel: $channel, localOnly: $localOnly)';
+  return 'NoteSearchCondition(query: $query, user: $user, channel: $channel, localOnly: $localOnly, rangeStartAt: $rangeStartAt, rangeEndAt: $rangeEndAt)';
 }
 
 
@@ -259,7 +263,7 @@ abstract mixin class _$NoteSearchConditionCopyWith<$Res> implements $NoteSearchC
   factory _$NoteSearchConditionCopyWith(_NoteSearchCondition value, $Res Function(_NoteSearchCondition) _then) = __$NoteSearchConditionCopyWithImpl;
 @override @useResult
 $Res call({
- String? query, User? user, CommunityChannel? channel, bool localOnly
+ String? query, User? user, CommunityChannel? channel, bool localOnly, DateTime? rangeStartAt, DateTime? rangeEndAt
 });
 
 
@@ -276,13 +280,15 @@ class __$NoteSearchConditionCopyWithImpl<$Res>
 
 /// Create a copy of NoteSearchCondition
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? query = freezed,Object? user = freezed,Object? channel = freezed,Object? localOnly = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? query = freezed,Object? user = freezed,Object? channel = freezed,Object? localOnly = null,Object? rangeStartAt = freezed,Object? rangeEndAt = freezed,}) {
   return _then(_NoteSearchCondition(
 query: freezed == query ? _self.query : query // ignore: cast_nullable_to_non_nullable
 as String?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
 as User?,channel: freezed == channel ? _self.channel : channel // ignore: cast_nullable_to_non_nullable
 as CommunityChannel?,localOnly: null == localOnly ? _self.localOnly : localOnly // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,rangeStartAt: freezed == rangeStartAt ? _self.rangeStartAt : rangeStartAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,rangeEndAt: freezed == rangeEndAt ? _self.rangeEndAt : rangeEndAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
   ));
 }
 

--- a/lib/view/search_page/note_search.dart
+++ b/lib/view/search_page/note_search.dart
@@ -3,10 +3,12 @@ import "package:flutter/material.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:mfm_parser/mfm_parser.dart";
+import "package:miria/extensions/date_time_extension.dart";
 import "package:miria/l10n/app_localizations.dart";
 import "package:miria/model/note_search_condition.dart";
 import "package:miria/providers.dart";
 import "package:miria/router/app_router.dart";
+import "package:miria/view/common/date_time_picker.dart";
 import "package:miria/view/common/misskey_notes/misskey_note.dart";
 import "package:miria/view/common/pushable_listview.dart";
 import "package:miria/view/user_page/user_list_item.dart";
@@ -27,6 +29,8 @@ class NoteSearch extends HookConsumerWidget {
     final selectedUser = useState(initialCondition?.user);
     final selectedChannel = useState(initialCondition?.channel);
     final localOnly = useState(initialCondition?.localOnly ?? false);
+    final rangeStartAt = useState(initialCondition?.rangeStartAt);
+    final rangeEndAt = useState(initialCondition?.rangeEndAt);
     final isDetail = useState(false);
 
     final selectedUserValue = selectedUser.value;
@@ -107,6 +111,16 @@ class NoteSearch extends HookConsumerWidget {
                         },
                         trailing: const Icon(Icons.keyboard_arrow_right),
                       ),
+                      _DateTimeTile(
+                        title: S.of(context).searchPostFrom,
+                        value: rangeStartAt.value,
+                        onChanged: (value) => rangeStartAt.value = value,
+                      ),
+                      _DateTimeTile(
+                        title: S.of(context).searchPostTo,
+                        value: rangeEndAt.value,
+                        onChanged: (value) => rangeEndAt.value = value,
+                      ),
                       CheckboxListTile(
                         title: Text(S.of(context).onlyLocal),
                         value: localOnly.value,
@@ -126,10 +140,55 @@ class NoteSearch extends HookConsumerWidget {
               localOnly: localOnly.value,
               channelId: selectedChannel.value?.id,
               userId: selectedUser.value?.id,
+              rangeStartAt: rangeStartAt.value,
+              rangeEndAt: rangeEndAt.value,
             ),
           ),
         ),
       ],
+    );
+  }
+}
+
+/// 投稿日時の範囲をひとつ指定するタイル。
+class _DateTimeTile extends StatelessWidget {
+  final String title;
+  final DateTime? value;
+  final ValueChanged<DateTime?> onChanged;
+
+  const _DateTimeTile({
+    required this.title,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final current = value;
+    return ListTile(
+      title: Text(title),
+      subtitle: current == null
+          ? null
+          : Text(current.formatUntilSeconds(context)),
+      trailing: current == null
+          ? const Icon(Icons.date_range)
+          : IconButton(
+              icon: const Icon(Icons.clear),
+              tooltip: S.of(context).clear,
+              onPressed: () => onChanged(null),
+            ),
+      onTap: () async {
+        final result = await showDateTimePicker(
+          context: context,
+          initialDate: current ?? DateTime.now(),
+          // Misskeyの誕生日より前を選ばせても意味がない
+          firstDate: DateTime(2014),
+          lastDate: DateTime.now().add(const Duration(days: 1)),
+          datePickerHelpText: title,
+          timePickerHelpText: title,
+        );
+        if (result != null) onChanged(result);
+      },
     );
   }
 }
@@ -139,6 +198,8 @@ class NoteSearchList extends ConsumerWidget {
   final bool localOnly;
   final String? channelId;
   final String? userId;
+  final DateTime? rangeStartAt;
+  final DateTime? rangeEndAt;
 
   const NoteSearchList({
     required this.query,
@@ -146,6 +207,8 @@ class NoteSearchList extends ConsumerWidget {
     super.key,
     this.channelId,
     this.userId,
+    this.rangeStartAt,
+    this.rangeEndAt,
   });
 
   @override
@@ -157,7 +220,14 @@ class NoteSearchList extends ConsumerWidget {
     if (query.isEmpty) return const SizedBox.shrink();
 
     return PushableListView(
-      listKey: Object.hash(query, localOnly, channelId, userId),
+      listKey: Object.hash(
+        query,
+        localOnly,
+        channelId,
+        userId,
+        rangeStartAt,
+        rangeEndAt,
+      ),
       initializeFuture: () async {
         final Iterable<Note> notes;
         if (isHashtagOnly) {
@@ -179,6 +249,8 @@ class NoteSearchList extends ConsumerWidget {
                   userId: userId,
                   channelId: channelId,
                   host: localOnly ? "." : null,
+                  rangeStartAt: rangeStartAt,
+                  rangeEndAt: rangeEndAt,
                 ),
               );
         }
@@ -208,6 +280,8 @@ class NoteSearchList extends ConsumerWidget {
                   userId: userId,
                   channelId: channelId,
                   host: localOnly ? "." : null,
+                  rangeStartAt: rangeStartAt,
+                  rangeEndAt: rangeEndAt,
                   untilId: lastItem.id,
                 ),
               );

--- a/test/view/search_page/search_page_test.dart
+++ b/test/view/search_page/search_page_test.dart
@@ -10,6 +10,7 @@ import "package:mockito/mockito.dart";
 import "../../test_util/default_root_widget.dart";
 import "../../test_util/mock.mocks.dart";
 import "../../test_util/test_datas.dart";
+import "../../test_util/widget_tester_extension.dart";
 
 void main() {
   group("ノート検索", () {
@@ -168,6 +169,82 @@ void main() {
         ),
       ).called(1);
     }, skip: true);
+
+    // notes/search は投稿日時での絞り込みを受け付けるのに、指定する手段がなかった
+    // https://github.com/shiosyakeyakini-info/miria/issues/294
+    testWidgets("投稿日時を指定すると、検索リクエストに載ること", (tester) async {
+      final mockMisskey = MockMisskey();
+      final mockNote = MockMisskeyNotes();
+      when(mockMisskey.notes).thenReturn(mockNote);
+      when(mockNote.search(any)).thenAnswer((_) async => [TestData.note1]);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            misskeyProvider.overrideWith((ref, account) => mockMisskey),
+          ],
+          child: DefaultRootWidget(
+            initialRoute: SearchRoute(accountContext: TestData.accountContext),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), "Misskey");
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      // 指定していないうちは載らない
+      verify(
+        mockNote.search(
+          argThat(equals(const NotesSearchRequest(query: "Misskey"))),
+        ),
+      ).called(1);
+
+      // 詳細を開いて「投稿日時（から）」を指定する
+      await tester.tap(find.byIcon(Icons.keyboard_arrow_down).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("投稿日時（から）"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("OK"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("OK"));
+      await tester.pumpAndSettle();
+
+      // 指定するとrangeStartAtつきで引き直される
+      verify(
+        mockNote.search(
+          argThat(
+            predicate<NotesSearchRequest>(
+              (request) =>
+                  request.query == "Misskey" &&
+                  request.rangeStartAt != null &&
+                  request.rangeEndAt == null,
+            ),
+          ),
+        ),
+      ).called(1);
+
+      // 続きを読み込んでも指定が維持されること
+      // 詳細を畳んで、残る keyboard_arrow_down を「さらに読み込む」だけにする
+      await tester.tap(find.byIcon(Icons.keyboard_arrow_up));
+      await tester.pumpAndSettle();
+
+      when(mockNote.search(any)).thenAnswer((_) async => [TestData.note2]);
+      await tester.pageNation();
+
+      verify(
+        mockNote.search(
+          argThat(
+            predicate<NotesSearchRequest>(
+              (request) =>
+                  request.rangeStartAt != null &&
+                  request.untilId == TestData.note1.id,
+            ),
+          ),
+        ),
+      ).called(1);
+    });
 
     testWidgets("ハッシュタグを検索した場合、ハッシュタグのエンドポイントで検索されること", (tester) async {
       final mockMisskey = MockMisskey();


### PR DESCRIPTION
> [!IMPORTANT]
> misskey_dart の [#110](https://github.com/shiosyakeyakini-info/misskey_dart/pull/110) が前提です。マージされたら `pubspec.lock` の `misskey_dart` を引き上げてください。それまではこのブランチ単体ではビルドが通らないので draft にしています。

検索の詳細条件に「投稿日時（から）」「投稿日時（まで）」を足して、`notes/search` の `rangeStartAt` / `rangeEndAt` に渡します。

| 詳細条件 | から を指定 | まで を指定 |
|---|---|---|
| <img width="330" src="https://github.com/user-attachments/assets/cccf0e4d-ae53-408b-84f1-da9941025c81"> | <img width="330" src="https://github.com/user-attachments/assets/8ac79e13-1d1e-4d1f-a64c-2f6a587fb450"> | <img width="330" src="https://github.com/user-attachments/assets/abafa0a6-820e-4af4-be9d-b08a96865a8f"> |

## id への変換は要らなくなっていた

issue が立った当時は日付を id に変換する必要があり、[aid だけ対応するか / 別エンドポイントを叩くか](https://github.com/shiosyakeyakini-info/miria/issues/294) で悩まれていました。いまは Misskey 側が `idService.gen()` で受け持っているので、日時をそのまま渡せます。手元のサーバーの id は `aidx` でしたが問題なく効きました。

## sinceDate ではなく rangeStartAt を使う理由

同じエンドポイントの `sinceDate` / `untilDate` はサーバーで `sinceId` / `untilId` に変換されます。つまりページングのカーソルなので、「さらに読み込む」で `untilId` を使う以上そちらは使えません。

```ts
// packages/backend/src/server/api/endpoints/notes/search.ts
const untilId = ps.untilId ?? (ps.untilDate ? this.idService.gen(ps.untilDate!) : undefined);
```

`rangeStartAt` / `rangeEndAt` は `searchService.searchNote` に絞り込み条件として渡るのでページングと独立しています。Misskey Web の検索画面 (`search.note.vue`) も日時にはこちらを使っています。

## 挙動

- 日時を変えると `listKey` が変わって引き直されます
- 続きを読み込むときも指定は維持されます（`untilId` と併用しても重複や範囲外は出ないことをサーバーで確認済み）
- ハッシュタグ検索は `notes/search-by-tag` が日時を受け付けないので、これまでどおり詳細条件は効きません（既存の注記のとおり）

## 動作確認

ローカルの Misskey 2026.7.0 で marionette から確認しました。8/3 のノート群と 8/5 のノート2件がある状態で「marionette」を検索し、

- 「投稿日時（から）＝ 8/4」→ 8/5 の2件だけになる
- 「投稿日時（まで）＝ 8/4」→ 8/3 のノートだけになる

テストは、日時を指定すると `rangeStartAt` つきで引き直されること・続きの読み込みでも維持されることを足しました。`fvm flutter test` は 403 件パスしています。

Fix #294