### PR TITLE
chore(deps): mfm を 1.0.11 に更新

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1014,10 +1014,10 @@ packages:
     dependency: "direct main"
     description:
       name: mfm
-      sha256: a95edd06754ebdf6e65ee975c4b2c227670e38b641d72ca0a49f36e19ea9c4c0
+      sha256: "10ed9e7ab347f89d7f93b98b2785b8f153128e2d04b6e0ba27a5eefd2a75fca7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.10"
+    version: "1.0.11"
   mfm_parser:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     git:
       url: https://github.com/shiosyakeyakini-info/misskey_dart.git
       ref: master
-  mfm: ^1.0.9
+  mfm: ^1.0.11
   tuple: ^2.0.1
   path_provider: ^2.1.6
   dio: ^5.10.0


### PR DESCRIPTION
## 概要

`miria_v4` で使用している MFM レンダラ (`mfm` パッケージ) を最新の 1.0.11 に更新します。

## 変更内容

- `pubspec.yaml`: `mfm: ^1.0.9` → `^1.0.11`
- `pubspec.lock`: `mfm` 1.0.10 → 1.0.11

なお `mfm_parser` は既に最新の 1.0.7 のため変更ありません。

## 取り込まれる upstream の変更

### 1.0.11
- `$[spin.x ]` / `$[spin.y ]` に透視投影が適用されていなかった不具合の修正。
  従来は `Matrix4.perspectiveTransform()` / `Matrix4.transform3()` を呼んでいましたが、
  これらは渡した `Vector3` を変換するだけで行列自体を変更しないため、
  結果として透視のかからない平行投影の回転になっていました。
  本家 Misskey と同じく `perspective(128px)` 相当の行列を掛けるよう修正されています。

### 1.0.10（制約の是正）
- `SimpleMfm` への `overflow` / `maxLines` オプション追加。
  `lib/view/common/misskey_notes/mfm_text.dart` の `SimpleMfmText` は既にこの 2 つを
  `SimpleMfm` に渡しており、実際には 1.0.10 以降を要求していましたが、
  `pubspec.yaml` の制約は `^1.0.9` のままでした。今回併せて是正しています。

## 確認したこと

- `fvm flutter pub get` — 解決成功（`mfm` 1.0.11）
- `fvm dart analyze` — error 0 件（既存の warning / info のみで、本 PR による増減なし）
- `fvm dart format --output=none --set-exit-if-changed .` — 差分なし（491 ファイル）
- `fvm flutter test` — All tests passed!（412 passed / 17 skipped）


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTYnwuKG3gzRchEaEWbSE3)_