### PR TITLE
Add bottom padidng for Android

### DIFF
--- a/lib/view/chat_page/chat_message_menu_sheet.dart
+++ b/lib/view/chat_page/chat_message_menu_sheet.dart
@@ -67,6 +67,7 @@ class ChatMessageMenuSheet extends ConsumerWidget implements AutoRouteWrapper {
             title: Text(S.of(context).chatReport),
             onTap: () => context.maybePop(ChatMessageMenuAction.report),
           ),
+        SizedBox(height: MediaQuery.of(context).padding.bottom),
       ],
     );
   }

--- a/lib/view/user_page/user_detail.dart
+++ b/lib/view/user_page/user_detail.dart
@@ -438,7 +438,10 @@ class UserDetail extends ConsumerWidget {
         ),
         if (response.pinnedNotes != null)
           SliverPadding(
-            padding: const EdgeInsets.only(right: 10),
+            padding: EdgeInsets.only(
+              right: 10,
+              bottom: MediaQuery.of(context).padding.bottom,
+            ),
             sliver: SliverList.builder(
               itemCount: response.pinnedNotes!.length,
               itemBuilder: (context, index) =>


### PR DESCRIPTION
チャットのメニューリストが最後の項目が選択できるように、ナビゲーションバーの高さ分の`SizedBox`を追加する提案です。
<img width="270" height="213.75" alt="Screenshot_20260818-113943" src="https://github.com/user-attachments/assets/ab811836-c855-469b-9455-3952f08e8a68" />
また、ユーザー詳細のピン留めノートもリアクションボタンなどが隠れていたのを確認したため、`padding`を追加しました。

Fix #888 