### PR TITLE
feat: メジャーバージョンを4.0.0に更新

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: miria
 description: Miria is Misskey Client for Mobile App.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 3.0.1+124
+version: 4.0.0+124
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
## 概要

#887 のマージで develop が v4 の内容になったため、アプリのメジャーバージョンを 4.0.0 に更新します。

## 変更内容

- `pubspec.yaml`: `version: 3.0.1+124` → `4.0.0+124`

ビルド番号は `.github/workflows/deploy.yml` の `cider bump build --bump-build` がデプロイ時に採番するため、本 PR では据え置きです。

## 確認したこと

- `fvm flutter pub get` — 解決成功（`pubspec.lock` に差分なし）
- `fvm dart analyze` — error 0 件
- `fvm flutter test` — All tests passed!（412 passed / 17 skipped）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aa71diCFhAUuWimJ4ibzva)_