### PR TITLE
chore: mfm を 1.0.11+2 に更新し、バージョンを 4.0.1 に上げる

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1015,10 +1015,10 @@ packages:
     dependency: "direct main"
     description:
       name: mfm
-      sha256: "10ed9e7ab347f89d7f93b98b2785b8f153128e2d04b6e0ba27a5eefd2a75fca7"
+      sha256: "3124c524d334a1b50d231ecb4cac239a1aef7aaa2d83974d33d77a2bc83d6ccc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "1.0.11+2"
   mfm_parser:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     git:
       url: https://github.com/shiosyakeyakini-info/misskey_dart.git
       ref: master
-  mfm: ^1.0.11
+  mfm: ^1.0.11+2
   tuple: ^2.0.1
   path_provider: ^2.1.6
   dio: ^5.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: miria
 description: Miria is Misskey Client for Mobile App.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 4.0.0+126
+version: 4.0.1+126
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
## 変更内容

- `mfm` を 1.0.11 → 1.0.11+2 に更新（pubspec.yaml の制約と pubspec.lock）
  - 1.0.11+2: 入れ子の `$[spin ]` のかかり方が本家と異なる不具合の修正。CSS の既定は `transform-style: flat` なので入れ子の要素は親の transform 前にいったん平面に潰されるが、Flutter の `Transform` は 4x4 行列を素直に掛けるため `preserve-3d` 相当になっており、`$[spin.y $[spin.y,left ]]` が打ち消しあって静止したり、`$[spin.y $[spin.y ]]` が倍速で回ったりしていた
  - 1.0.11+1: `$[rainbow ]` の色が本家とずれていた不具合の修正。アニメーションが半周ぶん位相ずれしていた（0% で赤がシアンに出る）ほか、コントラスト・彩度が過剰にかかって色が原色に張りついていた
- アプリのバージョンを 4.0.0 → 4.0.1 に更新。ビルド番号はデプロイワークフローの `cider bump build` が採番するため据え置き

## 確認したこと

- `dart analyze` … error / warning なし
- `dart format --set-exit-if-changed .` … 493ファイル無変更
- `flutter test` … 418 passed / 17 skipped

lock の差分は `mfm` の1エントリのみで、`misskey_dart` の git 参照などは動いていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2mKJbuE5LmC9424zVaKqP

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2mKJbuE5LmC9424zVaKqP)_