### PR TITLE
fix: リモートのノートの投票の選択肢でカスタム絵文字が出ないのを直した

### DIFF
--- a/lib/view/common/misskey_notes/mfm_text.dart
+++ b/lib/view/common/misskey_notes/mfm_text.dart
@@ -245,6 +245,7 @@ class SimpleMfmText extends ConsumerWidget {
   final String text;
   final TextStyle? style;
   final Map<String, String> emojis;
+  final String? host;
   final List<InlineSpan> suffixSpan;
   final List<InlineSpan> prefixSpan;
   final bool isNyaize;
@@ -256,6 +257,7 @@ class SimpleMfmText extends ConsumerWidget {
     super.key,
     this.style,
     this.emojis = const {},
+    this.host,
     this.suffixSpan = const [],
     this.prefixSpan = const [],
     this.isNyaize = false,
@@ -280,6 +282,7 @@ class SimpleMfmText extends ConsumerWidget {
               ),
             ),
             emojiInfo: emojis,
+            host: host,
           ),
           fontSizeRatio: 1,
           style: style,

--- a/lib/view/common/misskey_notes/note_vote.dart
+++ b/lib/view/common/misskey_notes/note_vote.dart
@@ -141,6 +141,8 @@ class NoteVote extends HookConsumerWidget {
                       child: SimpleMfmText(
                         choice.element.text,
                         style: Theme.of(context).textTheme.bodyMedium,
+                        emojis: displayNote.emojis,
+                        host: displayNote.user.host,
                         prefixSpan: [
                           if (choice.element.isVoted)
                             WidgetSpan(

--- a/test/view/common/misskey_notes/misskey_notes_test.dart
+++ b/test/view/common/misskey_notes/misskey_notes_test.dart
@@ -3,10 +3,12 @@ import "package:flutter_highlighting/flutter_highlighting.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:miria/model/general_settings.dart";
+import "package:miria/model/misskey_emoji_data.dart";
 import "package:miria/providers.dart";
 import "package:miria/repository/note_repository.dart";
 import "package:miria/router/app_router.dart";
 import "package:miria/view/common/account_scope.dart";
+import "package:miria/view/common/misskey_notes/custom_emoji.dart";
 import "package:miria/view/common/misskey_notes/misskey_note.dart";
 import "package:miria/view/common/misskey_notes/network_image.dart";
 import "package:miria/view/common/misskey_notes/reaction_button.dart";
@@ -243,6 +245,40 @@ System.out.println("@ai uneune");
           expect(find.textContaining(choice.text), findsOneWidget);
           expect(find.textContaining("${choice.votes}票"), findsOneWidget);
         }
+      });
+
+      testWidgets("リモートのノートの投票の選択肢のカスタム絵文字が表示されること", (tester) async {
+        final note = TestData.note4AsVote;
+        final poll = note.poll!;
+        await tester.pumpWidget(
+          buildTestWidget(
+            note: note.copyWith(
+              user: note.user.copyWith(host: "example.com"),
+              emojis: const {
+                "kirakira": "https://example.com/emojis/kirakira.webp",
+              },
+              poll: poll.copyWith(
+                choices: [
+                  poll.choices.first.copyWith(text: ":kirakira: ひかるやつ"),
+                  ...poll.choices.skip(1),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining(":kirakira:"), findsNothing);
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is CustomEmoji &&
+                widget.emojiData is CustomEmojiData &&
+                (widget.emojiData as CustomEmojiData).hostedName ==
+                    ":kirakira@example.com:",
+          ),
+          findsOneWidget,
+        );
       });
     });
 


### PR DESCRIPTION
NoteVote が選択肢を SimpleMfmText に渡すとき emojis を渡していなかったため、
ノート本文に持たされている絵文字の URL が引けず、リモート由来の絵文字が
`:name:` のままテキストで表示されていた。ローカルの絵文字は EmojiRepository
から引けるので気づきにくかった。

あわせて SimpleMfmText に host を足して、hostedName が
`:name@host:` に解決されるようにした（tooltip とミュート名の一致用）。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HygaGvaSMaWjrHYXYJyS6P