### PR TITLE
fix: iOSで外部サイトのリンクが外部ブラウザで開かない問題を修正

### DIFF
--- a/lib/view/common/misskey_notes/link_navigator.dart
+++ b/lib/view/common/misskey_notes/link_navigator.dart
@@ -10,6 +10,28 @@ import "package:url_launcher/url_launcher.dart";
 class LinkNavigator {
   const LinkNavigator();
 
+  /// URLを扱えるアプリがあればそれで、なければ外部ブラウザで開く。
+  ///
+  /// 失敗の伝え方がプラットフォームによって違う。Androidは
+  /// PlatformExceptionを投げるが、iOSは
+  /// UIApplication.open(universalLinksOnly:) がfalseを返すだけで例外を
+  /// 投げない。例外だけを見ていると、ふつうのWebサイトはUniversal Linkを
+  /// 持つアプリがないのでiOSでは何も起きなくなる。戻り値と例外の両方を見る。
+  Future<void> _launchExternal(Uri uri) async {
+    bool launched;
+    try {
+      launched = await launchUrl(
+        uri,
+        mode: LaunchMode.externalNonBrowserApplication,
+      );
+    } catch (_) {
+      launched = false;
+    }
+    if (!launched) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
   Future<void> onTapLink(
     BuildContext context,
     WidgetRef ref,
@@ -42,14 +64,7 @@ class LinkNavigator {
         await ref.read(emojiRepositoryProvider(account)).loadFromSourceIfNeed();
       } catch (e) {
         if (await canLaunchUrl(uri)) {
-          try {
-            await launchUrl(
-              uri,
-              mode: LaunchMode.externalNonBrowserApplication,
-            );
-          } catch (e) {
-            await launchUrl(uri, mode: LaunchMode.externalApplication);
-          }
+          await _launchExternal(uri);
           return;
         }
       }

--- a/test/view/common/misskey_notes/link_navigator_test.dart
+++ b/test/view/common/misskey_notes/link_navigator_test.dart
@@ -1,0 +1,139 @@
+import "package:flutter/material.dart";
+import "package:flutter/services.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:miria/providers.dart";
+import "package:miria/view/common/account_scope.dart";
+import "package:miria/view/common/misskey_notes/link_navigator.dart";
+import "package:mockito/mockito.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+import "package:url_launcher_platform_interface/url_launcher_platform_interface.dart";
+
+import "../../../test_util/default_root_widget.dart";
+import "../../../test_util/mock.mocks.dart";
+import "../../../test_util/test_datas.dart";
+
+const externalUrl = "https://example.com/gaibu";
+
+Widget buildTestWidget({
+  required List<Override> overrides,
+  String url = externalUrl,
+}) => ProviderScope(
+  overrides: overrides,
+  child: DefaultRootNoRouterWidget(
+    child: Scaffold(
+      body: AccountContextScope.as(
+        account: TestData.account,
+        child: Consumer(
+          builder: (context, ref, _) => ElevatedButton(
+            onPressed: () async =>
+                const LinkNavigator().onTapLink(context, ref, url, null),
+            child: const Text("ひらく"),
+          ),
+        ),
+      ),
+    ),
+  ),
+);
+
+/// [PreferredLaunchMode] で呼び出しを絞りこむ matcher
+Matcher launchedWith(PreferredLaunchMode mode) =>
+    predicate<LaunchOptions?>((options) => options?.mode == mode);
+
+void main() {
+  group("外部サイトのリンク", () {
+    late MockUrlLauncherPlatform mockUrlLauncher;
+    late MockMisskey mockMisskey;
+    late List<Override> overrides;
+
+    setUp(() {
+      mockUrlLauncher = MockUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = mockUrlLauncher;
+      when(mockUrlLauncher.canLaunch(any)).thenAnswer((_) async => true);
+
+      // Misskeyではないサーバーなので、メタ情報の取得に失敗する
+      mockMisskey = MockMisskey();
+      when(mockMisskey.meta()).thenThrow(Exception("not misskey"));
+
+      overrides = [
+        misskeyWithoutAccountProvider.overrideWith((ref, host) => mockMisskey),
+      ];
+    });
+
+    testWidgets("URLを扱えるアプリがない場合、外部ブラウザで開かれること", (tester) async {
+      // iOSでは、Universal Linkを扱えるアプリがないとき例外ではなくfalseが返る。
+      // 例外だけを見ているとフォールバックが発火せず、なにも起きなくなる。
+      when(mockUrlLauncher.launchUrl(any, any)).thenAnswer((invocation) async {
+        final options = invocation.positionalArguments[1] as LaunchOptions;
+        return options.mode !=
+            PreferredLaunchMode.externalNonBrowserApplication;
+      });
+
+      await tester.pumpWidget(buildTestWidget(overrides: overrides));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("ひらく"));
+      await tester.pumpAndSettle();
+
+      verify(
+        mockUrlLauncher.launchUrl(
+          externalUrl,
+          argThat(launchedWith(PreferredLaunchMode.externalApplication)),
+        ),
+      ).called(1);
+    });
+
+    testWidgets("例外が投げられた場合も、外部ブラウザで開かれること", (tester) async {
+      // Androidはfalseを返さずPlatformExceptionを投げる
+      when(
+        mockUrlLauncher.launchUrl(
+          any,
+          argThat(
+            launchedWith(PreferredLaunchMode.externalNonBrowserApplication),
+          ),
+        ),
+      ).thenThrow(PlatformException(code: "ACTIVITY_NOT_FOUND"));
+      when(
+        mockUrlLauncher.launchUrl(
+          any,
+          argThat(launchedWith(PreferredLaunchMode.externalApplication)),
+        ),
+      ).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(buildTestWidget(overrides: overrides));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("ひらく"));
+      await tester.pumpAndSettle();
+
+      verify(
+        mockUrlLauncher.launchUrl(
+          externalUrl,
+          argThat(launchedWith(PreferredLaunchMode.externalApplication)),
+        ),
+      ).called(1);
+    });
+
+    testWidgets("URLを扱えるアプリがある場合、外部ブラウザは開かれないこと", (tester) async {
+      when(mockUrlLauncher.launchUrl(any, any)).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(buildTestWidget(overrides: overrides));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("ひらく"));
+      await tester.pumpAndSettle();
+
+      verify(
+        mockUrlLauncher.launchUrl(
+          externalUrl,
+          argThat(
+            launchedWith(PreferredLaunchMode.externalNonBrowserApplication),
+          ),
+        ),
+      ).called(1);
+      verifyNever(
+        mockUrlLauncher.launchUrl(
+          any,
+          argThat(launchedWith(PreferredLaunchMode.externalApplication)),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## なにが起きていたか

iOS で、ノート中の外部サイトのリンク（および同じ URL のリンクプレビュー）をタップしても、なにも起きませんでした。エラーも出ません。

## 原因

`link_navigator.dart` の `onTapLink` で、外部ブラウザへのフォールバックが `catch` のなかにしか置かれていませんでした。

```dart
try {
  await launchUrl(uri, mode: LaunchMode.externalNonBrowserApplication);
} catch (e) {
  await launchUrl(uri, mode: LaunchMode.externalApplication);  // iOSでは発火しない
}
```

`launchUrl` の失敗の伝え方がプラットフォームごとに違うのが原因です。

| | `externalNonBrowserApplication` が失敗したとき |
|---|---|
| **iOS** | `UIApplication.open(url, options: [.universalLinksOnly: true])` が false → `url_launcher_ios` の `_mapLaunchResult` が **false を返すだけ**（`throw` は invalidUrl のときのみ） |
| Android | `PlatformException(ACTIVITY_NOT_FOUND)` を **throw** |
| Linux | `launchUrl` が `options.mode` を**一切見ず**、常に `gtk_show_uri_on_window` |

ふつうの Web サイトの https URL は Universal Link を持つアプリがないので、iOS では 1 回目の `launchUrl` が必ず false を返します。例外は飛ばないので `catch` に入らず、そのまま `return` していました。Android は throw するのでフォールバックが効き、Linux はモードを無視するので開きます。「iOS だけ」の症状と一致します。

## 直しかた

戻り値と例外の両方を見るようにして、`_launchExternal` にまとめました。もともと 2023 年の初期実装（`81bfb2cc`）は戻り値を見ていたので、実質そこへ catch を足して戻した形です。

同ファイル末尾の同一ホスト向けフォールバックや MiAuth (`account_repository.dart`) は最初から `externalApplication` を直接使っているため、影響はありません。壊れていたのは「他サーバー・外部サイト」判定に落ちた経路だけです。

## いつから

`6596810a`「Refactor provider」（2025-12-20）で、戻り値による分岐が例外による分岐に置き換わったときの退行です。挙動を変える意図はなさそうで、`await launchUrl(...)` の結果を捨てる形にリファクタした副作用に見えます。

- develop に入ったのは PR #850 (`migrate/3.38`) 経由、マージは 2026-07-17
- 含まれるタグは `v4.0.0+125` のみ。`v3.0.1+123` は無傷（まだストア配信前のため実害はなし）

## 確認したこと

- 追加したテスト 3 件。うち「URLを扱えるアプリがない場合、外部ブラウザで開かれること」は修正前のコードで**落ちる**ことを確認済み（他 2 件は修正前も通る = 退行していなかった経路の固定）
- `fvm flutter test` 全件（415 passed / 17 skipped）
- `fvm dart analyze` に本 PR 由来の指摘なし、`fvm dart format` 適用済み
- Linux 実機（marionette + ローカル Misskey サーバー）で、既定ブラウザが起動することを確認。`url_launcher_linux` が `LaunchMode` を見ないため、この不具合は Linux では再現しません

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsLoVpdQM7BRt13oc8yson)_