### PR TITLE
`flutter_secure_storage_linux`の更新

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.44.0"
+  "dart.flutterSdkPath": ".fvm/versions/3.44.6"
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -608,10 +608,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      sha256: "76fa9c841b3b1619fc5b5bc36efc7d158fa2356f223b6caeb1d0c80a54168546"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
`flutter_secure_storage_linux: 3.0.1`以前には[Snapパッケージで認証情報が読み書きできなくなる問題](https://github.com/juliansteenbakker/flutter_secure_storage/pull/1177)を抱えており、[`3.0.2`](https://github.com/juliansteenbakker/flutter_secure_storage/releases/tag/flutter_secure_storage_linux-v3.0.2)で修正が行われているため、パッケージを更新する提案です。