### PR TITLE
お気に入りの確認中、インジケーターを中央ではなく左端に表示する

### DIFF
--- a/lib/view/note_modal_sheet/note_modal_sheet.dart
+++ b/lib/view/note_modal_sheet/note_modal_sheet.dart
@@ -400,8 +400,10 @@ class NoteModalSheet extends ConsumerWidget implements AutoRouteWrapper {
         if (accountContext.isSame)
           switch (noteStatus) {
             null => const SizedBox.shrink(),
-            AsyncLoading() => const Center(
-              child: CircularProgressIndicator.adaptive(),
+            AsyncLoading() => ListTile(
+              leading: const CircularProgressIndicator.adaptive(),
+              title: Text(S.of(context).loading),
+              enabled: false,
             ),
             AsyncError() => Text(S.of(context).thrownError),
             AsyncData(:final value) => ListTile(


### PR DESCRIPTION
`note_modal_sheet`を表示したとき、ノートがお気に入りに追加されているか確認している間読み込み中のインジケーターが中央に表示されているが、これが確認後の表示に切り替わる前に他の項目を選択しようとするとUIが変化して誤タップを引き起こすことが多いため、読み込みインジケーターを`ListTile`のアイコンとして、「読み込み中…」の文字列を表示する提案です。
<img width="220" height="344" alt="Screenshot from 2026-08-17 17-13-46" src="https://github.com/user-attachments/assets/823c258e-9523-4ec5-aad7-3be4a8c97335" />
