### PR TITLE
docs(skill): Linux では XDG ポータル経由で file_picker を操作できるようにする

### DIFF
--- a/.claude/skills/drive-miria/SKILL.md
+++ b/.claude/skills/drive-miria/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: drive-miria
-description: Launch miria and operate it as a real user through marionette — log in, navigate, post a note, react, search, inspect Riverpod state, take screenshots. Use when asked to run miria, reproduce a UI bug, or confirm a change works in the running app rather than only in tests.
+description: Launch miria and operate it as a real user through marionette — log in, navigate, post a note, react, search, attach a file, inspect Riverpod state, take screenshots. Covers running it headless on Linux. Use when asked to run miria, reproduce a UI bug, or confirm a change works in the running app rather than only in tests.
 ---
 
 # Driving miria with marionette
@@ -19,10 +19,13 @@ is usually already signed in.
 
 ```bash
 fvm flutter run -d windows --debug    # prints: A Dart VM Service ... at: <URI>
+fvm flutter run -d linux   --debug    # same, on a Linux desktop or container
 ```
 
 That URI is the handle for everything, and changes on every launch. Windows
 builds need a pinned MSVC toolset — see `reference.md` if the build fails.
+Linux builds need no such coaxing, but a headless one needs an X display, a
+session bus and a few daemons around it — see **Linux, headless** below.
 
 Drive it with `scripts/marionette.py` (plain HTTP, no MCP server needed):
 
@@ -151,6 +154,46 @@ pre-populated default never does — then repeat with the real query.
 m swipe --start 190 450 --end 190 150
 ```
 
+### Attach a file (Linux only)
+
+On Linux the 「アップロード」 picker is **not** a native dialog: file_picker 12
+asks the XDG desktop portal over the session bus and waits for its reply. Serve
+that yourself with `scripts/portal_stub.py` and the picker becomes ordinary
+scripted UI — arm the answer, tap, verify.
+
+```bash
+python .claude/skills/drive-miria/scripts/portal_stub.py &   # once per session
+```
+
+```bash
+echo '{"paths": ["/abs/path/pic.png"]}' > /tmp/marionette-portal/answer.json
+m tap  --x 25 --y 238        # 画像アイコン, leftmost under the compose field
+m tap  --text "アップロード"
+```
+
+Re-read `elements` for that first coordinate rather than trusting it — it is
+from one 400×700 Linux window.
+
+The answer is consumed by one request, so arm it again for the next pick. Two
+paths in `paths` selects two files; **leaving the file absent is how you press
+Cancel**. Every call is appended to `/tmp/marionette-portal/requests.log` —
+that log is the proof the picker actually opened, since a tap that missed looks
+identical from `elements`.
+
+Give it real files. The stub hands over whatever path you name, but miria asks
+for `FileType.image` and decodes the result, and
+`note_create_state_notifier.dart` pops an error dialog when the decode yields
+nothing — so a bad file fails inside miria, well after the picker looked fine.
+Verify uploads on the server, never on the screen:
+
+```bash
+curl -s -X POST http://localhost:3000/api/users/notes \
+  -H "Content-Type: application/json" -d '{"userId":"<id>","limit":1}'
+```
+
+Windows has no equivalent — there the picker is a real native window and stays
+out of reach (`reference.md`).
+
 ### Log in (API key)
 
 Only needed on a fresh profile. MiAuth opens an external browser and cannot be
@@ -186,9 +229,49 @@ Repositories serialize to `{"runtimeType": ...}` only, so the timeline's notes
 are not reachable this way. Values can contain API tokens; never paste a raw
 snapshot anywhere public.
 
+## Linux, headless
+
+A container with no display runs miria fine — verified end to end on Ubuntu
+24.04 against a local misskey, including uploads. Bring these up **before**
+`flutter run`; the app inherits them from the environment:
+
+```bash
+Xvfb :99 -screen 0 1280x900x24 &
+export DISPLAY=:99
+export LIBGL_ALWAYS_SOFTWARE=1                 # llvmpipe; no GPU in a container
+export DBUS_SESSION_BUS_ADDRESS=$(dbus-daemon --session --print-address --fork)
+printf '\n' | gnome-keyring-daemon --unlock --replace --daemonize --components=secrets
+python .claude/skills/drive-miria/scripts/portal_stub.py &
+```
+
+- **Xvfb** — the GTK shell needs an X server. `m shot` still captures the
+  Flutter scene, so screenshots work with nothing on screen.
+- **gnome-keyring** — `flutter_secure_storage` stores the account through
+  `org.freedesktop.secrets`, which nothing else in a bare container provides.
+  It was up before the login above; a run without it was not tried.
+- **portal_stub.py** — the file picker. See the recipe above.
+
+The session bus is the load-bearing part: the app reads
+`DBUS_SESSION_BUS_ADDRESS` at startup, so a bus started afterwards is invisible
+to it. `dbus-send --session --dest=org.freedesktop.DBus --print-reply \
+/org/freedesktop/DBus org.freedesktop.DBus.ListNames` should list both
+`org.freedesktop.portal.Desktop` and `org.freedesktop.secrets` before you launch.
+
+The Linux window is larger than the Windows one — every coordinate under
+**The screen** is wrong here. Read `elements` and use what it reports.
+
 ## When it looks like nothing happened
 
-In order: re-read `elements`; take a screenshot; check whether a **native
-dialog** is up (`Get-Process | ? { $_.MainWindowTitle }` — file pickers and
-browsers are invisible to marionette); ask the server. `reference.md` has the
-full list of what is out of reach and why.
+In order: re-read `elements`; take a screenshot; ask the server. Then check
+whether something outside the Flutter scene is holding the app:
+
+- **Windows** — a native dialog (`Get-Process | ? { $_.MainWindowTitle }`);
+  file pickers and browsers are invisible to marionette.
+- **Linux** — no native dialog exists for the file picker, so read
+  `/tmp/marionette-portal/requests.log` instead. No request line at all means
+  the tap missed, or the stub is down and the call threw `ServiceUnknown`. A
+  request *and* a response logged, with nothing on screen, means the response
+  lost the subscription race and `pickFiles` is now hung — restart the stub
+  with a larger `PORTAL_STUB_DELAY` (`reference.md`).
+
+`reference.md` has the full list of what is out of reach and why.

--- a/.claude/skills/drive-miria/reference.md
+++ b/.claude/skills/drive-miria/reference.md
@@ -1,8 +1,9 @@
 # marionette against miria — mechanics and limits
 
 Read `SKILL.md` first; this is the "why" behind it. Everything here was
-observed against a real build (marionette_flutter 0.6.0, Flutter 3.44.6,
-Windows).
+observed against a real build (marionette_flutter 0.6.0, Flutter 3.44.6) —
+on Windows unless a section says Linux, and the Linux runs were headless in a
+container against misskey 2025.8.0-beta.4.
 
 ## Building on Windows
 
@@ -24,6 +25,38 @@ after any `flutter clean`.
 
 Do not run `flutter test` while `flutter run` is up — they share `build/` and
 clobber each other's `native_assets.json`.
+
+## A local misskey to drive against
+
+`assets_builder/misskey` is the submodule; `git submodule update --init --depth 1`
+brings it down. It needs postgres and redis, `.config/default.yml` pointing at
+them, `pnpm install`, `pnpm build`, `pnpm migrate`, `pnpm start`.
+
+Two things bite in a sandboxed container:
+
+- **Docker Hub is often unreachable** (the blob CDN, not the registry). Install
+  `postgresql` and `redis-server` from apt and start them with
+  `pg_ctlcluster 16 main start` / `redis-server --daemonize yes` instead of
+  `compose.local-db.yml`.
+- **`github:` dependencies fetch a codeload tarball**, which fails where plain
+  git clones succeed. Rewriting them in `packages/frontend/package.json` to
+  `git+https://github.com/<owner>/<repo>.git#<ref>` makes pnpm use git.
+  `CYPRESS_INSTALL_BINARY=0` skips another download that is only for e2e tests.
+
+`pnpm build` also builds the web frontend, which wants `fluent-emojis/dist/*.png`.
+Those are absent from a plain checkout and the vite build dies on them — but
+**miria only needs the backend API**, and `packages/backend/built` is produced
+before that failure. Migrate and start anyway.
+
+First account, then a token for the API-key login:
+
+```bash
+curl -s -X POST http://localhost:3000/api/admin/accounts/create \
+  -H "Content-Type: application/json" -d '{"username":"miria","password":"..."}'
+curl -s -X POST http://localhost:3000/api/signin-flow \
+  -H "Content-Type: application/json" \
+  -d '{"username":"miria","password":"..."}'      # -> {"i": "<token>"}
+```
 
 ## Transports
 
@@ -177,16 +210,71 @@ read that instead.
 Wiring `FlutterError.onError` and a `runZoned` print handler into the
 collector would make this tool useful.
 
+## Building on Linux
+
+Nothing to configure — `fvm flutter build linux --debug` succeeds against
+stock Ubuntu 24.04 build deps (clang, cmake, ninja, `libgtk-3-dev`). No
+toolset pinning, no `permission_handler` fallout: that package's Windows
+implementation is what breaks there, and it is not in the Linux build.
+
+Headless needs Xvfb, `LIBGL_ALWAYS_SOFTWARE=1`, a session bus, gnome-keyring
+and the portal stub — `SKILL.md` has the launch block. Flutter renders through
+llvmpipe without complaint; the only console noise is a harmless
+`Atk-CRITICAL ... atk_socket_embed` from GTK's accessibility bridge.
+
+## The file picker on Linux
+
+file_picker 12 dropped the native dialog on Linux. `FilePickerLinux` is pure
+D-Bus (`lib/src/platform/linux/file_picker_linux.dart`): it calls
+`org.freedesktop.portal.FileChooser.OpenFile` on
+`org.freedesktop.portal.Desktop`, gets back a Request object path, and awaits
+one `org.freedesktop.portal.Request.Response` signal (`ua{sv}`) on it —
+`response == 0` plus a `uris` array, or any non-zero for cancelled.
+`getDirectoryPath` is the same call with `directory: true`; `saveFile` is
+`SaveFile`. All three read `uris` from the same reply.
+
+Nothing about that is a GUI, so none of it needs one. `scripts/portal_stub.py`
+owns the name and answers from `/tmp/marionette-portal/answer.json` — the whole
+picker becomes a file you write before the tap. It is ~120 lines of `jeepney`
+(`pip install jeepney`, pure Python, no libdbus).
+
+Consequences worth knowing:
+
+- **With no portal on the bus, the picker throws** —
+  `org.freedesktop.DBus.Error.ServiceUnknown: The name
+  org.freedesktop.portal.Desktop was not provided by any .service files`.
+  A bare container has no `xdg-desktop-portal` installed, so this is the
+  default state, not an edge case.
+- **The response must not be instant.** The client subscribes to the Response
+  signal only *after* `OpenFile` returns, so a stub that answers in the same
+  millisecond loses the race and the signal is dropped. `pickFiles` then awaits
+  forever, with the app looking perfectly healthy. Measured: a 0-second delay
+  fails every time, 0.6 s (the stub default, `PORTAL_STUB_DELAY`) is reliable.
+  A real portal is safe here only because a human takes seconds to click.
+- **Request handles must stay unique across stub restarts.** A client whose
+  Response was lost is still subscribed to that object path. Restarting a stub
+  that numbers handles from zero hands the next client the same path, and the
+  one signal completes *both* awaits — observed as the same file attached
+  twice from a single tap. The stub puts its pid in the path for this reason.
+- `answer.json` is consumed per request (`"once": false` keeps it armed).
+  Absent file == cancelled, which is how you exercise the cancel branch.
+
+Verified against miria's composer: single file, two files, and cancel, each
+confirmed on the server (`/api/users/notes` showed the attached
+`image/png`, byte size matching the source). miria calls `pickFiles` from three
+places — `note_create_state_notifier.dart`, `chat_input_state_notifier.dart`,
+`profile_edit_page.dart` — all through this one platform call.
+
 ## Out of reach
 
-- **Native dialogs.** 「アップロード」 opens a `File Picker` window owned by the
-  miria process. `elements` does not change, `take_screenshots` does not show
-  it (it renders the Flutter scene only), and the VM Service keeps answering —
-  indistinguishable from a tap that did nothing. Detect with `Get-Process | ?
-  { $_.MainWindowTitle }`; dismiss with
+- **Native dialogs (Windows).** 「アップロード」 opens a `File Picker` window owned
+  by the miria process. `elements` does not change, `take_screenshots` does not
+  show it (it renders the Flutter scene only), and the VM Service keeps
+  answering — indistinguishable from a tap that did nothing. Detect with
+  `Get-Process | ? { $_.MainWindowTitle }`; dismiss with
   `(New-Object -ComObject WScript.Shell).AppActivate("File Picker")` then
   `SendKeys("{ESC}")`. The in-app drive picker (「ドライブから」) is fully
-  driveable.
+  driveable. **On Linux this limit does not apply** — see above.
 - **External browser.** MiAuth (`account_repository.dart`) and note links use
   `launchUrl(externalApplication)`. Same invisibility. API-key login is the
   only automatable sign-in for this reason.

--- a/.claude/skills/drive-miria/scripts/portal_stub.py
+++ b/.claude/skills/drive-miria/scripts/portal_stub.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Headless stand-in for org.freedesktop.portal.Desktop's FileChooser.
+
+file_picker >= 12 on Linux does not draw a dialog of its own: it calls
+OpenFile/SaveFile on the XDG desktop portal over the session bus and waits for
+the portal's Request.Response signal. That makes the picker scriptable — this
+serves the portal side and answers with whatever paths were armed beforehand.
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+
+from jeepney import DBusAddress, MessageType, new_error, new_method_return, new_signal
+from jeepney.bus_messages import DBusNameFlags, message_bus
+from jeepney.io.blocking import open_dbus_connection
+
+BUS_NAME = "org.freedesktop.portal.Desktop"
+OBJ_PATH = "/org/freedesktop/portal/desktop"
+IFACE = "org.freedesktop.portal.FileChooser"
+
+STATE_DIR = os.environ.get("PORTAL_STUB_DIR", "/tmp/marionette-portal")
+ANSWER = os.path.join(STATE_DIR, "answer.json")
+LOG = os.path.join(STATE_DIR, "requests.log")
+# The client subscribes to the Response signal only after OpenFile returns,
+# so answering instantly races the match rule being installed.
+DELAY = float(os.environ.get("PORTAL_STUB_DELAY", "0.6"))
+
+
+def log(entry):
+    entry["ts"] = time.time()
+    with open(LOG, "a") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def read_answer():
+    """Consume the armed answer. Missing/empty file == user pressed cancel."""
+    try:
+        with open(ANSWER) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    if data.get("once", True):
+        try:
+            os.remove(ANSWER)
+        except OSError:
+            pass
+    return data
+
+
+def respond(conn, req_path, answer):
+    time.sleep(DELAY)
+    addr = DBusAddress(req_path, interface="org.freedesktop.portal.Request")
+    if answer is None:
+        code, results = 1, {}          # 1 == cancelled by the user
+    else:
+        uris = ["file://" + os.path.abspath(p) for p in answer.get("paths", [])]
+        code, results = 0, {"uris": ("as", uris)}
+    conn.send(new_signal(addr, "Response", "ua{sv}", (code, results)))
+    log({"event": "response", "handle": req_path, "code": code,
+         "uris": list(results.get("uris", ("as", []))[1])})
+
+
+def main():
+    os.makedirs(STATE_DIR, exist_ok=True)
+    conn = open_dbus_connection(bus="SESSION")
+    reply = conn.send_and_get_reply(
+        message_bus.RequestName(BUS_NAME, DBusNameFlags.do_not_queue)
+    )
+    if reply.body[0] != 1:  # 1 == primary owner
+        sys.exit(f"could not own {BUS_NAME}: RequestName returned {reply.body[0]}")
+    print(f"portal stub owning {BUS_NAME}; state in {STATE_DIR}", flush=True)
+
+    serial = 0
+    while True:
+        msg = conn.receive()
+        if msg.header.message_type != MessageType.method_call:
+            continue
+        member = msg.header.fields.get(3)   # MEMBER
+        iface = msg.header.fields.get(2)    # INTERFACE
+        sender = msg.header.fields.get(7)   # SENDER
+
+        if iface == "org.freedesktop.DBus.Peer" and member == "Ping":
+            conn.send(new_method_return(msg, "", ()))
+            continue
+
+        if iface == IFACE and member in ("OpenFile", "SaveFile"):
+            _parent, title, options = msg.body
+            opts = {k: v[1] for k, v in options.items()}
+            serial += 1
+            token = opts.get("handle_token", "t") or "t"
+            # os.getpid() keeps handles unique across stub restarts: a client
+            # still awaiting a lost Response would otherwise match a reused
+            # path and complete a second time off someone else's answer.
+            req_path = (f"{OBJ_PATH}/request/"
+                        f"{sender.replace(':', '_').replace('.', '_')}/"
+                        f"{token}_{os.getpid()}_{serial}")
+            log({"event": member, "title": title, "handle": req_path,
+                 "multiple": bool(opts.get("multiple", False)),
+                 "directory": bool(opts.get("directory", False))})
+            conn.send(new_method_return(msg, "o", (req_path,)))
+            answer = read_answer()
+            threading.Thread(target=respond, args=(conn, req_path, answer),
+                             daemon=True).start()
+            continue
+
+        if iface == "org.freedesktop.portal.Request" and member == "Close":
+            conn.send(new_method_return(msg, "", ()))
+            continue
+
+        conn.send(new_error(msg, "org.freedesktop.DBus.Error.UnknownMethod",
+                            "s", (f"{iface}.{member} not implemented by stub",)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

`drive-miria` スキルは「ファイルピッカーはネイティブダイアログなので marionette からは触れない」としていましたが、**これは Windows に限った話**でした。

file_picker 12 の Linux 実装 (`FilePickerLinux`) はダイアログを一切描画せず、セッションバス経由で `org.freedesktop.portal.FileChooser.OpenFile` を呼んで `Request.Response` シグナルを待つだけの純粋な D-Bus 通信です。GUI ではないので GUI 自動化も要りません。**ポータル側を自前で提供すれば、ファイル選択は「タップ前に書く JSON ファイル」になります。**

なお素のコンテナには `xdg-desktop-portal` が入っていないため、何もしない状態ではピッカーは `ServiceUnknown` 例外になります。これは例外的な状況ではなく既定の状態です。

## 変更内容

- **`scripts/portal_stub.py`（新規）** — `org.freedesktop.portal.Desktop` を保持し、`OpenFile` / `SaveFile` に `/tmp/marionette-portal/answer.json` の内容で応答するスタブ。約 120 行、jeepney のみ（`pip install jeepney`、pure Python で libdbus 不要）
- **`SKILL.md`** — 「ファイルを添付する（Linux のみ）」レシピと「Linux, headless」節（Xvfb / セッションバス / gnome-keyring / スタブの起動手順）を追加。「何も起きていないように見えるとき」の項を Windows と Linux で分岐
- **`reference.md`** — D-Bus の仕組み、後述の2つの罠、Linux ビルド事情、検証用ローカル misskey の立て方を追加

ドキュメントと Python スクリプトのみで、**Dart コードの変更はありません。**

## 検証

コンテナ内で misskey 2025.8.0-beta.4 を起動し、Linux デバッグビルドの miria を Xvfb 上でヘッドレス起動して確認しました。コンポーザーの「アップロード」から以下3経路を実行し、いずれも画面ではなく**サーバー API で確認**しています（`/api/users/notes` に `marionette_test.png` / `image/png` / 7850 バイト、元ファイルと一致）。

- 単一ファイル選択
- 複数ファイル選択
- キャンセル

miria の `pickFiles` 呼び出しは `note_create_state_notifier.dart` / `chat_input_state_notifier.dart` / `profile_edit_page.dart` の3箇所ですが、いずれも同一のプラットフォーム呼び出しを通ります。実地検証したのはコンポーザー経路です。

Windows ビルドと違い、Linux ビルドはツールセットの小細工なしで一発で通りました。

## 見つかった罠（ドキュメント化済み）

1. **即答するとシグナルが取りこぼされる** — クライアントは `OpenFile` が返った*後*に購読するため、遅延0秒だと毎回競合に負けて `pickFiles` が永久に待ち続けます。アプリは健康そうに見えたままなので厄介です。実測で 0 秒は毎回失敗、0.6 秒（`PORTAL_STUB_DELAY` の既定値）で安定。本物のポータルは人間がクリックするまでの時間があるから成立しています。
2. **リクエストハンドルはスタブ再起動をまたいで一意である必要がある** — 応答を取り逃したクライアントはそのオブジェクトパスを購読したままなので、連番をリセットすると次のクライアントに同じパスを渡すことになり、1つのシグナルが両方の待機を完了させます。1回のタップで同じファイルが2回添付される形で顕在化しました。スタブはパスに pid を含めることで回避しています。

## 補足

検証環境の構築で踏んだ egress 制約（Docker Hub の blob CDN 拒否、`github:` 依存の codeload 403、フロントエンドビルドに必要な `fluent-emojis` 欠如）とその回避策は `reference.md` に記載しました。miria が必要とするのはバックエンド API のみなので、フロントエンドのビルド失敗は支障ありません。

`assets_builder/misskey` サブモジュールには手を触れていません（ピン留めコミットは `0c8545e` のまま）。検証中に加えたローカルの回避パッチは revert 済みで、内容は `reference.md` に文書化してあります。

## チェック

- `fvm dart analyze` — 新規エラーなし
- `fvm dart format --output=none --set-exit-if-changed .` — 0 changed
- `fvm flutter test` — **未実行**。Dart コードを一切変更していないことに加え、`flutter run` 起動中のテスト実行は `build/` を壊すとリポジトリ自身のドキュメントが警告しているためです

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mch6JyiJqHS8bP5ErVLpcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mch6JyiJqHS8bP5ErVLpcs)_