### PR TITLE
Misskey.ioではハードワードミュートを編集できないように

### DIFF
--- a/lib/view/several_account_settings_page/several_account_settings_page.dart
+++ b/lib/view/several_account_settings_page/several_account_settings_page.dart
@@ -63,8 +63,10 @@ class SeveralAccountSettingsPage extends StatelessWidget {
               WordMuteRoute(account: account, muteType: MuteType.hard),
             ),
             title: Text(S.of(context).hardWordMute),
+            subtitle: account.host != "misskey.io" ? null : Text(S.of(context).unsupportedServer),
             leading: const Icon(Icons.comments_disabled),
             trailing: const Icon(Icons.chevron_right),
+            enabled: account.host != "misskey.io",
           ),
           ListTile(
             onTap: () async =>


### PR DESCRIPTION
現在のMisskey.ioには、オリジナルのMisskeyと違いハードワートミュートが存在せず、アカウントごとの設定からハードワートミュートを設定しようとしても正常に保存操作が行われないため、Misskey.ioではハードワートミュートの設定画面を表示しないようにする提案です。
<img width="220" height="344" alt="Screenshot from 2026-08-17 17-07-48" src="https://github.com/user-attachments/assets/fa0e313d-0acb-4308-a015-ac26a3078ba9" />
