### PR TITLE
アプリのプライマリカラーをMFMの枠線のデフォルト色にする

### DIFF
--- a/lib/view/common/misskey_notes/mfm_text.dart
+++ b/lib/view/common/misskey_notes/mfm_text.dart
@@ -180,6 +180,7 @@ class MfmText extends ConsumerWidget {
       prefixSpan: prefixSpan,
       isUseAnimation: isEnableAnimatedMFM,
       maxLines: maxLines,
+      defaultBorderColor: AppTheme.of(context).colorTheme.primary,
     );
   }
 }


### PR DESCRIPTION
`defaultBorderColor`が未設定のままであり、`$[border ]`タグでユーザーが色を指定しなかった場合に枠線がアプリのテーマに従わず紫色となっていたのを修正する提案です。