### PR TITLE
fix(linux): Debianパッケージの不要なlibmpv2依存を削除

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -4,5 +4,5 @@ Section: net
 Priority: optional
 Architecture: amd64
 Maintainer: sorairo <sorairo@shiosyakeyakini.info>
-Depends: libgtk-3-0, libstdc++6, libmpv2, libsecret-1-0
+Depends: libgtk-3-0, libstdc++6, libsecret-1-0
 Description: Misskey client app for mobile (Linux build)


### PR DESCRIPTION
## 概要

Debian パッケージ（`.deb`）の `Depends` に残っていた不要な依存 `libmpv2` を削除します。

## 変更内容

- `linux/debian/control` の `Depends` から `libmpv2` を除去
  - 変更後: `libgtk-3-0, libstdc++6, libsecret-1-0`

## 背景

- 動画再生は `media_kit` から `fvp`（mdk ベース）へ置き換え済みで、アプリは libmpv を一切使用していません
- コードベース全体で `mpv` を参照している箇所はこの `Depends` 行のみでした
- `media_kit` から `fvp` への移行時（`3c3c6241`）に `Depends` の更新が漏れて残っていた名残です

## 確認事項

- `libgtk-3-0`: 必要（GTK3 埋め込み）
- `libstdc++6`: 必要
- `libsecret-1-0`: 必要（`flutter_secure_storage_linux` が `libsecret-1>=0.18.4` を要求）
- `libmpv2`: **不要**（`fvp` は mdk ベースで libmpv 非依存）