### PR TITLE
fix: リモートユーザーのクリップでAppBarのタイトルが空になる問題を修正

### DIFF
--- a/lib/view/clip_list_page/clip_detail_page.dart
+++ b/lib/view/clip_list_page/clip_detail_page.dart
@@ -10,6 +10,18 @@ import "package:miria/router/app_router.dart";
 import "package:miria/state_notifier/clip_list_page/clips_notifier.dart";
 import "package:miria/view/clip_list_page/clip_detail_note_list.dart";
 import "package:miria/view/common/account_scope.dart";
+import "package:misskey_dart/misskey_dart.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+part "clip_detail_page.g.dart";
+
+@Riverpod(dependencies: [misskeyGetContext])
+Future<Clip> _clipShow(Ref ref, String clipId) async {
+  return await ref
+      .read(misskeyGetContextProvider)
+      .clips
+      .show(ClipsShowRequest(clipId: clipId));
+}
 
 @RoutePage()
 class ClipDetailPage extends HookConsumerWidget implements AutoRouteWrapper {
@@ -27,11 +39,13 @@ class ClipDetailPage extends HookConsumerWidget implements AutoRouteWrapper {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final clip = ref.watch(
-      clipsProvider.select(
-        (clips) => clips.value?.firstWhereOrNull((e) => e.id == id),
-      ),
-    );
+    final clips = ref.watch(clipsProvider);
+    final ownClip = clips.value?.firstWhereOrNull((e) => e.id == id);
+    final clip = clips.isLoading && !clips.hasError
+        ? null
+        : ownClip ?? ref.watch(_clipShowProvider(id)).value;
+    final isOwn =
+        clip?.userId == ref.read(accountContextProvider).postAccount.userId;
     final updateClip = useAsync(() async {
       final target = clip;
       if (target == null) return;
@@ -49,7 +63,7 @@ class ClipDetailPage extends HookConsumerWidget implements AutoRouteWrapper {
       appBar: AppBar(
         title: Text(clip?.name ?? ""),
         actions: [
-          if (clip != null)
+          if (isOwn)
             IconButton(
               icon: const Icon(Icons.settings),
               onPressed: updateClip.executeOrNull,

--- a/lib/view/clip_list_page/clip_detail_page.g.dart
+++ b/lib/view/clip_list_page/clip_detail_page.g.dart
@@ -1,0 +1,86 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'clip_detail_page.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(_clipShow)
+final _clipShowProvider = _ClipShowFamily._();
+
+final class _ClipShowProvider
+    extends $FunctionalProvider<AsyncValue<Clip>, Clip, FutureOr<Clip>>
+    with $FutureModifier<Clip>, $FutureProvider<Clip> {
+  _ClipShowProvider._({
+    required _ClipShowFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'_clipShowProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  static final $allTransitiveDependencies0 = misskeyGetContextProvider;
+  static final $allTransitiveDependencies1 =
+      MisskeyGetContextProvider.$allTransitiveDependencies0;
+
+  @override
+  String debugGetCreateSourceHash() => _$_clipShowHash();
+
+  @override
+  String toString() {
+    return r'_clipShowProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<Clip> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<Clip> create(Ref ref) {
+    final argument = this.argument as String;
+    return _clipShow(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is _ClipShowProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$_clipShowHash() => r'517299596c32748aee322271fd1ca209c0c87f70';
+
+final class _ClipShowFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<Clip>, String> {
+  _ClipShowFamily._()
+    : super(
+        retry: null,
+        name: r'_clipShowProvider',
+        dependencies: <ProviderOrFamily>[misskeyGetContextProvider],
+        $allTransitiveDependencies: <ProviderOrFamily>[
+          _ClipShowProvider.$allTransitiveDependencies0,
+          _ClipShowProvider.$allTransitiveDependencies1,
+        ],
+        isAutoDispose: true,
+      );
+
+  _ClipShowProvider call(String clipId) =>
+      _ClipShowProvider._(argument: clipId, from: this);
+
+  @override
+  String toString() => r'_clipShowProvider';
+}

--- a/test/view/clip_detail_page/clip_detail_page_test.dart
+++ b/test/view/clip_detail_page/clip_detail_page_test.dart
@@ -17,6 +17,8 @@ void main() {
       final misskey = MockMisskey();
       when(misskey.clips).thenReturn(clip);
       when(clip.notes(any)).thenAnswer((_) async => [TestData.note1]);
+      when(clip.list(any)).thenAnswer((_) async => []);
+      when(clip.show(any)).thenAnswer((_) async => TestData.clip);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -45,6 +47,82 @@ void main() {
           ),
         ),
       ).called(1);
+    });
+  });
+
+  group("クリップのタイトル", () {
+    testWidgets("自分のクリップ一覧になくてもクリップ名が表示されること", (tester) async {
+      final clip = MockMisskeyClips();
+      final misskey = MockMisskey();
+      when(misskey.clips).thenReturn(clip);
+      when(clip.notes(any)).thenAnswer((_) async => []);
+      when(clip.list(any)).thenAnswer((_) async => []);
+      when(clip.show(any)).thenAnswer((_) async => TestData.clip);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [misskeyProvider.overrideWith((ref, account) => misskey)],
+          child: DefaultRootWidget(
+            initialRoute: ClipDetailRoute(
+              id: TestData.clip.id,
+              accountContext: TestData.accountContext,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(TestData.clip.name!), findsOneWidget);
+      verify(clip.show(any)).called(1);
+    });
+
+    testWidgets("自分のクリップ一覧の取得に失敗してもクリップ名が表示されること", (tester) async {
+      final clip = MockMisskeyClips();
+      final misskey = MockMisskey();
+      when(misskey.clips).thenReturn(clip);
+      when(clip.notes(any)).thenAnswer((_) async => []);
+      when(clip.list(any)).thenThrow(Exception("401 Unauthorized"));
+      when(clip.show(any)).thenAnswer((_) async => TestData.clip);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [misskeyProvider.overrideWith((ref, account) => misskey)],
+          child: DefaultRootWidget(
+            initialRoute: ClipDetailRoute(
+              id: TestData.clip.id,
+              accountContext: TestData.accountContext,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(TestData.clip.name!), findsOneWidget);
+      verify(clip.show(any)).called(1);
+    });
+
+    testWidgets("自分のクリップ一覧にあれば clips/show を呼ばないこと", (tester) async {
+      final clip = MockMisskeyClips();
+      final misskey = MockMisskey();
+      when(misskey.clips).thenReturn(clip);
+      when(clip.notes(any)).thenAnswer((_) async => []);
+      when(clip.list(any)).thenAnswer((_) async => [TestData.clip]);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [misskeyProvider.overrideWith((ref, account) => misskey)],
+          child: DefaultRootWidget(
+            initialRoute: ClipDetailRoute(
+              id: TestData.clip.id,
+              accountContext: TestData.accountContext,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(TestData.clip.name!), findsOneWidget);
+      verifyNever(clip.show(any));
     });
   });
 }


### PR DESCRIPTION
リモートユーザーのクリップを開いたとき、AppBar のタイトルが空のままになる問題を修正しました。

fix: #782