### PR TITLE
自身のチャットメッセージの色をprimaryからaccentedBackgroundに

### DIFF
--- a/lib/view/chat_page/chat_message_item.dart
+++ b/lib/view/chat_page/chat_message_item.dart
@@ -49,7 +49,7 @@ class ChatMessageItem extends ConsumerWidget {
                 onLongPress: () => _showMessageMenu(context, ref),
                 child: Bubble(
                   nip: BubbleNip.rightBottom,
-                  color: AppTheme.of(context).colorTheme.primary,
+                  color: AppTheme.of(context).colorTheme.accentedBackground,
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
チャットページにおいて、送信側のメッセージ内容が`primary`では明らかに本文が読めないテーマが多いため、`accentedBackground`に置き換える提案です。
一部テーマでハッシュタグが読みにくくなることがありますが、チャット内でハッシュタグを利用する可能性が低いと考えて（決めつけて）置き換えたほうが良いと考えています。
|テーマ|変更前|変更後|
|:-:|:-:|:-:|
|1|![](https://github.com/user-attachments/assets/c886e603-0107-460f-a0af-82ebe3b3c60a)|![](https://github.com/user-attachments/assets/d413ae59-327b-4bf7-966b-1fb67ff2b8ab)|
|2|![](https://github.com/user-attachments/assets/fb8421ed-bdf2-47ed-aa78-8d4112fec892)|![](https://github.com/user-attachments/assets/36a68346-9055-4ac2-8e66-f21fb8d1305a)|