### PR TITLE
[Linux] 動画プレイヤー入れ替えに伴うアプリクラッシュの修正

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -73,7 +73,6 @@ apply_standard_settings(${BINARY_NAME})
 # Add dependency libraries. Add any application-specific dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
-target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
 
 # Run the Flutter tool portions of the build. This must not be removed.
 add_dependencies(${BINARY_NAME} flutter_assemble)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -690,10 +690,10 @@ packages:
     dependency: "direct main"
     description:
       name: fvp
-      sha256: a2850b856e177cb48f3e49940613f2180f3375bcceab2f75e3d7b915009a2840
+      sha256: bc2cc7309cc5b177826af7a83cdd27ba0c542c821ad74287bbdff2b7434aff67
       url: "https://pub.dev"
     source: hosted
-    version: "0.34.0"
+    version: "0.38.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,7 @@ dependencies:
   image: ^4.9.1
   flutter_twemoji: ^1.0.1
   mime: ^2.0.0
-  fvp: ^0.34.0
+  fvp: ^0.38.0
   video_player: ^2.10.0
   video_player_avfoundation: ^2.8.4
   video_player_android: ^2.8.13
@@ -149,7 +149,7 @@ flutter_launcher_icons:
   image_path: "assets/images/icon.png"
   adaptive_icon_background: "#ace601"
   adaptive_icon_foreground: "assets/images/icon_adaptive_foreground.png"
-  adaptive_icon_monochrome: "assets/images/icon_adaptive_monochrome.png" # Not working?
+  adaptive_icon_monochrome: "assets/images/icon_adaptive_monochrome.png"
   min_sdk_android: 21
   windows:
     generate: true


### PR DESCRIPTION
#842 のマージ以降、Linux環境においてアプリ自体は起動できるようになったものの、タイムライン読み込み直前にクラッシュするようになっていたため、`media_kit`で使用されていたプロパティを削除して正常に動作させるようにするための提案です。